### PR TITLE
feat(projects): seed initial commit on new project creation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4832,6 +4832,7 @@ pub fn create_new_project(
     parent_path: String,
     name: String,
     ignore_safe_name: Option<bool>,
+    init_commit: Option<bool>,
 ) -> AppResult<Project> {
     let name = validate_new_project_name(&name, ignore_safe_name.unwrap_or(false))?;
     let parent = PathBuf::from(&parent_path);
@@ -4848,9 +4849,24 @@ pub fn create_new_project(
     }
 
     std::fs::create_dir(&target)?;
-    if let Err(err) = git2::Repository::init(&target) {
-        let _ = std::fs::remove_dir(&target);
-        return Err(AppError::Git(err));
+    let repo = match git2::Repository::init(&target) {
+        Ok(repo) => repo,
+        Err(err) => {
+            let _ = std::fs::remove_dir(&target);
+            return Err(AppError::Git(err));
+        }
+    };
+    // `Repository::init` leaves HEAD unborn (no commit), so `refs/heads/<default>`
+    // does not exist yet and any op that resolves HEAD — worktree creation, the
+    // GitHub menu — fails with "reference 'refs/heads/master' not found". Seeding
+    // an empty initial commit makes a brand-new project immediately usable; the
+    // caller can opt out to keep an unborn HEAD (defaults on).
+    if init_commit.unwrap_or(true) {
+        if let Err(err) = seed_initial_commit(&repo) {
+            drop(repo);
+            let _ = std::fs::remove_dir_all(&target);
+            return Err(AppError::Git(err));
+        }
     }
 
     let project = state
@@ -4858,6 +4874,23 @@ pub fn create_new_project(
         .ensure(target.clone(), project_basename(&target));
     persist(&state);
     Ok(project)
+}
+
+/// Create the empty initial commit that makes a freshly `init`-ed repo usable.
+/// Prefers the user's configured git identity, falling back to a generic Acorn
+/// signature when `user.name`/`user.email` are unset. Committing to the unborn
+/// `HEAD` symref creates whatever default branch git resolved (`main`/`master`).
+fn seed_initial_commit(repo: &git2::Repository) -> Result<(), git2::Error> {
+    let sig = repo
+        .signature()
+        .or_else(|_| git2::Signature::now("Acorn", "acorn@localhost"))?;
+    let tree_id = {
+        let mut index = repo.index()?;
+        index.write_tree()?
+    };
+    let tree = repo.find_tree(tree_id)?;
+    repo.commit(Some("HEAD"), &sig, &sig, "Initial commit", &tree, &[])?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -8909,7 +8942,7 @@ mod tests {
         create_unique_worktree, daemon_spawn_name_for_session, detach_requested_by_stale_renderer,
         font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
         memory_root_pids, poll_defers_to_hook, remove_linked_worktree_at_path,
-        restore_pending_session_removal, should_remove_local_project_mirror,
+        restore_pending_session_removal, seed_initial_commit, should_remove_local_project_mirror,
         validate_editor_command, validate_new_project_name, ChatProviderAdapter,
         ProcessMemorySnapshot,
     };
@@ -11443,6 +11476,21 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[test]
+    fn seeded_repo_supports_worktree_creation() {
+        // Regression: a `Repository::init`-only project has an unborn HEAD, so
+        // worktree creation fails with "reference 'refs/heads/master' not found".
+        // seed_initial_commit must make the repo immediately worktree-capable.
+        let repo_dir = unique_repo_dir("seed-initial-commit");
+        let repo = git2::Repository::init(&repo_dir).expect("init repo");
+        assert!(repo.head().is_err(), "fresh init must have unborn HEAD");
+        seed_initial_commit(&repo).expect("seed initial commit");
+        assert!(repo.head().is_ok(), "seeded repo must resolve HEAD");
+        drop(repo);
+        crate::worktree::create_worktree(&repo_dir, "feature")
+            .expect("worktree creation on seeded repo");
     }
 
     fn init_repo_with_commit(path: &Path) -> git2::Repository {

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -29,6 +29,7 @@ interface NewProjectDialogProps {
     parentPath: string,
     name: string,
     ignoreSafeName: boolean,
+    initCommit: boolean,
   ) => Promise<void>;
 }
 
@@ -42,6 +43,7 @@ export function NewProjectDialog({
   const [parentPath, setParentPath] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [ignoreSafeName, setIgnoreSafeName] = useState(false);
+  const [initCommit, setInitCommit] = useState(true);
   const [pending, setPending] = useState(false);
   const locationPickedRef = useRef(false);
 
@@ -53,6 +55,7 @@ export function NewProjectDialog({
     setParentPath("");
     setError(null);
     setIgnoreSafeName(false);
+    setInitCommit(true);
     setPending(false);
     void api
       .getLastProjectParentFolder()
@@ -116,7 +119,7 @@ export function NewProjectDialog({
     setPending(true);
     setError(null);
     try {
-      await onCreate(parentPath, trimmedName, ignoreSafeName);
+      await onCreate(parentPath, trimmedName, ignoreSafeName, initCommit);
       onClose();
     } catch (err) {
       setError(errorMessage(err));
@@ -210,6 +213,15 @@ export function NewProjectDialog({
               </Button>
             </div>
           </Field>
+          <label className="flex items-center gap-2 text-xs text-fg-muted">
+            <input
+              type="checkbox"
+              checked={initCommit}
+              onChange={(e) => setInitCommit(e.target.checked)}
+              className="acorn-check"
+            />
+            <span>{dt(t, "dialogs.newProject.initCommit")}</span>
+          </label>
           {finalPath ? (
             <div className="space-y-1 text-xs">
               <div className="text-fg-muted">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1352,9 +1352,9 @@ export function Sidebar() {
       <NewProjectDialog
         open={newProjectOpen}
         onClose={() => setNewProjectOpen(false)}
-        onCreate={async (parentPath, name, ignoreSafeName) => {
+        onCreate={async (parentPath, name, ignoreSafeName, initCommit) => {
           try {
-            await createNewProject(parentPath, name, ignoreSafeName);
+            await createNewProject(parentPath, name, ignoreSafeName, initCommit);
           } catch (e) {
             showToast(`${t("toasts.project.createFailed")} ${String(e)}`);
             throw e;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -292,11 +292,13 @@ export const api = {
     parentPath: string,
     name: string,
     ignoreSafeName = false,
+    initCommit = true,
   ): Promise<Project> {
     return invoke<Project>("create_new_project", {
       parentPath,
       name,
       ignoreSafeName,
+      initCommit,
     });
   },
   removeProject(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1845,6 +1845,7 @@
       "projectNameLabel": "Project name",
       "projectNameHint": "Use a single folder name.",
       "ignoreSafeName": "Ignore safe-name check",
+      "initCommit": "Create an initial commit (needed for worktrees and GitHub)",
       "locationLabel": "Location",
       "locationPlaceholder": "Choose a parent folder",
       "locationAriaLabel": "Project location",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1845,6 +1845,7 @@
       "projectNameLabel": "프로젝트 이름",
       "projectNameHint": "단일 폴더 이름을 사용하세요.",
       "ignoreSafeName": "안전한 이름 검사 무시",
+      "initCommit": "초기 커밋 생성 (worktree·GitHub 사용에 필요)",
       "locationLabel": "위치",
       "locationPlaceholder": "상위 폴더 선택",
       "locationAriaLabel": "프로젝트 위치",

--- a/src/store.ts
+++ b/src/store.ts
@@ -533,6 +533,7 @@ interface AppStateModel {
     parentPath: string,
     name: string,
     ignoreSafeName?: boolean,
+    initCommit?: boolean,
   ) => Promise<Project>;
   removeProject: (
     repoPath: string,
@@ -3263,12 +3264,13 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
-  async createNewProject(parentPath, name, ignoreSafeName = false) {
+  async createNewProject(parentPath, name, ignoreSafeName = false, initCommit = true) {
     try {
       const project = await api.createNewProject(
         parentPath,
         name,
         ignoreSafeName,
+        initCommit,
       );
       await get().refreshProjects();
       get().setActiveProject(project.repo_path);


### PR DESCRIPTION
## Problem

Creating a new project inside Acorn ran `git init` but never made a commit, leaving the repository with an **unborn HEAD**. Any operation that resolves `HEAD` — opening the GitHub menu, creating a worktree — then failed with `git error: reference 'refs/heads/master' not found; class=Reference (4)`.

## Fix

Seed an empty initial commit right after `Repository::init`, so a brand-new project resolves its default branch (`main`/`master`, whatever git's `init.defaultBranch` yields) and is immediately worktree/GitHub-ready. The commit prefers the user's configured git identity and falls back to a generic `Acorn <acorn@localhost>` signature when `user.name`/`user.email` are unset.

## Option

The New Project dialog gains an **"initial commit"** checkbox, on by default. Users who prefer to keep an unborn HEAD (e.g. to author the first commit themselves) can uncheck it; the backend `create_new_project` command takes an `init_commit` flag (defaults on) and skips the seed when it is off.

## Tests

- New Rust regression `seeded_repo_supports_worktree_creation` — asserts a fresh `init` has an unborn HEAD, that seeding makes `HEAD` resolvable, and that worktree creation then succeeds (the exact op that used to throw).
- `tsc --noEmit` clean; existing `store.test.ts` suite (164 tests) green.

https://claude.ai/code/session_01HyE6CWvugswu43vq4wY218
