### PR TITLE
feat(chat): live reasoning + tool activity across Claude, Codex, and agy

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -1586,6 +1586,26 @@ fn antigravity_brain_roots() -> Vec<PathBuf> {
         .collect()
 }
 
+pub fn locate_antigravity_transcript(uuid: &str) -> Option<PathBuf> {
+    locate_antigravity_transcript_in(&antigravity_brain_roots(), uuid)
+}
+
+fn locate_antigravity_transcript_in(brain_roots: &[PathBuf], uuid: &str) -> Option<PathBuf> {
+    if !is_uuid_v4_shape(uuid) {
+        return None;
+    }
+    brain_roots.iter().find_map(|root| {
+        let session_dir = root.join(uuid);
+        let path = session_dir
+            .join(".system_generated")
+            .join("logs")
+            .join("transcript.jsonl");
+        (safe_antigravity_transcript_path(&session_dir, &path)
+            && antigravity_uuid_from_transcript_path(&path).as_deref() == Some(uuid))
+        .then_some(path)
+    })
+}
+
 fn antigravity_owner_cursor_id(storage_root: Option<&Path>, cwd: &Path) -> Option<String> {
     let cwd = cwd.to_str()?;
     let path = storage_root?
@@ -4186,6 +4206,30 @@ mod tests {
             antigravity_uuid_from_transcript_path(path).as_deref(),
             Some("17f38e8c-3a7e-408b-8c79-aef7432c0fd2")
         );
+    }
+
+    #[test]
+    fn locates_antigravity_transcript_by_brain_id() {
+        use std::fs::{self, File};
+
+        let root = std::env::temp_dir().join(format!(
+            "acorn-antigravity-locate-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let brain_root = root.join("brain");
+        let id = "17f38e8c-3a7e-408b-8c79-aef7432c0fd2";
+        let logs = brain_root.join(id).join(".system_generated").join("logs");
+        fs::create_dir_all(&logs).unwrap();
+        let transcript = logs.join("transcript.jsonl");
+        File::create(&transcript).unwrap();
+
+        assert_eq!(
+            locate_antigravity_transcript_in(&[brain_root], id),
+            Some(transcript)
+        );
+        assert!(locate_antigravity_transcript_in(&[], "not-a-uuid").is_none());
+
+        fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -51,6 +51,11 @@ pub struct ResolvedAiCommand {
     pub prompt_transport: PromptTransport,
 }
 
+pub enum AiProcessStreamEvent<'a> {
+    Stdout(&'a str),
+    Tick,
+}
+
 impl AiExecutionRequest {
     pub fn resolve(&self) -> AppResult<ResolvedAiCommand> {
         match self.provider {
@@ -164,10 +169,10 @@ pub fn run_resolved_streaming_in_dir_cancellable<F>(
     settings_label: &str,
     cwd: Option<&Path>,
     cancellation: Option<ChatCancellation>,
-    on_stdout_chunk: F,
+    on_event: F,
 ) -> AppResult<String>
 where
-    F: FnMut(&str),
+    F: FnMut(AiProcessStreamEvent<'_>),
 {
     run_streaming_in_dir_cancellable_with_transport(
         resolved.command,
@@ -177,7 +182,7 @@ where
         cwd,
         cancellation,
         resolved.prompt_transport,
-        on_stdout_chunk,
+        on_event,
     )
 }
 
@@ -257,10 +262,10 @@ fn run_streaming_in_dir_cancellable_with_transport<F>(
     cwd: Option<&Path>,
     cancellation: Option<ChatCancellation>,
     prompt_transport: PromptTransport,
-    mut on_stdout_chunk: F,
+    mut on_event: F,
 ) -> AppResult<String>
 where
-    F: FnMut(&str),
+    F: FnMut(AiProcessStreamEvent<'_>),
 {
     let resolved = cli_resolver::resolve(command).map_err(|_| {
         AppError::Other(format!(
@@ -306,8 +311,7 @@ where
         }
     }
 
-    let output =
-        wait_with_timeout_streaming(command, child, None, cancellation, &mut on_stdout_chunk)?;
+    let output = wait_with_timeout_streaming(command, child, None, cancellation, &mut on_event)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -673,10 +677,10 @@ fn process_stdout_chunk<F>(
     chunk: io::Result<Vec<u8>>,
     stdout: &mut Vec<u8>,
     decoder: &mut Utf8ChunkDecoder,
-    on_stdout_chunk: &mut F,
+    on_event: &mut F,
 ) -> AppResult<()>
 where
-    F: FnMut(&str),
+    F: FnMut(AiProcessStreamEvent<'_>),
 {
     let chunk =
         chunk.map_err(|e| AppError::Other(format!("failed reading {command} stdout: {e}")))?;
@@ -686,7 +690,7 @@ where
     stdout.extend_from_slice(&chunk);
     let text = decoder.push(&chunk);
     if !text.is_empty() {
-        on_stdout_chunk(&text);
+        on_event(AiProcessStreamEvent::Stdout(&text));
     }
     Ok(())
 }
@@ -696,14 +700,14 @@ fn drain_stdout_chunks<F>(
     stdout_rx: &Receiver<io::Result<Vec<u8>>>,
     stdout: &mut Vec<u8>,
     decoder: &mut Utf8ChunkDecoder,
-    on_stdout_chunk: &mut F,
+    on_event: &mut F,
 ) -> AppResult<()>
 where
-    F: FnMut(&str),
+    F: FnMut(AiProcessStreamEvent<'_>),
 {
     loop {
         match stdout_rx.try_recv() {
-            Ok(chunk) => process_stdout_chunk(command, chunk, stdout, decoder, on_stdout_chunk)?,
+            Ok(chunk) => process_stdout_chunk(command, chunk, stdout, decoder, on_event)?,
             Err(TryRecvError::Empty | TryRecvError::Disconnected) => return Ok(()),
         }
     }
@@ -714,10 +718,10 @@ fn wait_with_timeout_streaming<F>(
     mut child: std::process::Child,
     timeout: Option<Duration>,
     cancellation: Option<ChatCancellation>,
-    on_stdout_chunk: &mut F,
+    on_event: &mut F,
 ) -> AppResult<Output>
 where
-    F: FnMut(&str),
+    F: FnMut(AiProcessStreamEvent<'_>),
 {
     let child_id = child.id();
     let stdout_pipe = child
@@ -760,13 +764,8 @@ where
     let status = if let Some(cancellation) = cancellation {
         cancellation.set_child(child);
         let status = loop {
-            drain_stdout_chunks(
-                command,
-                &stdout_rx,
-                &mut stdout,
-                &mut decoder,
-                on_stdout_chunk,
-            )?;
+            drain_stdout_chunks(command, &stdout_rx, &mut stdout, &mut decoder, on_event)?;
+            on_event(AiProcessStreamEvent::Tick);
             if cancellation.is_cancelled() {
                 terminate_child_process_group(child_id);
                 cancellation.kill_and_wait();
@@ -796,13 +795,8 @@ where
         status
     } else {
         loop {
-            drain_stdout_chunks(
-                command,
-                &stdout_rx,
-                &mut stdout,
-                &mut decoder,
-                on_stdout_chunk,
-            )?;
+            drain_stdout_chunks(command, &stdout_rx, &mut stdout, &mut decoder, on_event)?;
+            on_event(AiProcessStreamEvent::Tick);
             match child
                 .try_wait()
                 .map_err(|e| AppError::Other(format!("failed waiting for {command}: {e}")))?
@@ -831,16 +825,11 @@ where
     stdout_reader
         .join()
         .map_err(|_| AppError::Other(format!("{command} stdout reader failed")))?;
-    drain_stdout_chunks(
-        command,
-        &stdout_rx,
-        &mut stdout,
-        &mut decoder,
-        on_stdout_chunk,
-    )?;
+    drain_stdout_chunks(command, &stdout_rx, &mut stdout, &mut decoder, on_event)?;
+    on_event(AiProcessStreamEvent::Tick);
     let trailing = decoder.finish();
     if !trailing.is_empty() {
-        on_stdout_chunk(&trailing);
+        on_event(AiProcessStreamEvent::Stdout(&trailing));
     }
     let stderr = stderr_reader
         .join()
@@ -1018,13 +1007,42 @@ mod tests {
             None,
             None,
             PromptTransport::Stdin,
-            |chunk| chunks.push(chunk.to_string()),
+            |event| {
+                if let AiProcessStreamEvent::Stdout(chunk) = event {
+                    chunks.push(chunk.to_string());
+                }
+            },
         )
         .unwrap();
 
         assert_eq!(output, "onetwo");
         assert_eq!(chunks.concat(), "onetwo");
         assert!(!chunks.is_empty());
+    }
+
+    #[test]
+    fn streaming_reports_ticks_while_stdout_is_idle() {
+        let args = vec!["-c".to_string(), "sleep 0.08; printf done".to_string()];
+        let mut ticks = 0usize;
+
+        let output = run_streaming_in_dir_cancellable_with_transport(
+            "/bin/sh",
+            &args,
+            "",
+            "test settings",
+            None,
+            None,
+            PromptTransport::Stdin,
+            |event| {
+                if matches!(event, AiProcessStreamEvent::Tick) {
+                    ticks += 1;
+                }
+            },
+        )
+        .unwrap();
+
+        assert_eq!(output, "done");
+        assert!(ticks > 0);
     }
 
     #[cfg(unix)]
@@ -1042,7 +1060,11 @@ mod tests {
             None,
             None,
             PromptTransport::Stdin,
-            |chunk| chunks.push(chunk.to_string()),
+            |event| {
+                if let AiProcessStreamEvent::Stdout(chunk) = event {
+                    chunks.push(chunk.to_string());
+                }
+            },
         )
         .unwrap();
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::io::{self, Read, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::time::{Duration, Instant, SystemTime};
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
 use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, Emitter, Runtime, State};
@@ -649,14 +649,29 @@ pub(crate) trait ChatProviderAdapter {
     fn send_message_streaming(
         &self,
         input: ChatProviderInput,
-        on_chunk: &mut dyn FnMut(&str),
+        on_event: &mut dyn FnMut(ChatProviderStreamEvent),
     ) -> AppResult<ProviderResponse> {
-        let _ = on_chunk;
+        let _ = on_event;
         self.send_message(input)
     }
 }
 
-fn ignore_chat_streaming_chunk(_: &str) {}
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ChatProviderStreamEvent {
+    AssistantTextDelta(String),
+    Activity(ChatActivityPatch),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ChatActivityPatch {
+    id: String,
+    kind: persistence::ChatActivityKind,
+    title: Option<String>,
+    detail: Option<String>,
+    status: persistence::ChatActivityStatus,
+}
+
+fn ignore_chat_streaming_event(_: ChatProviderStreamEvent) {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ChatCliOutputMode {
@@ -671,6 +686,16 @@ struct ChatCliOutputParser {
     emitted_text: String,
     final_text: Option<String>,
     usage: Option<serde_json::Value>,
+    claude_message_id: Option<String>,
+    claude_blocks: HashMap<u64, ClaudePartialBlock>,
+}
+
+struct ClaudePartialBlock {
+    id: String,
+    kind: persistence::ChatActivityKind,
+    title: String,
+    detail: String,
+    input_json: String,
 }
 
 impl ChatCliOutputParser {
@@ -681,18 +706,20 @@ impl ChatCliOutputParser {
             emitted_text: String::new(),
             final_text: None,
             usage: None,
+            claude_message_id: None,
+            claude_blocks: HashMap::new(),
         }
     }
 
-    fn push_chunk(&mut self, chunk: &str, on_chunk: &mut dyn FnMut(&str)) {
+    fn push_chunk(&mut self, chunk: &str, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
         match self.mode {
-            ChatCliOutputMode::Text => self.emit_delta(chunk, on_chunk),
+            ChatCliOutputMode::Text => self.emit_delta(chunk, on_event),
             ChatCliOutputMode::ClaudeStreamJson | ChatCliOutputMode::CodexJson => {
                 self.pending_line.push_str(chunk);
                 while let Some(newline) = self.pending_line.find('\n') {
                     let line = self.pending_line[..newline].to_string();
                     self.pending_line.drain(..=newline);
-                    self.process_json_line(&line, on_chunk);
+                    self.process_json_line(&line, on_event);
                 }
             }
         }
@@ -702,11 +729,8 @@ impl ChatCliOutputParser {
         if self.mode == ChatCliOutputMode::Text {
             return raw.trim().to_string();
         }
-        if !self.pending_line.trim().is_empty() {
-            let line = std::mem::take(&mut self.pending_line);
-            let mut ignore_chunk = ignore_chat_streaming_chunk;
-            self.process_json_line(&line, &mut ignore_chunk);
-        }
+        let mut ignore_event = ignore_chat_streaming_event;
+        self.flush_pending(&mut ignore_event);
         self.final_text
             .as_deref()
             .unwrap_or(self.emitted_text.as_str())
@@ -714,7 +738,16 @@ impl ChatCliOutputParser {
             .to_string()
     }
 
-    fn process_json_line(&mut self, line: &str, on_chunk: &mut dyn FnMut(&str)) {
+    fn flush_pending(&mut self, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
+        if self.pending_line.trim().is_empty() {
+            self.pending_line.clear();
+            return;
+        }
+        let line = std::mem::take(&mut self.pending_line);
+        self.process_json_line(&line, on_event);
+    }
+
+    fn process_json_line(&mut self, line: &str, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
         let line = line.trim();
         if line.is_empty() {
             return;
@@ -725,48 +758,235 @@ impl ChatCliOutputParser {
         if let Some(usage) = extract_chat_stream_usage(self.mode, &value) {
             self.usage = Some(usage);
         }
+        let mut activities = if self.mode == ChatCliOutputMode::ClaudeStreamJson {
+            self.extract_claude_partial_activities(&value)
+        } else {
+            Vec::new()
+        };
+        activities.extend(extract_chat_stream_activities(self.mode, &value));
+        for activity in activities {
+            on_event(ChatProviderStreamEvent::Activity(activity));
+        }
         let Some(event) = extract_chat_stream_text(self.mode, &value) else {
             return;
         };
         if event.is_final {
             self.final_text = Some(event.text.clone());
         }
-        self.emit_text_candidate(&event, on_chunk);
+        self.emit_text_candidate(&event, on_event);
     }
 
-    fn emit_text_candidate(&mut self, event: &ChatStreamTextEvent, on_chunk: &mut dyn FnMut(&str)) {
+    fn emit_text_candidate(
+        &mut self,
+        event: &ChatStreamTextEvent,
+        on_event: &mut dyn FnMut(ChatProviderStreamEvent),
+    ) {
         let text = event.text.as_str();
         if text.is_empty() {
             return;
         }
         if let Some(delta) = text.strip_prefix(&self.emitted_text) {
-            self.emit_delta(delta, on_chunk);
+            self.emit_delta(delta, on_event);
         } else if event.is_final {
             // Persist normalized final text from finish() without briefly
             // appending a divergent duplicate to the live stream.
         } else if event.boundary != ChatStreamTextBoundary::Delta {
             let separator = message_boundary_separator(&self.emitted_text, text);
             if !separator.is_empty() {
-                self.emit_delta(separator, on_chunk);
+                self.emit_delta(separator, on_event);
             }
-            self.emit_delta(text, on_chunk);
+            self.emit_delta(text, on_event);
         } else {
-            self.emit_delta(text, on_chunk);
+            self.emit_delta(text, on_event);
         }
     }
 
-    fn emit_delta(&mut self, delta: &str, on_chunk: &mut dyn FnMut(&str)) {
+    fn emit_delta(&mut self, delta: &str, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
         if delta.is_empty() {
             return;
         }
         self.emitted_text.push_str(delta);
-        on_chunk(delta);
+        on_event(ChatProviderStreamEvent::AssistantTextDelta(
+            delta.to_string(),
+        ));
     }
 
     fn provider_metadata(&self) -> Option<serde_json::Value> {
         self.usage
             .as_ref()
             .map(|usage| serde_json::json!({ "usage": usage }))
+    }
+
+    fn extract_claude_partial_activities(
+        &mut self,
+        value: &serde_json::Value,
+    ) -> Vec<ChatActivityPatch> {
+        if value.get("type").and_then(serde_json::Value::as_str) != Some("stream_event") {
+            return Vec::new();
+        }
+        let Some(event) = value.get("event") else {
+            return Vec::new();
+        };
+        let event_type = event.get("type").and_then(serde_json::Value::as_str);
+        match event_type {
+            Some("message_start") => {
+                self.claude_message_id = event
+                    .get("message")
+                    .and_then(|message| message.get("id"))
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                self.claude_blocks.clear();
+                Vec::new()
+            }
+            Some("content_block_start") => {
+                let Some(index) = event.get("index").and_then(serde_json::Value::as_u64) else {
+                    return Vec::new();
+                };
+                let Some(block) = event.get("content_block") else {
+                    return Vec::new();
+                };
+                let Some(block_type) = block.get("type").and_then(serde_json::Value::as_str) else {
+                    return Vec::new();
+                };
+                let message_id = self.claude_message_id.as_deref().unwrap_or("assistant");
+                let partial = match block_type {
+                    "thinking" | "redacted_thinking" => ClaudePartialBlock {
+                        id: format!("claude:{message_id}:reasoning:{index}"),
+                        kind: persistence::ChatActivityKind::Reasoning,
+                        title: "Reasoning".to_string(),
+                        detail: block
+                            .get("thinking")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default()
+                            .to_string(),
+                        input_json: String::new(),
+                    },
+                    "tool_use" | "server_tool_use" => {
+                        let name = block
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("Tool");
+                        ClaudePartialBlock {
+                            id: block
+                                .get("id")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| format!("claude:{message_id}:tool:{index}")),
+                            kind: tool_activity_kind(name),
+                            title: humanize_activity_name(name),
+                            detail: tool_input_detail(block.get("input")).unwrap_or_default(),
+                            input_json: String::new(),
+                        }
+                    }
+                    _ => return Vec::new(),
+                };
+                let patch =
+                    claude_partial_block_patch(&partial, persistence::ChatActivityStatus::Running);
+                self.claude_blocks.insert(index, partial);
+                vec![patch]
+            }
+            Some("content_block_delta") => {
+                let Some(index) = event.get("index").and_then(serde_json::Value::as_u64) else {
+                    return Vec::new();
+                };
+                let Some(delta) = event.get("delta") else {
+                    return Vec::new();
+                };
+                let delta_type = delta.get("type").and_then(serde_json::Value::as_str);
+                if delta_type == Some("thinking_delta") && !self.claude_blocks.contains_key(&index)
+                {
+                    let message_id = self.claude_message_id.as_deref().unwrap_or("assistant");
+                    self.claude_blocks.insert(
+                        index,
+                        ClaudePartialBlock {
+                            id: format!("claude:{message_id}:reasoning:{index}"),
+                            kind: persistence::ChatActivityKind::Reasoning,
+                            title: "Reasoning".to_string(),
+                            detail: String::new(),
+                            input_json: String::new(),
+                        },
+                    );
+                }
+                let Some(partial) = self.claude_blocks.get_mut(&index) else {
+                    return Vec::new();
+                };
+                match delta_type {
+                    Some("thinking_delta") => {
+                        if let Some(fragment) =
+                            delta.get("thinking").and_then(serde_json::Value::as_str)
+                        {
+                            append_limited_activity_text(&mut partial.detail, fragment);
+                        }
+                    }
+                    Some("input_json_delta") => {
+                        if let Some(fragment) = delta
+                            .get("partial_json")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            append_limited_tool_input_json(&mut partial.input_json, fragment);
+                        }
+                    }
+                    _ => return Vec::new(),
+                }
+                vec![claude_partial_block_patch(
+                    partial,
+                    persistence::ChatActivityStatus::Running,
+                )]
+            }
+            Some("content_block_stop") => {
+                let Some(index) = event.get("index").and_then(serde_json::Value::as_u64) else {
+                    return Vec::new();
+                };
+                let Some(mut partial) = self.claude_blocks.remove(&index) else {
+                    return Vec::new();
+                };
+                if partial.kind != persistence::ChatActivityKind::Reasoning
+                    && !partial.input_json.is_empty()
+                {
+                    partial.detail = serde_json::from_str::<serde_json::Value>(&partial.input_json)
+                        .ok()
+                        .as_ref()
+                        .and_then(|input| tool_input_detail(Some(input)))
+                        .unwrap_or_default();
+                }
+                let status = if partial.kind == persistence::ChatActivityKind::Reasoning {
+                    persistence::ChatActivityStatus::Complete
+                } else {
+                    persistence::ChatActivityStatus::Running
+                };
+                vec![claude_partial_block_patch(&partial, status)]
+            }
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn claude_partial_block_patch(
+    partial: &ClaudePartialBlock,
+    status: persistence::ChatActivityStatus,
+) -> ChatActivityPatch {
+    ChatActivityPatch {
+        id: partial.id.clone(),
+        kind: partial.kind,
+        title: Some(partial.title.clone()),
+        detail: activity_detail(Some(&partial.detail)),
+        status,
+    }
+}
+
+fn append_limited_activity_text(target: &mut String, fragment: &str) {
+    let remaining = MAX_CHAT_ACTIVITY_DETAIL_CHARS.saturating_sub(target.chars().count());
+    if remaining > 0 {
+        target.extend(fragment.chars().take(remaining));
+    }
+}
+
+const MAX_CHAT_TOOL_INPUT_JSON_CHARS: usize = 16_000;
+
+fn append_limited_tool_input_json(target: &mut String, fragment: &str) {
+    let remaining = MAX_CHAT_TOOL_INPUT_JSON_CHARS.saturating_sub(target.chars().count());
+    if remaining > 0 {
+        target.extend(fragment.chars().take(remaining));
     }
 }
 
@@ -826,6 +1046,12 @@ fn extract_claude_stream_usage(value: &serde_json::Value) -> Option<serde_json::
                 .get("message")
                 .and_then(|message| message.get("usage"))
         })
+        .or_else(|| {
+            value
+                .get("event")
+                .and_then(|event| event.get("message"))
+                .and_then(|message| message.get("usage"))
+        })
         .cloned()
 }
 
@@ -844,6 +1070,615 @@ fn extract_codex_event_usage(value: &serde_json::Value) -> Option<serde_json::Va
             .cloned();
     }
     value.get("usage").cloned()
+}
+
+const MAX_CHAT_ACTIVITY_DETAIL_CHARS: usize = 4_000;
+const MAX_CHAT_ACTIVITY_ID_CHARS: usize = 512;
+const MAX_CHAT_ACTIVITY_TITLE_CHARS: usize = 200;
+const MAX_CHAT_TURN_ACTIVITIES: usize = 512;
+
+fn extract_chat_stream_activities(
+    mode: ChatCliOutputMode,
+    value: &serde_json::Value,
+) -> Vec<ChatActivityPatch> {
+    match mode {
+        ChatCliOutputMode::Text => Vec::new(),
+        ChatCliOutputMode::ClaudeStreamJson => extract_claude_stream_activities(value),
+        ChatCliOutputMode::CodexJson => extract_codex_stream_activities(value),
+    }
+}
+
+fn extract_claude_stream_activities(value: &serde_json::Value) -> Vec<ChatActivityPatch> {
+    let event_type = value.get("type").and_then(serde_json::Value::as_str);
+    match event_type {
+        Some("assistant") => {
+            let Some(message) = value.get("message") else {
+                return Vec::new();
+            };
+            let message_id = message
+                .get("id")
+                .or_else(|| value.get("uuid"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("assistant");
+            let block_status = if message
+                .get("stop_reason")
+                .is_some_and(|reason| !reason.is_null())
+            {
+                persistence::ChatActivityStatus::Complete
+            } else {
+                persistence::ChatActivityStatus::Running
+            };
+            message
+                .get("content")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .take(MAX_CHAT_TURN_ACTIVITIES)
+                .enumerate()
+                .filter_map(|(index, block)| {
+                    let block_type = block.get("type").and_then(serde_json::Value::as_str)?;
+                    match block_type {
+                        "thinking" | "redacted_thinking" => Some(ChatActivityPatch {
+                            id: format!("claude:{message_id}:reasoning:{index}"),
+                            kind: persistence::ChatActivityKind::Reasoning,
+                            title: Some("Reasoning".to_string()),
+                            detail: activity_detail(
+                                block
+                                    .get("thinking")
+                                    .or_else(|| block.get("text"))
+                                    .and_then(json_display_text)
+                                    .as_deref(),
+                            ),
+                            status: block_status,
+                        }),
+                        "tool_use" | "server_tool_use" => {
+                            let name = block
+                                .get("name")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or("Tool");
+                            let id = block
+                                .get("id")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| format!("claude:{message_id}:tool:{index}"));
+                            Some(ChatActivityPatch {
+                                id,
+                                kind: tool_activity_kind(name),
+                                title: Some(humanize_activity_name(name)),
+                                detail: tool_input_detail(block.get("input")),
+                                status: persistence::ChatActivityStatus::Running,
+                            })
+                        }
+                        _ => None,
+                    }
+                })
+                .collect()
+        }
+        Some("user") => value
+            .get("message")
+            .and_then(|message| message.get("content"))
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .take(MAX_CHAT_TURN_ACTIVITIES)
+            .filter_map(|block| {
+                if block.get("type").and_then(serde_json::Value::as_str) != Some("tool_result") {
+                    return None;
+                }
+                let id = block
+                    .get("tool_use_id")
+                    .and_then(serde_json::Value::as_str)?
+                    .to_string();
+                let is_error = block
+                    .get("is_error")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                Some(ChatActivityPatch {
+                    id,
+                    kind: persistence::ChatActivityKind::Tool,
+                    title: None,
+                    detail: None,
+                    status: if is_error {
+                        persistence::ChatActivityStatus::Error
+                    } else {
+                        persistence::ChatActivityStatus::Complete
+                    },
+                })
+            })
+            .collect(),
+        Some("tool_progress") => {
+            let Some(id) = value.get("tool_use_id").and_then(serde_json::Value::as_str) else {
+                return Vec::new();
+            };
+            vec![ChatActivityPatch {
+                id: id.to_string(),
+                kind: persistence::ChatActivityKind::Tool,
+                title: value
+                    .get("tool_name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(humanize_activity_name),
+                detail: None,
+                status: persistence::ChatActivityStatus::Running,
+            }]
+        }
+        Some("tool_use_summary") => {
+            let summary = value
+                .get("summary")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|summary| activity_detail(Some(summary)));
+            value
+                .get("preceding_tool_use_ids")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+                .take(MAX_CHAT_TURN_ACTIVITIES)
+                .filter_map(serde_json::Value::as_str)
+                .map(|id| ChatActivityPatch {
+                    id: id.to_string(),
+                    kind: persistence::ChatActivityKind::Tool,
+                    title: None,
+                    detail: summary.clone(),
+                    status: persistence::ChatActivityStatus::Complete,
+                })
+                .collect()
+        }
+        Some("result") => value
+            .get("permission_denials")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+            .take(MAX_CHAT_TURN_ACTIVITIES)
+            .filter_map(|denial| {
+                let id = denial
+                    .get("tool_use_id")
+                    .or_else(|| denial.get("id"))
+                    .and_then(serde_json::Value::as_str)?;
+                Some(ChatActivityPatch {
+                    id: id.to_string(),
+                    kind: persistence::ChatActivityKind::Tool,
+                    title: denial
+                        .get("tool_name")
+                        .and_then(serde_json::Value::as_str)
+                        .map(humanize_activity_name),
+                    detail: denial
+                        .get("message")
+                        .and_then(json_display_text)
+                        .and_then(|detail| activity_detail(Some(&detail))),
+                    status: persistence::ChatActivityStatus::Error,
+                })
+            })
+            .collect(),
+        Some("system") => extract_claude_system_activity(value).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn extract_claude_system_activity(value: &serde_json::Value) -> Option<ChatActivityPatch> {
+    let subtype = value.get("subtype").and_then(serde_json::Value::as_str)?;
+    let id = value
+        .get("task_id")
+        .or_else(|| value.get("tool_use_id"))
+        .or_else(|| value.get("uuid"))
+        .and_then(serde_json::Value::as_str)?;
+    match subtype {
+        "task_started" | "task_progress" | "task_notification" => {
+            let status = match value.get("status").and_then(serde_json::Value::as_str) {
+                Some("failed") => persistence::ChatActivityStatus::Error,
+                Some("stopped") => persistence::ChatActivityStatus::Cancelled,
+                Some("completed") => persistence::ChatActivityStatus::Complete,
+                _ => persistence::ChatActivityStatus::Running,
+            };
+            Some(ChatActivityPatch {
+                id: format!("claude:task:{id}"),
+                kind: persistence::ChatActivityKind::Tool,
+                title: Some("Background task".to_string()),
+                detail: value
+                    .get("summary")
+                    .or_else(|| value.get("description"))
+                    .and_then(json_display_text)
+                    .and_then(|detail| activity_detail(Some(&detail))),
+                status,
+            })
+        }
+        "permission_denied" => Some(ChatActivityPatch {
+            id: id.to_string(),
+            kind: persistence::ChatActivityKind::Tool,
+            title: value
+                .get("tool_name")
+                .and_then(serde_json::Value::as_str)
+                .map(humanize_activity_name),
+            detail: value
+                .get("message")
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status: persistence::ChatActivityStatus::Error,
+        }),
+        _ => None,
+    }
+}
+
+fn extract_codex_stream_activities(value: &serde_json::Value) -> Vec<ChatActivityPatch> {
+    let outer_type = value.get("type").and_then(serde_json::Value::as_str);
+    if matches!(
+        outer_type,
+        Some("item.started" | "item.updated" | "item.completed")
+    ) {
+        return value
+            .get("item")
+            .and_then(|item| codex_item_activity(outer_type.unwrap_or_default(), item))
+            .into_iter()
+            .collect();
+    }
+
+    let event = value
+        .get("msg")
+        .filter(|event| event.is_object())
+        .or_else(|| value.get("payload").filter(|event| event.is_object()))
+        .unwrap_or(value);
+    codex_legacy_activity(event).into_iter().collect()
+}
+
+fn codex_item_activity(outer_type: &str, item: &serde_json::Value) -> Option<ChatActivityPatch> {
+    let item_type = item.get("type").and_then(serde_json::Value::as_str)?;
+    if item_type == "agent_message" {
+        return None;
+    }
+    let id = item
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("codex:{item_type}"));
+    let status = codex_activity_status(outer_type, item);
+    let patch = match item_type {
+        "reasoning" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Reasoning,
+            title: Some("Reasoning".to_string()),
+            detail: item
+                .get("text")
+                .or_else(|| item.get("summary"))
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status,
+        },
+        "command_execution" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Command,
+            title: Some("Command".to_string()),
+            detail: item
+                .get("command")
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status,
+        },
+        "file_change" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::FileChange,
+            title: Some("File changes".to_string()),
+            detail: codex_file_change_detail(item),
+            status,
+        },
+        "mcp_tool_call" => {
+            let server = item
+                .get("server")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("MCP");
+            let tool = item
+                .get("tool")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("tool");
+            ChatActivityPatch {
+                id,
+                kind: persistence::ChatActivityKind::Tool,
+                title: Some(format!("{server} · {tool}")),
+                detail: None,
+                status,
+            }
+        }
+        "collab_tool_call" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Tool,
+            title: Some("Sub-agent".to_string()),
+            detail: item
+                .get("tool")
+                .and_then(json_display_text)
+                .map(|detail| humanize_activity_name(&detail))
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status,
+        },
+        "web_search" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::WebSearch,
+            title: Some("Web search".to_string()),
+            detail: item
+                .get("query")
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status,
+        },
+        "todo_list" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Plan,
+            title: Some("Plan".to_string()),
+            detail: codex_todo_detail(item),
+            status,
+        },
+        "error" => ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Tool,
+            title: Some("Provider error".to_string()),
+            detail: item
+                .get("message")
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status: persistence::ChatActivityStatus::Error,
+        },
+        _ => return None,
+    };
+    Some(patch)
+}
+
+fn codex_activity_status(
+    outer_type: &str,
+    item: &serde_json::Value,
+) -> persistence::ChatActivityStatus {
+    match item.get("status").and_then(serde_json::Value::as_str) {
+        Some("failed" | "error" | "declined") => persistence::ChatActivityStatus::Error,
+        Some("cancelled") => persistence::ChatActivityStatus::Cancelled,
+        Some("completed") => persistence::ChatActivityStatus::Complete,
+        Some("in_progress") => persistence::ChatActivityStatus::Running,
+        _ if outer_type == "item.completed" => persistence::ChatActivityStatus::Complete,
+        _ => persistence::ChatActivityStatus::Running,
+    }
+}
+
+fn codex_legacy_activity(event: &serde_json::Value) -> Option<ChatActivityPatch> {
+    let event_type = event.get("type").and_then(serde_json::Value::as_str)?;
+    let id = event
+        .get("call_id")
+        .or_else(|| event.get("id"))
+        .or_else(|| event.get("turn_id"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("codex:{event_type}"));
+    let is_error = event
+        .get("success")
+        .and_then(serde_json::Value::as_bool)
+        .is_some_and(|success| !success)
+        || matches!(
+            event.get("status").and_then(serde_json::Value::as_str),
+            Some("failed" | "error" | "declined")
+        );
+    let ending = event_type.ends_with("_end") || event_type.ends_with("_complete");
+    let status = if is_error {
+        persistence::ChatActivityStatus::Error
+    } else if ending {
+        persistence::ChatActivityStatus::Complete
+    } else {
+        persistence::ChatActivityStatus::Running
+    };
+
+    match event_type {
+        "reasoning" => Some(ChatActivityPatch {
+            id: format!("{id}:reasoning"),
+            kind: persistence::ChatActivityKind::Reasoning,
+            title: Some("Reasoning".to_string()),
+            detail: event
+                .get("text")
+                .or_else(|| event.get("summary"))
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status: persistence::ChatActivityStatus::Complete,
+        }),
+        "exec_command_begin" | "exec_command_end" => Some(ChatActivityPatch {
+            id,
+            kind: persistence::ChatActivityKind::Command,
+            title: Some("Command".to_string()),
+            detail: event
+                .get("command")
+                .or_else(|| event.get("cmd"))
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail))),
+            status,
+        }),
+        "patch_apply_begin" | "patch_apply_end" | "apply_patch_begin" | "apply_patch_end" => {
+            Some(ChatActivityPatch {
+                id,
+                kind: persistence::ChatActivityKind::FileChange,
+                title: Some("File changes".to_string()),
+                detail: codex_file_change_detail(event),
+                status,
+            })
+        }
+        "mcp_tool_call_begin" | "mcp_tool_call_end" => {
+            let invocation = event.get("invocation").unwrap_or(event);
+            let server = invocation
+                .get("server")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("MCP");
+            let tool = invocation
+                .get("tool")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("tool");
+            Some(ChatActivityPatch {
+                id,
+                kind: persistence::ChatActivityKind::Tool,
+                title: Some(format!("{server} · {tool}")),
+                detail: None,
+                status,
+            })
+        }
+        "function_call" | "custom_tool_call" => {
+            let name = event
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("Tool");
+            Some(ChatActivityPatch {
+                id,
+                kind: tool_activity_kind(name),
+                title: Some(humanize_activity_name(name)),
+                detail: tool_input_detail(event.get("arguments").or_else(|| event.get("input"))),
+                status,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn codex_file_change_detail(value: &serde_json::Value) -> Option<String> {
+    let mut paths = Vec::new();
+    if let Some(changes) = value.get("changes").and_then(serde_json::Value::as_array) {
+        for change in changes.iter().take(20) {
+            if let Some(path) = change.get("path").and_then(serde_json::Value::as_str) {
+                paths.push(path.to_string());
+            }
+        }
+    } else if let Some(changes) = value.get("changes").and_then(serde_json::Value::as_object) {
+        paths.extend(changes.keys().take(20).cloned());
+    }
+    activity_detail((!paths.is_empty()).then(|| paths.join("\n")).as_deref())
+}
+
+fn codex_todo_detail(value: &serde_json::Value) -> Option<String> {
+    let items = value.get("items")?.as_array()?;
+    let lines = items
+        .iter()
+        .take(30)
+        .filter_map(|item| {
+            let text = item.get("text").and_then(serde_json::Value::as_str)?;
+            let marker = if item
+                .get("completed")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+            {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            Some(format!("{marker} {text}"))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    activity_detail(Some(&lines))
+}
+
+fn tool_activity_kind(name: &str) -> persistence::ChatActivityKind {
+    let normalized = name.to_ascii_lowercase();
+    if normalized.contains("bash")
+        || normalized.contains("shell")
+        || normalized.contains("command")
+        || normalized == "exec"
+    {
+        persistence::ChatActivityKind::Command
+    } else if normalized.contains("search") || normalized.contains("grep") {
+        persistence::ChatActivityKind::WebSearch
+    } else if normalized.contains("write")
+        || normalized.contains("edit")
+        || normalized.contains("patch")
+    {
+        persistence::ChatActivityKind::FileChange
+    } else {
+        persistence::ChatActivityKind::Tool
+    }
+}
+
+fn tool_input_detail(input: Option<&serde_json::Value>) -> Option<String> {
+    let input = input?;
+    if let Some(text) = input.as_str() {
+        return activity_detail(json_display_text(input).as_deref().or(Some(text)));
+    }
+    let object = input.as_object()?;
+    const SAFE_DETAIL_KEYS: &[&str] = &[
+        "command",
+        "cmd",
+        "file_path",
+        "path",
+        "AbsolutePath",
+        "DirectoryPath",
+        "pattern",
+        "query",
+        "url",
+        "description",
+        "toolAction",
+        "toolSummary",
+    ];
+    SAFE_DETAIL_KEYS.iter().find_map(|key| {
+        object
+            .get(*key)
+            .and_then(json_display_text)
+            .and_then(|detail| activity_detail(Some(&detail)))
+    })
+}
+
+fn json_display_text(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.starts_with('"') && trimmed.ends_with('"') {
+                serde_json::from_str::<String>(trimmed)
+                    .ok()
+                    .or_else(|| Some(trimmed.to_string()))
+            } else if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        serde_json::Value::Array(values) => {
+            let text = values
+                .iter()
+                .filter_map(|value| {
+                    value
+                        .get("text")
+                        .and_then(json_display_text)
+                        .or_else(|| json_display_text(value))
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    }
+}
+
+fn activity_detail(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    let mut detail = value
+        .chars()
+        .take(MAX_CHAT_ACTIVITY_DETAIL_CHARS)
+        .collect::<String>();
+    if value.chars().count() > MAX_CHAT_ACTIVITY_DETAIL_CHARS {
+        detail.push('…');
+    }
+    Some(detail)
+}
+
+fn humanize_activity_name(value: &str) -> String {
+    let mut out = String::new();
+    let mut previous_lowercase = false;
+    for ch in value.trim().chars() {
+        if ch == '_' || ch == '-' {
+            if !out.ends_with(' ') {
+                out.push(' ');
+            }
+            previous_lowercase = false;
+            continue;
+        }
+        if ch.is_ascii_uppercase() && previous_lowercase {
+            out.push(' ');
+        }
+        out.push(ch);
+        previous_lowercase = ch.is_ascii_lowercase();
+    }
+    let compact = out.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.is_empty() {
+        "Tool".to_string()
+    } else {
+        compact
+    }
 }
 
 fn extract_claude_stream_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
@@ -870,11 +1705,44 @@ fn extract_claude_stream_text(value: &serde_json::Value) -> Option<ChatStreamTex
                 is_final: false,
             })
         }
+        Some("stream_event") => {
+            let event = value.get("event")?;
+            if event.get("type").and_then(serde_json::Value::as_str) != Some("content_block_delta")
+                || event
+                    .get("delta")
+                    .and_then(|delta| delta.get("type"))
+                    .and_then(serde_json::Value::as_str)
+                    != Some("text_delta")
+            {
+                return None;
+            }
+            json_delta_text(event).map(|text| ChatStreamTextEvent {
+                text,
+                boundary: ChatStreamTextBoundary::Delta,
+                is_final: false,
+            })
+        }
         _ => None,
     }
 }
 
 fn extract_codex_stream_text(value: &serde_json::Value) -> Option<ChatStreamTextEvent> {
+    if matches!(
+        value.get("type").and_then(serde_json::Value::as_str),
+        Some("item.started" | "item.updated" | "item.completed")
+    ) {
+        let item = value.get("item")?;
+        if item.get("type").and_then(serde_json::Value::as_str) == Some("agent_message") {
+            return item
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .map(|text| ChatStreamTextEvent {
+                    text: text.to_string(),
+                    boundary: ChatStreamTextBoundary::Message,
+                    is_final: false,
+                });
+        }
+    }
     if let Some(event) = extract_codex_event_text(value) {
         return Some(event);
     }
@@ -1081,6 +1949,278 @@ fn backfill_latest_empty_codex_assistant_message(
     backfill_latest_empty_codex_assistant_message_from_path(state, &path)
 }
 
+const ANTIGRAVITY_TRANSCRIPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const ANTIGRAVITY_TRANSCRIPT_DISCOVERY_INTERVAL: Duration = Duration::from_millis(500);
+const MAX_ANTIGRAVITY_TRANSCRIPT_READ_BYTES: u64 = 1024 * 1024;
+const MAX_ANTIGRAVITY_TRANSCRIPT_LINE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_ANTIGRAVITY_FINISH_POLLS: usize = 8;
+
+struct AntigravityTranscriptFollower {
+    cwd: PathBuf,
+    process_start: SystemTime,
+    path: Option<PathBuf>,
+    offset: u64,
+    pending_bytes: Vec<u8>,
+    discard_until_newline: bool,
+    last_poll: Option<Instant>,
+    last_discovery: Option<Instant>,
+    line_sequence: u64,
+    pending_tools: VecDeque<(String, persistence::ChatActivityKind)>,
+}
+
+impl AntigravityTranscriptFollower {
+    fn new(cwd: PathBuf, resume_token: Option<&str>, process_start: SystemTime) -> Self {
+        let path = resume_token.and_then(acorn_transcript::locate_antigravity_transcript);
+        let offset = path
+            .as_ref()
+            .and_then(|path| std::fs::metadata(path).ok())
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        Self {
+            cwd,
+            process_start,
+            path,
+            offset,
+            pending_bytes: Vec::new(),
+            discard_until_newline: false,
+            last_poll: None,
+            last_discovery: None,
+            line_sequence: 0,
+            pending_tools: VecDeque::new(),
+        }
+    }
+
+    fn poll(&mut self, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
+        let now = Instant::now();
+        if self
+            .last_poll
+            .is_some_and(|last| now.duration_since(last) < ANTIGRAVITY_TRANSCRIPT_POLL_INTERVAL)
+        {
+            return;
+        }
+        self.last_poll = Some(now);
+        self.poll_now(on_event);
+    }
+
+    fn poll_now(&mut self, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
+        if self.path.is_none() {
+            let now = Instant::now();
+            if self.last_discovery.is_some_and(|last| {
+                now.duration_since(last) < ANTIGRAVITY_TRANSCRIPT_DISCOVERY_INTERVAL
+            }) {
+                return;
+            }
+            self.last_discovery = Some(now);
+            self.path = acorn_transcript::find_agent_run_transcript(
+                &self.cwd,
+                AgentKind::Antigravity,
+                self.process_start,
+            )
+            .map(|(path, _)| path);
+        }
+        let Some(path) = self.path.clone() else {
+            return;
+        };
+        let Ok(mut file) = std::fs::File::open(&path) else {
+            return;
+        };
+        let Ok(metadata) = file.metadata() else {
+            return;
+        };
+        if !metadata.file_type().is_file() {
+            return;
+        }
+        if metadata.len() < self.offset {
+            self.offset = 0;
+            self.pending_bytes.clear();
+            self.discard_until_newline = false;
+            self.line_sequence = 0;
+            self.pending_tools.clear();
+        }
+        let available = metadata.len().saturating_sub(self.offset);
+        if available == 0 || file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return;
+        }
+        let mut bytes = Vec::new();
+        if file
+            .take(available.min(MAX_ANTIGRAVITY_TRANSCRIPT_READ_BYTES))
+            .read_to_end(&mut bytes)
+            .is_err()
+        {
+            return;
+        }
+        self.offset = self.offset.saturating_add(bytes.len() as u64);
+        self.consume_bytes(&bytes, on_event);
+    }
+
+    fn finish(&mut self, on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
+        self.last_discovery = None;
+        for _ in 0..MAX_ANTIGRAVITY_FINISH_POLLS {
+            let previous_path = self.path.clone();
+            let previous_offset = self.offset;
+            self.poll_now(on_event);
+            if self.path == previous_path && self.offset == previous_offset {
+                break;
+            }
+        }
+        if !self.discard_until_newline && !self.pending_bytes.is_empty() {
+            let line = std::mem::take(&mut self.pending_bytes);
+            self.process_line(&line, on_event);
+        }
+    }
+
+    fn consume_bytes(
+        &mut self,
+        mut bytes: &[u8],
+        on_event: &mut dyn FnMut(ChatProviderStreamEvent),
+    ) {
+        if self.discard_until_newline {
+            let Some(newline) = bytes.iter().position(|byte| *byte == b'\n') else {
+                return;
+            };
+            bytes = &bytes[newline + 1..];
+            self.discard_until_newline = false;
+        }
+        self.pending_bytes.extend_from_slice(bytes);
+        while let Some(newline) = self.pending_bytes.iter().position(|byte| *byte == b'\n') {
+            let mut line = self.pending_bytes.drain(..=newline).collect::<Vec<_>>();
+            line.pop();
+            if line.len() <= MAX_ANTIGRAVITY_TRANSCRIPT_LINE_BYTES {
+                self.process_line(&line, on_event);
+            }
+        }
+        if self.pending_bytes.len() > MAX_ANTIGRAVITY_TRANSCRIPT_LINE_BYTES {
+            self.pending_bytes.clear();
+            self.discard_until_newline = true;
+        }
+    }
+
+    fn process_line(&mut self, line: &[u8], on_event: &mut dyn FnMut(ChatProviderStreamEvent)) {
+        let Ok(value) = serde_json::from_slice::<serde_json::Value>(line) else {
+            return;
+        };
+        let line_type = value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        if matches!(line_type, "" | "USER_INPUT" | "CONVERSATION_HISTORY") {
+            return;
+        }
+        self.line_sequence = self.line_sequence.saturating_add(1);
+        let step = value
+            .get("step_index")
+            .and_then(serde_json::Value::as_u64)
+            .map(|step| step.to_string())
+            .unwrap_or_else(|| self.line_sequence.to_string());
+        let line_type_upper = line_type.to_ascii_uppercase();
+        let provider_status = value
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_ascii_uppercase);
+        let status = match provider_status.as_deref() {
+            Some("ERROR" | "FAILED") => persistence::ChatActivityStatus::Error,
+            Some("CANCELLED" | "CANCELED" | "STOPPED") => {
+                persistence::ChatActivityStatus::Cancelled
+            }
+            _ if line_type_upper.contains("ERROR") => persistence::ChatActivityStatus::Error,
+            _ => persistence::ChatActivityStatus::Complete,
+        };
+
+        if line_type == "PLANNER_RESPONSE" {
+            let thinking = value
+                .get("thinking")
+                .and_then(json_display_text)
+                .and_then(|detail| activity_detail(Some(&detail)));
+            let has_thinking = thinking.is_some();
+            if thinking.is_some() {
+                on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                    id: format!("antigravity:{step}:reasoning"),
+                    kind: persistence::ChatActivityKind::Reasoning,
+                    title: Some("Reasoning".to_string()),
+                    detail: thinking,
+                    status: persistence::ChatActivityStatus::Complete,
+                }));
+            }
+            let tool_calls = value
+                .get("tool_calls")
+                .and_then(serde_json::Value::as_array);
+            if let Some(tool_calls) = tool_calls.filter(|calls| !calls.is_empty()) {
+                if !has_thinking {
+                    if let Some(detail) = value
+                        .get("content")
+                        .and_then(json_display_text)
+                        .and_then(|detail| activity_detail(Some(&detail)))
+                    {
+                        on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                            id: format!("antigravity:{step}:reasoning"),
+                            kind: persistence::ChatActivityKind::Reasoning,
+                            title: Some("Reasoning".to_string()),
+                            detail: Some(detail),
+                            status: persistence::ChatActivityStatus::Complete,
+                        }));
+                    }
+                }
+                for (index, tool_call) in tool_calls
+                    .iter()
+                    .take(MAX_CHAT_TURN_ACTIVITIES.saturating_sub(self.pending_tools.len()))
+                    .enumerate()
+                {
+                    let name = tool_call
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("Tool");
+                    let id = format!("antigravity:{step}:tool:{index}");
+                    let kind = tool_activity_kind(name);
+                    let args = tool_call.get("args");
+                    let title = args
+                        .and_then(|args| args.get("toolAction"))
+                        .or_else(|| args.and_then(|args| args.get("toolSummary")))
+                        .and_then(json_display_text)
+                        .unwrap_or_else(|| humanize_activity_name(name));
+                    on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                        id: id.clone(),
+                        kind,
+                        title: Some(title),
+                        detail: tool_input_detail(args),
+                        status: persistence::ChatActivityStatus::Running,
+                    }));
+                    self.pending_tools.push_back((id, kind));
+                }
+            } else if status == persistence::ChatActivityStatus::Error {
+                on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                    id: format!("antigravity:{step}:error"),
+                    kind: persistence::ChatActivityKind::Tool,
+                    title: Some("Provider error".to_string()),
+                    detail: value
+                        .get("content")
+                        .and_then(json_display_text)
+                        .and_then(|detail| activity_detail(Some(&detail))),
+                    status,
+                }));
+            }
+            return;
+        }
+
+        if let Some((id, kind)) = self.pending_tools.pop_front() {
+            on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                id,
+                kind,
+                title: None,
+                detail: None,
+                status,
+            }));
+        } else {
+            on_event(ChatProviderStreamEvent::Activity(ChatActivityPatch {
+                id: format!("antigravity:{step}:{line_type}"),
+                kind: tool_activity_kind(line_type),
+                title: Some(humanize_activity_name(line_type)),
+                detail: None,
+                status,
+            }));
+        }
+    }
+}
+
 struct CliChatProviderAdapter {
     ai: crate::ai::AiExecutionRequest,
     cwd: PathBuf,
@@ -1102,26 +2242,48 @@ impl ChatProviderAdapter for CliChatProviderAdapter {
     }
 
     fn send_message(&self, input: ChatProviderInput) -> AppResult<ProviderResponse> {
-        let mut ignore_chunk: fn(&str) = ignore_chat_streaming_chunk;
-        self.send_message_streaming(input, &mut ignore_chunk)
+        let mut ignore_event: fn(ChatProviderStreamEvent) = ignore_chat_streaming_event;
+        self.send_message_streaming(input, &mut ignore_event)
     }
 
     fn send_message_streaming(
         &self,
         input: ChatProviderInput,
-        on_chunk: &mut dyn FnMut(&str),
+        on_event: &mut dyn FnMut(ChatProviderStreamEvent),
     ) -> AppResult<ProviderResponse> {
         let invocation = resolve_chat_cli_invocation(&self.ai, &input)?;
         let started_at = SystemTime::now();
         let mut output_parser = ChatCliOutputParser::new(invocation.output_mode);
+        let mut antigravity_follower = (self.ai.provider == crate::ai::AiProvider::Antigravity)
+            .then(|| {
+                AntigravityTranscriptFollower::new(
+                    self.cwd.clone(),
+                    invocation.resume_token.as_deref(),
+                    started_at,
+                )
+            });
         let raw = crate::ai::run_resolved_streaming_in_dir_cancellable(
             &invocation.cli,
             &invocation.prompt,
             "Settings → Agents",
             Some(&self.cwd),
             self.cancellation.clone(),
-            |chunk| output_parser.push_chunk(chunk, on_chunk),
-        )?;
+            |event| match event {
+                crate::ai::AiProcessStreamEvent::Stdout(chunk) => {
+                    output_parser.push_chunk(chunk, on_event);
+                }
+                crate::ai::AiProcessStreamEvent::Tick => {
+                    if let Some(follower) = antigravity_follower.as_mut() {
+                        follower.poll(on_event);
+                    }
+                }
+            },
+        );
+        if let Some(follower) = antigravity_follower.as_mut() {
+            follower.finish(on_event);
+        }
+        output_parser.flush_pending(on_event);
+        let raw = raw?;
         let content = output_parser.finish(&raw);
         let discovered_thread_id = invocation.transcript_discovery.and_then(|kind| {
             acorn_transcript::find_completed_agent_run(&self.cwd, kind, started_at)
@@ -1602,6 +2764,7 @@ fn start_chat_turn(
         started_at: now,
         completed_at: None,
         error: None,
+        activities: Vec::new(),
     });
     chat_state
         .context_snapshots
@@ -1700,6 +2863,7 @@ fn finish_chat_turn(
         .iter_mut()
         .find(|turn| turn.id == started.turn_id)
     {
+        finish_running_chat_activities(&mut turn.activities, turn_status, completed_at);
         turn.status = turn_status;
         turn.completed_at = Some(completed_at);
         turn.error = error;
@@ -1758,6 +2922,107 @@ fn append_streaming_chat_chunk(
     true
 }
 
+fn upsert_chat_activity(
+    chat_state: &mut persistence::ChatSessionState,
+    turn_id: &str,
+    mut patch: ChatActivityPatch,
+) -> bool {
+    patch.id = patch
+        .id
+        .trim()
+        .chars()
+        .take(MAX_CHAT_ACTIVITY_ID_CHARS)
+        .collect();
+    if patch.id.is_empty() {
+        return false;
+    }
+    patch.title = patch.title.and_then(|title| {
+        let title = title
+            .trim()
+            .chars()
+            .take(MAX_CHAT_ACTIVITY_TITLE_CHARS)
+            .collect::<String>();
+        (!title.is_empty()).then_some(title)
+    });
+    patch.detail = patch
+        .detail
+        .as_deref()
+        .and_then(|detail| activity_detail(Some(detail)));
+
+    let Some(turn) = chat_state.turns.iter_mut().find(|turn| turn.id == turn_id) else {
+        return false;
+    };
+    let now = chrono::Utc::now();
+    if let Some(activity) = turn
+        .activities
+        .iter_mut()
+        .find(|activity| activity.id == patch.id)
+    {
+        if let Some(title) = patch.title {
+            activity.title = title;
+        }
+        if let Some(detail) = patch.detail {
+            activity.detail = Some(detail);
+        }
+        activity.status = patch.status;
+        activity.completed_at = match patch.status {
+            persistence::ChatActivityStatus::Running => None,
+            _ => Some(now),
+        };
+    } else {
+        if turn.activities.len() >= MAX_CHAT_TURN_ACTIVITIES {
+            return false;
+        }
+        let title = patch
+            .title
+            .unwrap_or_else(|| default_chat_activity_title(patch.kind).to_string());
+        turn.activities.push(persistence::ChatActivity {
+            id: patch.id,
+            kind: patch.kind,
+            title,
+            detail: patch.detail,
+            status: patch.status,
+            started_at: now,
+            completed_at: match patch.status {
+                persistence::ChatActivityStatus::Running => None,
+                _ => Some(now),
+            },
+        });
+    }
+    chat_state.session.updated_at = now;
+    chat_state.updated_at = now;
+    true
+}
+
+fn default_chat_activity_title(kind: persistence::ChatActivityKind) -> &'static str {
+    match kind {
+        persistence::ChatActivityKind::Reasoning => "Reasoning",
+        persistence::ChatActivityKind::Tool => "Tool",
+        persistence::ChatActivityKind::Command => "Command",
+        persistence::ChatActivityKind::FileChange => "File changes",
+        persistence::ChatActivityKind::WebSearch => "Web search",
+        persistence::ChatActivityKind::Plan => "Plan",
+    }
+}
+
+fn finish_running_chat_activities(
+    activities: &mut [persistence::ChatActivity],
+    turn_status: persistence::ChatTurnStatus,
+    completed_at: chrono::DateTime<chrono::Utc>,
+) {
+    let status = match turn_status {
+        persistence::ChatTurnStatus::Error => persistence::ChatActivityStatus::Error,
+        persistence::ChatTurnStatus::Cancelled => persistence::ChatActivityStatus::Cancelled,
+        _ => persistence::ChatActivityStatus::Complete,
+    };
+    for activity in activities {
+        if activity.status == persistence::ChatActivityStatus::Running {
+            activity.status = status;
+            activity.completed_at = Some(completed_at);
+        }
+    }
+}
+
 fn chat_turn_finish_from_result(
     provider_result: AppResult<ProviderResponse>,
     was_cancelled: bool,
@@ -1783,6 +3048,11 @@ fn cancel_chat_turn_in_state(
             turn.status,
             persistence::ChatTurnStatus::Pending | persistence::ChatTurnStatus::Running
         ) {
+            finish_running_chat_activities(
+                &mut turn.activities,
+                persistence::ChatTurnStatus::Cancelled,
+                completed_at,
+            );
             turn.status = persistence::ChatTurnStatus::Cancelled;
             turn.completed_at = Some(completed_at);
             turn.error = None;
@@ -3309,12 +4579,21 @@ fn send_chat_message_from_state_inner<R: Runtime>(
     let provider_input = started.input.clone();
     let assistant_message_id = started.assistant_message_id.clone();
     let provider_result = if adapter.capabilities().streaming {
-        let mut on_chunk = |chunk: &str| {
-            if append_streaming_chat_chunk(&mut started.state, &assistant_message_id, chunk) {
+        let turn_id = started.turn_id.clone();
+        let mut on_event = |event| {
+            let changed = match event {
+                ChatProviderStreamEvent::AssistantTextDelta(chunk) => {
+                    append_streaming_chat_chunk(&mut started.state, &assistant_message_id, &chunk)
+                }
+                ChatProviderStreamEvent::Activity(activity) => {
+                    upsert_chat_activity(&mut started.state, &turn_id, activity)
+                }
+            };
+            if changed {
                 emit_chat_session_state_changed(app, &started.state);
             }
         };
-        adapter.send_message_streaming(provider_input, &mut on_chunk)
+        adapter.send_message_streaming(provider_input, &mut on_event)
     } else {
         adapter.send_message(provider_input)
     };
@@ -8114,6 +9393,7 @@ mod tests {
             started_at: now,
             completed_at: None,
             error: None,
+            activities: Vec::new(),
         });
 
         assert!(super::chat_state_has_running_message(&state));
@@ -8149,13 +9429,73 @@ mod tests {
     }
 
     #[test]
+    fn streaming_activity_updates_one_stable_turn_entry() {
+        let now = chrono::Utc::now();
+        let mut state = chat_state_for_runtime(Vec::new());
+        state.turns.push(crate::persistence::ChatTurn {
+            id: "turn-1".to_string(),
+            session_id: state.session_id.clone(),
+            provider: "codex".to_string(),
+            model: None,
+            status: crate::persistence::ChatTurnStatus::Running,
+            user_message_id: "u1".to_string(),
+            assistant_message_id: Some("a1".to_string()),
+            started_at: now,
+            completed_at: None,
+            error: None,
+            activities: Vec::new(),
+        });
+
+        assert!(super::upsert_chat_activity(
+            &mut state,
+            "turn-1",
+            super::ChatActivityPatch {
+                id: "tool-1".to_string(),
+                kind: crate::persistence::ChatActivityKind::Command,
+                title: Some("Run tests".to_string()),
+                detail: Some("cargo test".to_string()),
+                status: crate::persistence::ChatActivityStatus::Running,
+            },
+        ));
+        assert!(super::upsert_chat_activity(
+            &mut state,
+            "turn-1",
+            super::ChatActivityPatch {
+                id: "tool-1".to_string(),
+                kind: crate::persistence::ChatActivityKind::Tool,
+                title: None,
+                detail: None,
+                status: crate::persistence::ChatActivityStatus::Complete,
+            },
+        ));
+
+        let activities = &state.turns[0].activities;
+        assert_eq!(activities.len(), 1);
+        assert_eq!(
+            activities[0].kind,
+            crate::persistence::ChatActivityKind::Command
+        );
+        assert_eq!(activities[0].title, "Run tests");
+        assert_eq!(activities[0].detail.as_deref(), Some("cargo test"));
+        assert_eq!(
+            activities[0].status,
+            crate::persistence::ChatActivityStatus::Complete
+        );
+        assert!(activities[0].completed_at.is_some());
+    }
+
+    #[test]
     fn chat_stream_parser_extracts_claude_partial_jsonl_without_duplicates() {
         let mut parser =
             super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hel"}]}}"#,
                 &mut on_chunk,
@@ -8175,13 +9515,126 @@ mod tests {
     }
 
     #[test]
+    fn chat_stream_parser_normalizes_claude_reasoning_and_tool_lifecycle() {
+        let mut parser =
+            super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
+        let mut events = Vec::new();
+
+        {
+            let mut on_event = |event| events.push(event);
+            parser.push_chunk(
+                concat!(
+                    r#"{"type":"assistant","message":{"id":"msg-1","stop_reason":null,"content":[{"type":"thinking","thinking":"Inspect the repository first."},{"type":"tool_use","id":"tool-1","name":"Bash","input":{"command":"rg --files"}}]}}"#,
+                    "\n",
+                    r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"done"}]}}"#,
+                    "\n"
+                ),
+                &mut on_event,
+            );
+        }
+
+        assert_eq!(
+            events,
+            vec![
+                super::ChatProviderStreamEvent::Activity(super::ChatActivityPatch {
+                    id: "claude:msg-1:reasoning:0".to_string(),
+                    kind: crate::persistence::ChatActivityKind::Reasoning,
+                    title: Some("Reasoning".to_string()),
+                    detail: Some("Inspect the repository first.".to_string()),
+                    status: crate::persistence::ChatActivityStatus::Running,
+                }),
+                super::ChatProviderStreamEvent::Activity(super::ChatActivityPatch {
+                    id: "tool-1".to_string(),
+                    kind: crate::persistence::ChatActivityKind::Command,
+                    title: Some("Bash".to_string()),
+                    detail: Some("rg --files".to_string()),
+                    status: crate::persistence::ChatActivityStatus::Running,
+                }),
+                super::ChatProviderStreamEvent::Activity(super::ChatActivityPatch {
+                    id: "tool-1".to_string(),
+                    kind: crate::persistence::ChatActivityKind::Tool,
+                    title: None,
+                    detail: None,
+                    status: crate::persistence::ChatActivityStatus::Complete,
+                }),
+            ]
+        );
+    }
+
+    #[test]
+    fn chat_stream_parser_normalizes_claude_partial_stream_events() {
+        let mut parser =
+            super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
+        let mut events = Vec::new();
+
+        {
+            let mut on_event = |event| events.push(event);
+            parser.push_chunk(
+                concat!(
+                    r#"{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg-live","usage":{"input_tokens":8}}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Inspect live."}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool-live","name":"Bash","input":{}}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\""}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"pwd\"}"}}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_stop","index":1}}"#,
+                    "\n",
+                    r#"{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Done"}}}"#,
+                    "\n"
+                ),
+                &mut on_event,
+            );
+        }
+
+        let activities = events
+            .iter()
+            .filter_map(|event| match event {
+                super::ChatProviderStreamEvent::Activity(activity) => Some(activity),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(activities[2].id, "claude:msg-live:reasoning:0");
+        assert_eq!(activities[2].detail.as_deref(), Some("Inspect live."));
+        assert_eq!(
+            activities[2].status,
+            crate::persistence::ChatActivityStatus::Complete
+        );
+        let tool = activities.last().unwrap();
+        assert_eq!(tool.id, "tool-live");
+        assert_eq!(tool.detail.as_deref(), Some("pwd"));
+        assert_eq!(tool.status, crate::persistence::ChatActivityStatus::Running);
+        assert!(events.iter().any(|event| {
+            matches!(
+                event,
+                super::ChatProviderStreamEvent::AssistantTextDelta(text) if text == "Done"
+            )
+        }));
+        assert_eq!(
+            parser.provider_metadata(),
+            Some(serde_json::json!({ "usage": { "input_tokens": 8 } }))
+        );
+    }
+
+    #[test]
     fn chat_stream_parser_records_claude_usage_metadata() {
         let mut parser =
             super::ChatCliOutputParser::new(super::ChatCliOutputMode::ClaudeStreamJson);
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":11,"output_tokens":3}}}"#,
                 &mut on_chunk,
@@ -8207,7 +9660,11 @@ mod tests {
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"핵심 파일 확인."}]}}"#,
                 &mut on_chunk,
@@ -8236,7 +9693,11 @@ mod tests {
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"msg":{"type":"agent_message_content_delta","delta":"hel"}}"#,
                 &mut on_chunk,
@@ -8259,12 +9720,121 @@ mod tests {
     }
 
     #[test]
+    fn chat_stream_parser_normalizes_codex_item_events() {
+        let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
+        let mut events = Vec::new();
+
+        {
+            let mut on_event = |event| events.push(event);
+            parser.push_chunk(
+                concat!(
+                    r#"{"type":"item.completed","item":{"id":"reason-1","type":"reasoning","text":"Find the relevant call path."}}"#,
+                    "\n",
+                    r#"{"type":"item.started","item":{"id":"command-1","type":"command_execution","command":"cargo test","status":"in_progress"}}"#,
+                    "\n",
+                    r#"{"type":"item.completed","item":{"id":"command-1","type":"command_execution","command":"cargo test","status":"completed"}}"#,
+                    "\n"
+                ),
+                &mut on_event,
+            );
+        }
+
+        assert_eq!(events.len(), 3);
+        let super::ChatProviderStreamEvent::Activity(reasoning) = &events[0] else {
+            panic!("expected reasoning activity");
+        };
+        assert_eq!(
+            reasoning.kind,
+            crate::persistence::ChatActivityKind::Reasoning
+        );
+        assert_eq!(
+            reasoning.detail.as_deref(),
+            Some("Find the relevant call path.")
+        );
+        assert_eq!(
+            reasoning.status,
+            crate::persistence::ChatActivityStatus::Complete
+        );
+
+        let super::ChatProviderStreamEvent::Activity(started) = &events[1] else {
+            panic!("expected command activity");
+        };
+        let super::ChatProviderStreamEvent::Activity(completed) = &events[2] else {
+            panic!("expected command completion");
+        };
+        assert_eq!(started.id, "command-1");
+        assert_eq!(completed.id, "command-1");
+        assert_eq!(
+            started.status,
+            crate::persistence::ChatActivityStatus::Running
+        );
+        assert_eq!(
+            completed.status,
+            crate::persistence::ChatActivityStatus::Complete
+        );
+    }
+
+    #[test]
+    fn antigravity_transcript_follower_normalizes_planner_and_tool_result() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut follower = super::AntigravityTranscriptFollower::new(
+            tmp.path().to_path_buf(),
+            None,
+            std::time::SystemTime::now(),
+        );
+        let mut events = Vec::new();
+        let mut on_event = |event| events.push(event);
+
+        follower.process_line(
+            br#"{"type":"PLANNER_RESPONSE","step_index":7,"thinking":"Inspect before editing.","tool_calls":[{"name":"run_command","args":{"toolAction":"Run tests","command":"pnpm test"}}]}"#,
+            &mut on_event,
+        );
+        follower.process_line(
+            br#"{"type":"RUN_COMMAND","step_index":7,"status":"SUCCESS"}"#,
+            &mut on_event,
+        );
+
+        assert_eq!(events.len(), 3);
+        let super::ChatProviderStreamEvent::Activity(reasoning) = &events[0] else {
+            panic!("expected reasoning activity");
+        };
+        assert_eq!(
+            reasoning.kind,
+            crate::persistence::ChatActivityKind::Reasoning
+        );
+        assert_eq!(reasoning.detail.as_deref(), Some("Inspect before editing."));
+
+        let super::ChatProviderStreamEvent::Activity(started) = &events[1] else {
+            panic!("expected tool activity");
+        };
+        let super::ChatProviderStreamEvent::Activity(completed) = &events[2] else {
+            panic!("expected tool completion");
+        };
+        assert_eq!(started.id, "antigravity:7:tool:0");
+        assert_eq!(started.title.as_deref(), Some("Run tests"));
+        assert_eq!(started.detail.as_deref(), Some("pnpm test"));
+        assert_eq!(
+            started.status,
+            crate::persistence::ChatActivityStatus::Running
+        );
+        assert_eq!(completed.id, started.id);
+        assert_eq!(
+            completed.status,
+            crate::persistence::ChatActivityStatus::Complete
+        );
+    }
+
+    #[test]
     fn chat_stream_parser_extracts_codex_task_complete_payload_message() {
         let mut parser = super::ChatCliOutputParser::new(super::ChatCliOutputMode::CodexJson);
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"안녕하세요. 무엇을 도와드릴까요?"}}"#,
                 &mut on_chunk,
@@ -8456,7 +10026,11 @@ mod tests {
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"msg":{"type":"token_count","info":{"total_token_usage":{"input_tokens":20,"cached_input_tokens":7,"output_tokens":5,"reasoning_output_tokens":2,"total_tokens":32}}}}"#,
                 &mut on_chunk,
@@ -8484,7 +10058,11 @@ mod tests {
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"msg":{"type":"agent_message","message":"디렉토리 + 타입 정의 핵심 파일 확인."}}"#,
                 &mut on_chunk,
@@ -8513,7 +10091,11 @@ mod tests {
         let mut chunks = Vec::new();
 
         {
-            let mut on_chunk = |chunk: &str| chunks.push(chunk.to_string());
+            let mut on_chunk = |event| {
+                if let super::ChatProviderStreamEvent::AssistantTextDelta(chunk) = event {
+                    chunks.push(chunk);
+                }
+            };
             parser.push_chunk(
                 r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}}"#,
                 &mut on_chunk,
@@ -9116,6 +10698,15 @@ mod tests {
             started_at: now,
             completed_at: None,
             error: None,
+            activities: vec![crate::persistence::ChatActivity {
+                id: "tool-1".to_string(),
+                kind: crate::persistence::ChatActivityKind::Command,
+                title: "Long command".to_string(),
+                detail: None,
+                status: crate::persistence::ChatActivityStatus::Running,
+                started_at: now,
+                completed_at: None,
+            }],
         });
         state.messages.push(crate::persistence::ChatMessage {
             id: "a1".to_string(),
@@ -9137,6 +10728,11 @@ mod tests {
         );
         assert!(state.turns[0].completed_at.is_some());
         assert_eq!(state.turns[0].error, None);
+        assert_eq!(
+            state.turns[0].activities[0].status,
+            crate::persistence::ChatActivityStatus::Cancelled
+        );
+        assert!(state.turns[0].activities[0].completed_at.is_some());
         assert_eq!(state.messages[1].content, "Cancelled");
         assert_eq!(
             state.messages[1].status,

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -172,6 +172,41 @@ pub struct ChatTurn {
     pub completed_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub activities: Vec<ChatActivity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ChatActivity {
+    pub id: String,
+    pub kind: ChatActivityKind,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub status: ChatActivityStatus,
+    pub started_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatActivityKind {
+    Reasoning,
+    Tool,
+    Command,
+    FileChange,
+    WebSearch,
+    Plan,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatActivityStatus {
+    Running,
+    Complete,
+    Error,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -635,6 +670,21 @@ fn validate_chat_session_state(mut state: ChatSessionState) -> AppResult<(Uuid, 
         turn.model = normalize_optional_string(turn.model.take());
         turn.assistant_message_id = normalize_optional_string(turn.assistant_message_id.take());
         turn.error = normalize_optional_string(turn.error.take());
+        for activity in &mut turn.activities {
+            activity.id = activity.id.trim().to_string();
+            if activity.id.is_empty() {
+                return Err(AppError::Other(
+                    "chat activity id must not be empty".to_string(),
+                ));
+            }
+            activity.title = activity.title.trim().to_string();
+            if activity.title.is_empty() {
+                return Err(AppError::Other(
+                    "chat activity title must not be empty".to_string(),
+                ));
+            }
+            activity.detail = normalize_optional_string(activity.detail.take());
+        }
     }
     for thread in &mut state.provider_threads {
         if thread.session_id.trim().is_empty() {

--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -2360,4 +2360,144 @@ describe("ChatPane", () => {
     expect(container.textContent).toContain("hi from antigravity");
   });
 
+  it("shows normalized agent activity instead of the generic running label", async () => {
+    const loaded = chatState(
+      "s1",
+      [
+        {
+          id: "u1",
+          turn_id: "turn-1",
+          role: "user",
+          content: "inspect the repository",
+          created_at: "2026-01-01T00:00:00Z",
+          status: "complete",
+          metadata: null,
+        },
+        {
+          id: "a1",
+          turn_id: "turn-1",
+          role: "assistant",
+          content: "",
+          created_at: "2026-01-01T00:00:01Z",
+          status: "pending",
+          metadata: { provider: "antigravity" },
+        },
+      ],
+      "antigravity",
+    );
+    loaded.turns = [
+      {
+        id: "turn-1",
+        session_id: "s1",
+        provider: "antigravity",
+        status: "running",
+        user_message_id: "u1",
+        assistant_message_id: "a1",
+        started_at: "2026-01-01T00:00:00Z",
+        activities: [
+          {
+            id: "agy-tool-1",
+            kind: "command",
+            title: "Inspect repository",
+            detail: "rg --files",
+            status: "running",
+            started_at: "2026-01-01T00:00:01Z",
+          },
+        ],
+      },
+    ];
+    mocks.loadChatSessionState.mockResolvedValueOnce(loaded);
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    expect(container.querySelector("[data-chat-activity-timeline]")).toBeTruthy();
+    expect(container.querySelector("[data-chat-activity-list]")).toBeTruthy();
+    expect(container.textContent).toContain("Inspect repository");
+    expect(container.textContent).toContain("rg --files");
+    expect(container.querySelector("[data-chat-running-label]")).toBeNull();
+  });
+
+  it("collapses completed agent activity and lets the user inspect it", async () => {
+    const loaded = chatState(
+      "s1",
+      [
+        {
+          id: "u1",
+          turn_id: "turn-1",
+          role: "user",
+          content: "fix it",
+          created_at: "2026-01-01T00:00:00Z",
+          status: "complete",
+          metadata: null,
+        },
+        {
+          id: "a1",
+          turn_id: "turn-1",
+          role: "assistant",
+          content: "Done.",
+          created_at: "2026-01-01T00:00:03Z",
+          status: "complete",
+          metadata: { provider: "codex" },
+        },
+      ],
+      "codex",
+    );
+    loaded.turns = [
+      {
+        id: "turn-1",
+        session_id: "s1",
+        provider: "codex",
+        status: "complete",
+        user_message_id: "u1",
+        assistant_message_id: "a1",
+        started_at: "2026-01-01T00:00:00Z",
+        completed_at: "2026-01-01T00:00:03Z",
+        activities: [
+          {
+            id: "reasoning-1",
+            kind: "reasoning",
+            title: "Reasoning",
+            detail: "The failing path is in the parser.",
+            status: "complete",
+            started_at: "2026-01-01T00:00:01Z",
+            completed_at: "2026-01-01T00:00:02Z",
+          },
+          {
+            id: "file-1",
+            kind: "file_change",
+            title: "File changes",
+            detail: "src/parser.ts",
+            status: "complete",
+            started_at: "2026-01-01T00:00:02Z",
+            completed_at: "2026-01-01T00:00:03Z",
+          },
+        ],
+      },
+    ];
+    mocks.loadChatSessionState.mockResolvedValueOnce(loaded);
+
+    await act(async () => {
+      root.render(<ChatPane sessionId="s1" />);
+    });
+    await settle();
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      "[data-chat-activity-toggle]",
+    );
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector("[data-chat-activity-list]")).toBeNull();
+    expect(container.textContent).toContain("2 activities");
+    expect(container.textContent).toContain("Done.");
+
+    await act(async () => {
+      toggle!.click();
+    });
+
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("The failing path is in the parser.");
+    expect(container.textContent).toContain("src/parser.ts");
+  });
 });

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -47,6 +47,7 @@ import type {
   SessionAgentProvider,
   SessionStatus,
 } from "../lib/types";
+import { ChatActivityTimeline } from "./chat/ChatActivityTimeline";
 import { ChatMessageBody } from "./chat/ChatMessageBody";
 import { Tooltip } from "./Tooltip";
 import { Button, Modal, ModalFooter, ModalHeader, Select } from "./ui";
@@ -1162,6 +1163,15 @@ export function ChatPane({
               const isPending = message.status === "pending";
               const isStreaming = message.status === "streaming";
               const isRunningMessage = isPending || isStreaming;
+              const turn = message.turn_id
+                ? state?.turns.find((turn) => turn.id === message.turn_id)
+                : undefined;
+              const activities =
+                message.role === "assistant" ? (turn?.activities ?? []) : [];
+              const hasActivities = activities.length > 0;
+              const activityIsRunning =
+                isRunningMessage ||
+                activities.some((activity) => activity.status === "running");
               const isCancelled = message.status === "cancelled";
               const canForkBeforeMessage =
                 !isRunningMessage &&
@@ -1266,18 +1276,7 @@ export function ChatPane({
                           : ""
                       }`}
                     >
-                      {isPending || (isStreaming && !message.content) ? (
-                        <div className="flex items-center text-fg-muted">
-                          <span
-                            className="animate-pulse"
-                            data-chat-running-label
-                          >
-                            Running {providerLabel(
-                              messageProvider ?? stateProvider ?? provider,
-                            )}
-                          </span>
-                        </div>
-                      ) : isEditing ? (
+                      {isEditing ? (
                         <div className="flex min-w-0 flex-col gap-2">
                           <textarea
                             aria-label="Edit user message content"
@@ -1324,11 +1323,39 @@ export function ChatPane({
                           </div>
                         </div>
                       ) : (
-                        <StreamingChatMessageBody
-                          content={message.content}
-                          repoPath={repoPath}
-                          isStreaming={isStreaming}
-                        />
+                        <>
+                          {hasActivities ? (
+                            <ChatActivityTimeline
+                              activities={activities}
+                              isRunning={activityIsRunning}
+                            />
+                          ) : null}
+                          {isPending ||
+                          (isStreaming && !message.content) ? (
+                            hasActivities ? null : (
+                              <div className="flex items-center text-fg-muted">
+                                <span
+                                  className="animate-pulse"
+                                  data-chat-running-label
+                                >
+                                  Running {providerLabel(
+                                    messageProvider ??
+                                      stateProvider ??
+                                      provider,
+                                  )}
+                                </span>
+                              </div>
+                            )
+                          ) : message.content ? (
+                            <div className={hasActivities ? "mt-2" : undefined}>
+                              <StreamingChatMessageBody
+                                content={message.content}
+                                repoPath={repoPath}
+                                isStreaming={isStreaming}
+                              />
+                            </div>
+                          ) : null}
+                        </>
                       )}
                     </div>
                     {showMessageMeta ? (

--- a/src/components/chat/ChatActivityTimeline.tsx
+++ b/src/components/chat/ChatActivityTimeline.tsx
@@ -1,0 +1,187 @@
+import {
+  Brain,
+  Check,
+  ChevronDown,
+  CircleX,
+  FilePenLine,
+  ListChecks,
+  LoaderCircle,
+  Search,
+  Terminal,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type {
+  ChatActivity,
+  ChatActivityKind,
+  ChatActivityStatus,
+} from "../../lib/types";
+
+interface ChatActivityTimelineProps {
+  activities: ChatActivity[];
+  isRunning: boolean;
+}
+
+const ACTIVITY_ICONS: Record<ChatActivityKind, LucideIcon> = {
+  reasoning: Brain,
+  tool: Wrench,
+  command: Terminal,
+  file_change: FilePenLine,
+  web_search: Search,
+  plan: ListChecks,
+};
+
+function ActivityStatusIcon({ status }: { status: ChatActivityStatus }) {
+  if (status === "running") {
+    return (
+      <LoaderCircle
+        aria-label="Running"
+        className="animate-spin text-accent"
+        size={12}
+      />
+    );
+  }
+  if (status === "error") {
+    return <CircleX aria-label="Failed" className="text-danger" size={12} />;
+  }
+  if (status === "cancelled") {
+    return <X aria-label="Cancelled" className="text-fg-muted" size={12} />;
+  }
+  return <Check aria-label="Complete" className="text-success" size={12} />;
+}
+
+function activitySummary(activities: ChatActivity[], isRunning: boolean) {
+  const active = [...activities]
+    .reverse()
+    .find((activity) => activity.status === "running");
+  if (isRunning && active) return active.title;
+  const failed = activities.filter(
+    (activity) => activity.status === "error",
+  ).length;
+  const count = `${activities.length} ${
+    activities.length === 1 ? "activity" : "activities"
+  }`;
+  if (failed > 0) return `${count} · ${failed} failed`;
+  return count;
+}
+
+export function ChatActivityTimeline({
+  activities,
+  isRunning,
+}: ChatActivityTimelineProps) {
+  const [expanded, setExpanded] = useState(isRunning);
+  const wasRunning = useRef(isRunning);
+
+  useEffect(() => {
+    if (isRunning) {
+      setExpanded(true);
+    } else if (wasRunning.current) {
+      setExpanded(false);
+    }
+    wasRunning.current = isRunning;
+  }, [isRunning]);
+
+  if (activities.length === 0) return null;
+
+  const hasError = activities.some((activity) => activity.status === "error");
+  const hasCancelled = activities.some(
+    (activity) => activity.status === "cancelled",
+  );
+
+  return (
+    <section
+      className="min-w-[16rem] overflow-hidden rounded-md border border-border/80 bg-bg-sidebar/45"
+      data-chat-activity-timeline
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-label={`${expanded ? "Collapse" : "Expand"} agent activity`}
+        className="flex w-full items-center gap-2 px-2.5 py-2 text-left text-xs text-fg-muted transition hover:bg-bg-sidebar/70 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent/60"
+        data-chat-activity-toggle
+        onClick={() => setExpanded((value) => !value)}
+      >
+        {isRunning ? (
+          <LoaderCircle
+            aria-hidden="true"
+            className="shrink-0 animate-spin text-accent"
+            size={13}
+          />
+        ) : hasError ? (
+          <CircleX
+            aria-hidden="true"
+            className="shrink-0 text-danger"
+            size={13}
+          />
+        ) : hasCancelled ? (
+          <X
+            aria-hidden="true"
+            className="shrink-0 text-fg-muted/75"
+            size={13}
+          />
+        ) : (
+          <Check
+            aria-hidden="true"
+            className="shrink-0 text-fg-muted/75"
+            size={13}
+          />
+        )}
+        <span className="min-w-0 flex-1 truncate">
+          {activitySummary(activities, isRunning)}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
+          size={13}
+        />
+      </button>
+      {expanded ? (
+        <ol
+          className="border-t border-border/70 px-2.5 py-1.5"
+          data-chat-activity-list
+        >
+          {activities.map((activity) => {
+            const Icon = ACTIVITY_ICONS[activity.kind];
+            const detailIsCode =
+              activity.kind === "command" || activity.kind === "file_change";
+            return (
+              <li
+                key={activity.id}
+                className="grid grid-cols-[14px_minmax(0,1fr)_14px] gap-x-2 border-b border-border/45 py-2 last:border-b-0"
+                data-chat-activity-item
+                data-chat-activity-kind={activity.kind}
+                data-chat-activity-status={activity.status}
+              >
+                <Icon
+                  aria-hidden="true"
+                  className="mt-0.5 text-fg-muted"
+                  size={13}
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-xs font-medium leading-4 text-fg/90">
+                    {activity.title}
+                  </div>
+                  {activity.detail ? (
+                    <div
+                      className={`acorn-selectable mt-1 max-h-36 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-4 text-fg-muted ${
+                        detailIsCode ? "font-mono" : ""
+                      }`}
+                      data-chat-activity-detail
+                    >
+                      {activity.detail}
+                    </div>
+                  ) : null}
+                </div>
+                <span className="mt-0.5 flex justify-end">
+                  <ActivityStatusIcon status={activity.status} />
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      ) : null}
+    </section>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -221,6 +221,31 @@ export interface ChatTurn {
   started_at: string;
   completed_at?: string | null;
   error?: string | null;
+  activities?: ChatActivity[];
+}
+
+export type ChatActivityKind =
+  | "reasoning"
+  | "tool"
+  | "command"
+  | "file_change"
+  | "web_search"
+  | "plan";
+
+export type ChatActivityStatus =
+  | "running"
+  | "complete"
+  | "error"
+  | "cancelled";
+
+export interface ChatActivity {
+  id: string;
+  kind: ChatActivityKind;
+  title: string;
+  detail?: string | null;
+  status: ChatActivityStatus;
+  started_at: string;
+  completed_at?: string | null;
 }
 
 export interface ProviderThread {

--- a/tests/e2e/chat-message-actions.spec.ts
+++ b/tests/e2e/chat-message-actions.spec.ts
@@ -29,6 +29,112 @@ const PROJECT = {
 };
 
 test.describe("chat message actions", () => {
+  test("shows normalized live reasoning and tool activity", async ({
+    page,
+    tauri,
+  }) => {
+    const now = "2026-01-01T00:00:00Z";
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      { ...CHAT_SESSION, status: "working" },
+    ]);
+    await tauri.respond("load_chat_session_state", {
+      schema_version: 1,
+      session_id: "chat-actions",
+      session: {
+        id: "chat-actions",
+        workspace_path: "/tmp/demo",
+        title: "Chat actions",
+        active_provider: "antigravity",
+        active_model: null,
+        created_at: now,
+        updated_at: now,
+      },
+      provider: "antigravity",
+      model: null,
+      messages: [
+        {
+          id: "u1",
+          session_id: "chat-actions",
+          turn_id: "t1",
+          role: "user",
+          content: "inspect the project",
+          created_at: now,
+          status: "complete",
+          metadata: { provider: "antigravity" },
+        },
+        {
+          id: "a1",
+          session_id: "chat-actions",
+          turn_id: "t1",
+          role: "assistant",
+          content: "",
+          created_at: "2026-01-01T00:00:01Z",
+          status: "pending",
+          metadata: { provider: "antigravity" },
+        },
+      ],
+      turns: [
+        {
+          id: "t1",
+          session_id: "chat-actions",
+          provider: "antigravity",
+          status: "running",
+          user_message_id: "u1",
+          assistant_message_id: "a1",
+          started_at: now,
+          activities: [
+            {
+              id: "reasoning-1",
+              kind: "reasoning",
+              title: "Reasoning",
+              detail: "Locate the relevant files first.",
+              status: "complete",
+              started_at: "2026-01-01T00:00:01Z",
+              completed_at: "2026-01-01T00:00:02Z",
+            },
+            {
+              id: "tool-1",
+              kind: "command",
+              title: "Search source files",
+              detail: "rg --files src",
+              status: "running",
+              started_at: "2026-01-01T00:00:02Z",
+            },
+          ],
+        },
+      ],
+      provider_threads: [],
+      context_snapshots: [],
+      memory: {
+        session_id: "chat-actions",
+        summary: null,
+        important_decisions: [],
+        facts: [],
+        through_message_id: null,
+        updated_at: now,
+      },
+      created_at: now,
+      updated_at: now,
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("button", { name: "Collapse agent activity" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("Locate the relevant files first."),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator("[data-chat-activity-item]")
+        .filter({ hasText: "Search source files" }),
+    ).toBeVisible();
+    await expect(page.getByText("rg --files src")).toBeVisible();
+    await expect(page.locator("[data-chat-running-label]")).toHaveCount(0);
+  });
+
   test("can stop a running native chat response", async ({ page, tauri }) => {
     await tauri.respond("list_projects", [PROJECT]);
     await tauri.respond("list_sessions", [CHAT_SESSION]);


### PR DESCRIPTION
## Summary
Acorn native chat now surfaces provider-exposed reasoning and execution activity while a response is running, including Antigravity (`agy`).

1. **Normalized activity contract** — add persisted per-turn activity records with stable IDs, typed kinds, lifecycle status, bounded detail, and backward-compatible deserialization.
2. **Provider adapters** — normalize Claude stream events and partial blocks, Codex item/legacy JSON events, and Antigravity planner/tool records into the same activity model.
3. **Live activity timeline** — replace the generic running label when structured activity exists, keep active work expanded, and collapse completed work into an inspectable summary.
4. **Lifecycle coverage** — upsert repeated provider events, finish running entries on success/error/cancellation, and cover parser, persistence, component, and end-to-end behavior.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| In-progress feedback | Generic `Running <provider>` label | Live reasoning, tool, command, file-change, search, and plan activity |
| Provider coverage | Final/streamed assistant text only | Normalized activity for Claude, Codex, and Antigravity |
| Completed turns | Execution steps disappear after completion | Persisted, collapsed timeline remains available for inspection |
| Prompt quality | Assistant/user messages form provider context | Activity stays separate from message content and does not pollute context |

## Design notes
- Provider events update stable activity IDs in place, so start/progress/completion records remain one timeline item and unfinished items inherit the turn's terminal status.
- Claude uses structured stream JSON (including partial messages); Codex supports current item events plus legacy event envelopes.
- `agy` emits text-only stdout, so Acorn follows the validated brain transcript for the active conversation. Discovery and polling are throttled, reads and line sizes are bounded, and persisted details are capped.
- The UI renders only reasoning or summaries explicitly exposed by each provider. It does not synthesize hidden reasoning.
- `activities` defaults to an empty array during deserialization, preserving existing chat session files without a schema migration.

## Follow-up (not in this PR)
- Add richer provider-specific result previews only where stable schemas are available; this PR intentionally keeps the shared contract compact.

## Test plan
- [x] `cargo check -p acorn` passes
- [x] `cargo test -p acorn --lib -- --test-threads=1` — 603 passed, 1 ignored
- [x] `cargo test -p acorn-transcript locates_antigravity_transcript_by_brain_id -- --nocapture` — passes
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — 100 files, 1,144 tests passed
- [x] `pnpm exec vitest run src/components/ChatPane.test.tsx` — 35 passed
- [x] `pnpm exec playwright test tests/e2e/chat-message-actions.spec.ts` — 3 passed
- [x] `pnpm run build:frontend` passes
- [x] Changed Rust files pass `rustfmt --edition 2021 --check`
- [x] `git diff --check` passes

## Notes
- One parallel Rust run exposed existing interference in `agent_wrappers::tests::codex_wrapper_forwards_fallback_observations_without_shell_arbitration` and `agent_wrappers::tests::codex_wrapper_maps_current_tui_user_turn_to_turn_start`. Both pass individually, and the full current suite passes with `--test-threads=1`; the affected wrapper code is unchanged by this PR.
- Workspace-wide `cargo fmt --all -- --check` reports existing formatting drift in `acorn-daemon/src/protocol.rs`, `acorn-ipc/src/bin/acorn-ipc.rs`, and `src/pty_env.rs`. All Rust files changed here pass the formatter check.
