### PR TITLE
fix(history): hide Codex image envelope markers from history

### DIFF
--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -164,23 +164,34 @@ fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
     let event = codex_event_value(value);
     let event_role = codex_role_from_event(value, event);
     let texts = codex_event_texts(value, event);
-    let response_text = codex_response_text(value, event);
-    let state_text = match event_role {
-        TranscriptRole::User => joined_text(&texts),
-        TranscriptRole::Assistant => first_text(&texts),
-        TranscriptRole::Other => None,
-    };
-    let text = match event_role {
-        TranscriptRole::User => joined_text(&texts),
-        TranscriptRole::Assistant => first_text(&texts).or_else(|| response_text.clone()),
-        TranscriptRole::Other => None,
-    };
-    let display_role = if event_role == TranscriptRole::User && text.is_none() {
+    let hides_image_envelope =
+        event_role == TranscriptRole::User && codex_user_content_has_image_attachment(&texts);
+    let content_role = if hides_image_envelope {
         TranscriptRole::Other
     } else {
         event_role
     };
-    let (preview_role, preview_text) = codex_preview_role_and_text(value, event, event_role);
+    let response_text = codex_response_text(value, event);
+    let state_text = match content_role {
+        TranscriptRole::User => joined_text(&texts),
+        TranscriptRole::Assistant => first_text(&texts),
+        TranscriptRole::Other => None,
+    };
+    let text = match content_role {
+        TranscriptRole::User => joined_text(&texts),
+        TranscriptRole::Assistant => first_text(&texts).or_else(|| response_text.clone()),
+        TranscriptRole::Other => None,
+    };
+    let display_role = if content_role == TranscriptRole::User && text.is_none() {
+        TranscriptRole::Other
+    } else {
+        content_role
+    };
+    let (preview_role, preview_text) = if hides_image_envelope {
+        (TranscriptRole::Other, None)
+    } else {
+        codex_preview_role_and_text(value, event, event_role)
+    };
 
     ParsedTranscriptLine {
         timestamp: string_at(Some(value), "timestamp")
@@ -678,9 +689,18 @@ fn looks_like_hidden_message_block(text: &str) -> bool {
         "<user_shell_command>",
         "<user_action>",
         "<image name=",
+        "</image>",
     ]
     .iter()
     .any(|tag| lower.starts_with(tag))
+}
+
+fn codex_user_content_has_image_attachment(texts: &[String]) -> bool {
+    texts.iter().any(|text| {
+        text.trim_start()
+            .to_ascii_lowercase()
+            .starts_with("<image name=")
+    })
 }
 
 fn looks_like_skill_context_block(text: &str) -> bool {
@@ -911,6 +931,7 @@ mod tests {
             "<recommended_plugins>\nInternal recommendations.\n</recommended_plugins>",
             "<user_shell_command>\npnpm test\n</user_shell_command>",
             "<user_action>\nInternal action metadata.\n</user_action>",
+            "</image>",
             "<image name=[Image #1] path=\"/tmp/clipboard.png\">\n</image>\nShip the release",
         ];
 
@@ -943,8 +964,45 @@ mod tests {
     }
 
     #[test]
+    fn codex_split_image_envelope_is_not_user_content() {
+        let value = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "<image name=[Image #1] path=\"/tmp/clipboard.png\">",
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64,abc",
+                    },
+                    {
+                        "type": "input_text",
+                        "text": "</image>",
+                    },
+                    {
+                        "type": "input_text",
+                        "text": "[Image #1] Remove the </image> marker from History",
+                    },
+                ],
+            },
+        });
+        let parsed = parse_transcript_value(AgentKind::Codex, &value);
+
+        assert_eq!(parsed.role, TranscriptRole::Other);
+        assert_eq!(parsed.text, None);
+        assert_eq!(parsed.state_role, TranscriptRole::Other);
+        assert_eq!(parsed.state_text, None);
+        assert_eq!(parsed.preview_role, TranscriptRole::Other);
+        assert_eq!(parsed.preview_text, None);
+    }
+
+    #[test]
     fn codex_keeps_inline_hidden_tag_mentions_as_user_content() {
-        let message = "Why does <codex_internal_context> appear in History?";
+        let message = "Why do <codex_internal_context> and </image> appear in History?";
         let value = serde_json::json!({
             "type": "response_item",
             "payload": {

--- a/src-tauri/src/agent_history.rs
+++ b/src-tauri/src/agent_history.rs
@@ -2728,17 +2728,31 @@ mod tests {
                 "payload": {
                     "type": "message",
                     "role": "user",
-                    "content": [{
-                        "type": "input_text",
-                        "text": "<image name=[Image #1] path=\"/tmp/clipboard.png\">\n</image>\nShip the release",
-                    }],
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": "<image name=[Image #1] path=\"/tmp/clipboard.png\">",
+                        },
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,abc",
+                        },
+                        {
+                            "type": "input_text",
+                            "text": "</image>",
+                        },
+                        {
+                            "type": "input_text",
+                            "text": "[Image #1] Ship the release despite the </image> marker",
+                        },
+                    ],
                 },
             }),
             serde_json::json!({
                 "type": "event_msg",
                 "payload": {
                     "type": "user_message",
-                    "message": "Ship the release",
+                    "message": "[Image #1] Ship the release despite the </image> marker",
                 },
             }),
             serde_json::json!({
@@ -2756,7 +2770,10 @@ mod tests {
 
         let scope_repo = normalize_path(&repo);
         let item = parse_codex_file(&transcript, HistoryScope::Project(&scope_repo)).unwrap();
-        assert_eq!(item.title, "Ship the release");
+        assert_eq!(
+            item.title,
+            "[Image #1] Ship the release despite the </image> marker"
+        );
         assert_eq!(item.preview.as_deref(), Some("The release is published."));
 
         let summary =
@@ -2773,7 +2790,10 @@ mod tests {
                 .map(|message| (message.role.as_str(), message.text.as_str()))
                 .collect::<Vec<_>>(),
             vec![
-                ("user", "Ship the release"),
+                (
+                    "user",
+                    "[Image #1] Ship the release despite the </image> marker"
+                ),
                 ("assistant", "The release is published."),
             ]
         );


### PR DESCRIPTION
## Summary

Codex image attachment metadata no longer leaks into user-facing agent history titles and transcript-derived previews.

1. **Central transcript filtering** — classify structured Codex image `response_item` envelopes as metadata so the normalized `event_msg` supplies the user text.
2. **Closing-marker handling** — recognize standalone `</image>` control parts while preserving the same text when it appears inline in a genuine user message.
3. **Regression coverage** — model the current split content format (`<image>`, image payload, `</image>`, prompt) in both parser and History-level tests.

## Expected impact

| Surface | Before | After |
| --- | --- | --- |
| Agents → History title | Can start with a synthetic `</image>` marker | Starts with the normalized user request |
| Resume preview / generated title context | Can consume attachment envelope text | Uses the same cleaned transcript event as History |
| Literal inline `</image>` in user text | At risk from broad string stripping | Preserved when it is genuine message content |

## Design notes

- Filtering lives in `acorn-transcript`, the shared parser used by History, resume previews, transcript summaries, and automatic title context.
- Codex records an image turn twice: a structured `response_item` containing the attachment envelope and a normalized `event_msg` containing the user request. The structured image record is treated as metadata, preserving existing message counts and avoiding duplicated summary entries.
- The UI does not add a second sanitization path; all consumers receive the same parsed contract.

## Test plan

- [x] `rustfmt --edition 2021 --check src-tauri/crates/acorn-transcript/src/line.rs src-tauri/src/agent_history.rs`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript --lib` — 92 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib agent_history::tests::codex_` — 13 passed
- [x] Rebased onto current `origin/main` and reran the parser suite plus the focused History regression test
- [x] Required GitHub check `Frontend` passed

## Notes

- Optional `E2E (shard 2/2)` currently fails two project-lifecycle assertions because merged PR #703 added `initCommit: true` without updating those expectations. The same shard failed on PR #703 and its main-branch merge run; this is a pre-existing base regression and is not caused by this PR.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn-transcript --all-targets -- -D warnings` remains blocked by existing warnings outside this change (documentation indentation, manual flattening, argument count, and test-style lints). These warnings are present on `main` and are not caused by this PR.
