### PR TITLE
fix(history): resume sessions after source worktree removal

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1354,6 +1354,14 @@ function agentHistoryRecoverableSignalLabel(
   });
 }
 
+function isUnavailableHistoryWorktreeError(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("no such file or directory") ||
+    normalized.includes("worktree is not registered")
+  );
+}
+
 function AgentHistoryTab({
   scope,
   repoPath,
@@ -1495,26 +1503,35 @@ function AgentHistoryTab({
         showToast(`${t("toasts.session.createFailed")} ${message}`);
         return;
       }
+      let adoptedWorktree = false;
       if (shouldUseWorktree && item.worktree) {
+        let adoptionError: string | null = null;
         try {
           await adoptSessionWorktree(created.id, item.worktree.path);
-          const error = useAppStore.getState().consumeError();
-          if (error) {
-            setError(error);
-            showToast(`${t("toasts.session.worktreeAdoptFailed")} ${error}`);
+          adoptionError = useAppStore.getState().consumeError();
+        } catch (e) {
+          adoptionError = String(e);
+        }
+        if (adoptionError) {
+          if (
+            mode !== "auto" ||
+            !isUnavailableHistoryWorktreeError(adoptionError)
+          ) {
+            setError(adoptionError);
+            showToast(
+              `${t("toasts.session.worktreeAdoptFailed")} ${adoptionError}`,
+            );
             return;
           }
-        } catch (e) {
-          const message = String(e);
-          setError(message);
-          showToast(`${t("toasts.session.worktreeAdoptFailed")} ${message}`);
-          return;
+          setError(rt(t, "rightPanel.history.worktreeFallback"));
+        } else {
+          adoptedWorktree = true;
         }
       }
       setPendingTerminalInput(created.id, item.resume_command, {
         agentProvider,
       });
-      if (shouldUseWorktree && item.worktree) {
+      if (adoptedWorktree && item.worktree) {
         setWorktreeNotice(item.worktree);
       }
     } catch (e) {
@@ -1581,19 +1598,29 @@ function AgentHistoryTab({
       </div>
       <div className="acorn-no-scrollbar flex-1 overflow-x-hidden overflow-y-auto">
         {error ? (
-          <div className="p-3 text-xs text-danger">{error}</div>
-        ) : !historyItems ? (
           <div
-            role="status"
-            aria-busy="true"
-            aria-label={rt(t, "rightPanel.history.loading")}
+            role="alert"
+            className="border-b border-danger/20 p-3 text-xs text-danger"
           >
-            {Array.from({ length: 8 }).map((_, i) => (
-              <HistorySkeletonRow key={i} index={i} />
-            ))}
+            {error}
           </div>
+        ) : null}
+        {!historyItems ? (
+          error ? null : (
+            <div
+              role="status"
+              aria-busy="true"
+              aria-label={rt(t, "rightPanel.history.loading")}
+            >
+              {Array.from({ length: 8 }).map((_, i) => (
+                <HistorySkeletonRow key={i} index={i} />
+              ))}
+            </div>
+          )
         ) : historyItems.length === 0 ? (
-          <Empty msg={rt(t, "rightPanel.history.empty")} />
+          error ? null : (
+            <Empty msg={rt(t, "rightPanel.history.empty")} />
+          )
         ) : visibleItems.length === 0 ? (
           <Empty msg={rt(t, "rightPanel.history.emptyForFilter")} />
         ) : (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1523,6 +1523,7 @@
       "moveTranscriptToTrash": "Move transcript to Trash...",
       "worktreeMissing": "missing",
       "worktreeUnavailable": "That worktree is no longer available.",
+      "worktreeFallback": "That worktree is no longer available. Resumed from the project root instead.",
       "worktreeRunTitle": "Running in worktree",
       "worktreeRunBody": "The resumed session was started in worktree {name}.",
       "worktreeRunConfirm": "OK",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1523,6 +1523,7 @@
       "moveTranscriptToTrash": "transcript를 휴지통으로 이동...",
       "worktreeMissing": "없음",
       "worktreeUnavailable": "해당 워크트리를 더 이상 사용할 수 없습니다.",
+      "worktreeFallback": "해당 워크트리를 더 이상 사용할 수 없어 프로젝트 루트에서 대신 재개했습니다.",
       "worktreeRunTitle": "워크트리에서 실행 중",
       "worktreeRunBody": "resume 세션이 {name} 워크트리에서 시작되었습니다.",
       "worktreeRunConfirm": "확인",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1998,6 +1998,117 @@ test.describe("right panel: groups", () => {
     ).toBeVisible();
   });
 
+  test("History resume falls back to the project root when its cached worktree disappeared", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __historyFallbackSession?: Record<string, unknown>;
+      };
+      const sessions: Record<string, unknown>[] = [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      if (w.__historyFallbackSession) {
+        sessions.push(w.__historyFallbackSession);
+      }
+      return sessions;
+    });
+    await tauri.handle("list_agent_history", () => [
+      {
+        provider: "codex",
+        id: "codex-stale-worktree",
+        title: "Resume after goal cleanup",
+        preview: null,
+        queued_message_count: 0,
+        subagent_transcript_count: 0,
+        cwd: "/tmp/demo/.acorn/worktrees/removed-goal",
+        worktree: {
+          name: "removed-goal",
+          path: "/tmp/demo/.acorn/worktrees/removed-goal",
+          exists: true,
+        },
+        transcript_path: "/tmp/codex-stale-worktree.jsonl",
+        updated_at: 1770000000,
+        resume_command: "codex resume codex-stale-worktree",
+      },
+    ]);
+    await tauri.handle("create_session", (args) => {
+      const input = args as { name: string; repoPath: string };
+      const created = {
+        id: "created-fallback",
+        name: input.name,
+        repo_path: input.repoPath,
+        worktree_path: input.repoPath,
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+      (
+        window as unknown as {
+          __historyFallbackSession?: Record<string, unknown>;
+        }
+      ).__historyFallbackSession = created;
+      return created;
+    });
+    await tauri.handle("update_session_worktree", () => {
+      throw new Error("io error: No such file or directory (os error 2)");
+    });
+    await tauri.handle("pty_write", (args) => {
+      const w = window as unknown as { __historyFallbackWrites?: string[] };
+      w.__historyFallbackWrites = w.__historyFallbackWrites ?? [];
+      const input = args as { data?: string };
+      const decoded = input.data
+        ? new TextDecoder().decode(
+            Uint8Array.from(atob(input.data), (char) => char.charCodeAt(0)),
+          )
+        : "";
+      w.__historyFallbackWrites.push(decoded);
+      return undefined;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "Agents" }).click();
+    await page.getByRole("button", { name: "History" }).click();
+    const title = page.getByText("Resume after goal cleanup");
+    const historyRow = title.locator(
+      "xpath=ancestor::div[contains(@class, 'rounded-md')][1]",
+    );
+    await dblclickRowRightSide(page, historyRow);
+
+    await expect(title).toBeVisible();
+    await expect(page.getByRole("alert")).toContainText(
+      "Resumed from the project root instead",
+    );
+    await expect(
+      page.getByRole("dialog", { name: "Running in worktree" }),
+    ).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __historyFallbackWrites?: string[] })
+              .__historyFallbackWrites ?? [],
+        ),
+      )
+      .toContain("codex resume codex-stale-worktree\r");
+  });
+
   test("History run in new terminal hosts resumed sessions in the project root", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

History resumes now recover cleanly when their original linked worktree disappears after the History list was cached.

1. **Safe automatic fallback** — continue automatic resume in the already-created project-root terminal when worktree adoption fails because the path disappeared or is no longer registered.
2. **Persistent History visibility** — render action errors as an alert above cached History rows instead of replacing the entire list.
3. **Regression coverage** — reproduce the stale worktree race end to end and verify that the resume command reaches the project-root PTY without showing the worktree-success dialog.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Resume after source worktree cleanup | `io error: No such file or directory` and History rows disappear | Resume continues from the project root with a clear fallback notice |
| Explicit Run in worktree failure | Adoption error stops the action | Unchanged; explicit worktree intent still fails visibly |
| Other adoption failures | Could be mistaken for a missing worktree | Preserve the original error and stop instead of falling back |

## Design notes

- Automatic fallback is limited to missing-path and unregistered-worktree errors. Permission, refresh, and other unexpected failures keep the existing fail-fast behavior.
- Session creation already targets the project root before optional worktree adoption, so the fallback reuses that valid terminal and queues the provider resume command there.
- Fetch and action errors share the existing state, but cached rows remain visible whenever data is available.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run build:frontend` — passes
- [x] `pnpm run test` — 100 files, 1,144 tests pass
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 30 tests pass
- [x] `git diff origin/main..HEAD --check` — passes