### PR TITLE
feat(chat): soften tool activity into a conversational timeline

### DIFF
--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -2415,6 +2415,9 @@ describe("ChatPane", () => {
 
     expect(container.querySelector("[data-chat-activity-timeline]")).toBeTruthy();
     expect(container.querySelector("[data-chat-activity-list]")).toBeTruthy();
+    expect(
+      container.querySelector("[data-chat-activity-summary]")?.textContent,
+    ).toBe("Working · Inspect repository");
     expect(container.textContent).toContain("Inspect repository");
     expect(container.textContent).toContain("rg --files");
     expect(container.querySelector("[data-chat-running-label]")).toBeNull();
@@ -2489,7 +2492,7 @@ describe("ChatPane", () => {
     );
     expect(toggle?.getAttribute("aria-expanded")).toBe("false");
     expect(container.querySelector("[data-chat-activity-list]")).toBeNull();
-    expect(container.textContent).toContain("2 activities");
+    expect(container.textContent).toContain("Worked through 2 steps");
     expect(container.textContent).toContain("Done.");
 
     await act(async () => {

--- a/src/components/chat/ChatActivityTimeline.tsx
+++ b/src/components/chat/ChatActivityTimeline.tsx
@@ -5,7 +5,6 @@ import {
   CircleX,
   FilePenLine,
   ListChecks,
-  LoaderCircle,
   Search,
   Terminal,
   Wrench,
@@ -33,38 +32,67 @@ const ACTIVITY_ICONS: Record<ChatActivityKind, LucideIcon> = {
   plan: ListChecks,
 };
 
-function ActivityStatusIcon({ status }: { status: ChatActivityStatus }) {
+function ActivityStatusMark({ status }: { status: ChatActivityStatus }) {
   if (status === "running") {
     return (
-      <LoaderCircle
+      <span
         aria-label="Running"
-        className="animate-spin text-accent"
-        size={12}
-      />
+        className="relative flex size-4 items-center justify-center rounded-full bg-bg-elevated ring-1 ring-accent/30"
+        role="img"
+      >
+        <span
+          aria-hidden="true"
+          className="absolute size-2 rounded-full bg-accent/25 motion-safe:animate-ping"
+        />
+        <span
+          aria-hidden="true"
+          className="relative size-1.5 rounded-full bg-accent"
+        />
+      </span>
     );
   }
   if (status === "error") {
-    return <CircleX aria-label="Failed" className="text-danger" size={12} />;
+    return (
+      <span className="flex size-4 items-center justify-center rounded-full bg-bg-elevated ring-1 ring-danger/25">
+        <CircleX aria-label="Failed" className="text-danger" size={10} />
+      </span>
+    );
   }
   if (status === "cancelled") {
-    return <X aria-label="Cancelled" className="text-fg-muted" size={12} />;
+    return (
+      <span className="flex size-4 items-center justify-center rounded-full bg-bg-elevated ring-1 ring-border/75">
+        <X aria-label="Cancelled" className="text-fg-muted" size={10} />
+      </span>
+    );
   }
-  return <Check aria-label="Complete" className="text-success" size={12} />;
+  return (
+    <span className="flex size-4 items-center justify-center rounded-full bg-bg-elevated ring-1 ring-border/75">
+      <Check aria-label="Complete" className="text-success/85" size={10} />
+    </span>
+  );
 }
 
 function activitySummary(activities: ChatActivity[], isRunning: boolean) {
   const active = [...activities]
     .reverse()
     .find((activity) => activity.status === "running");
-  if (isRunning && active) return active.title;
+  if (isRunning && active) return `Working · ${active.title}`;
+  const stepCount = `${activities.length} ${
+    activities.length === 1 ? "step" : "steps"
+  }`;
+  if (isRunning) return `Working through ${stepCount}`;
   const failed = activities.filter(
     (activity) => activity.status === "error",
   ).length;
-  const count = `${activities.length} ${
-    activities.length === 1 ? "activity" : "activities"
-  }`;
-  if (failed > 0) return `${count} · ${failed} failed`;
-  return count;
+  if (failed > 0) {
+    return `${stepCount} · ${failed} ${
+      failed === 1 ? "needs" : "need"
+    } attention`;
+  }
+  if (activities.some((activity) => activity.status === "cancelled")) {
+    return `${stepCount} · paused`;
+  }
+  return `Worked through ${stepCount}`;
 }
 
 export function ChatActivityTimeline({
@@ -91,24 +119,23 @@ export function ChatActivityTimeline({
   );
 
   return (
-    <section
-      className="min-w-[16rem] overflow-hidden rounded-md border border-border/80 bg-bg-sidebar/45"
-      data-chat-activity-timeline
-    >
+    <section className="min-w-0" data-chat-activity-timeline>
       <button
         type="button"
         aria-expanded={expanded}
         aria-label={`${expanded ? "Collapse" : "Expand"} agent activity`}
-        className="flex w-full items-center gap-2 px-2.5 py-2 text-left text-xs text-fg-muted transition hover:bg-bg-sidebar/70 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent/60"
+        className="group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11px] leading-4 text-fg-muted transition-[background-color,color,transform] hover:bg-fill hover:text-fg active:translate-y-px focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent/55"
         data-chat-activity-toggle
         onClick={() => setExpanded((value) => !value)}
       >
         {isRunning ? (
-          <LoaderCircle
+          <span
             aria-hidden="true"
-            className="shrink-0 animate-spin text-accent"
-            size={13}
-          />
+            className="relative flex size-4 shrink-0 items-center justify-center"
+          >
+            <span className="absolute size-2.5 rounded-full bg-accent/20 motion-safe:animate-ping" />
+            <span className="relative size-1.5 rounded-full bg-accent" />
+          </span>
         ) : hasError ? (
           <CircleX
             aria-hidden="true"
@@ -128,18 +155,22 @@ export function ChatActivityTimeline({
             size={13}
           />
         )}
-        <span className="min-w-0 flex-1 truncate">
+        <span
+          aria-live="polite"
+          className="min-w-0 flex-1 truncate"
+          data-chat-activity-summary
+        >
           {activitySummary(activities, isRunning)}
         </span>
         <ChevronDown
           aria-hidden="true"
-          className={`shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
-          size={13}
+          className={`shrink-0 text-fg-muted/70 transition-transform duration-200 group-hover:text-fg ${expanded ? "rotate-180" : ""}`}
+          size={12}
         />
       </button>
       {expanded ? (
         <ol
-          className="border-t border-border/70 px-2.5 py-1.5"
+          className="relative ml-4 mt-1 space-y-0.5 border-l border-border/55 pb-1 pl-3"
           data-chat-activity-list
         >
           {activities.map((activity) => {
@@ -149,24 +180,35 @@ export function ChatActivityTimeline({
             return (
               <li
                 key={activity.id}
-                className="grid grid-cols-[14px_minmax(0,1fr)_14px] gap-x-2 border-b border-border/45 py-2 last:border-b-0"
+                className={`relative rounded-lg px-2 py-1.5 transition-colors ${
+                  activity.status === "running"
+                    ? "bg-accent/[0.06]"
+                    : "hover:bg-fill/70"
+                }`}
                 data-chat-activity-item
                 data-chat-activity-kind={activity.kind}
                 data-chat-activity-status={activity.status}
               >
-                <Icon
-                  aria-hidden="true"
-                  className="mt-0.5 text-fg-muted"
-                  size={13}
-                />
+                <span className="absolute -left-[1.31rem] top-1.5">
+                  <ActivityStatusMark status={activity.status} />
+                </span>
                 <div className="min-w-0">
-                  <div className="truncate text-xs font-medium leading-4 text-fg/90">
-                    {activity.title}
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <Icon
+                      aria-hidden="true"
+                      className="shrink-0 text-fg-muted/70"
+                      size={12}
+                    />
+                    <span className="truncate text-[11px] font-medium leading-4 text-fg/90">
+                      {activity.title}
+                    </span>
                   </div>
                   {activity.detail ? (
                     <div
-                      className={`acorn-selectable mt-1 max-h-36 overflow-auto whitespace-pre-wrap break-words text-[11px] leading-4 text-fg-muted ${
-                        detailIsCode ? "font-mono" : ""
+                      className={`acorn-selectable max-h-36 overflow-auto whitespace-pre-wrap break-words text-[10.5px] leading-4 text-fg-muted/90 ${
+                        detailIsCode
+                          ? "mt-1 rounded-md bg-fill px-2 py-1 font-mono"
+                          : "mt-0.5 pl-[18px]"
                       }`}
                       data-chat-activity-detail
                     >
@@ -174,9 +216,6 @@ export function ChatActivityTimeline({
                     </div>
                   ) : null}
                 </div>
-                <span className="mt-0.5 flex justify-end">
-                  <ActivityStatusIcon status={activity.status} />
-                </span>
               </li>
             );
           })}

--- a/tests/e2e/chat-message-actions.spec.ts
+++ b/tests/e2e/chat-message-actions.spec.ts
@@ -123,6 +123,9 @@ test.describe("chat message actions", () => {
     await expect(
       page.getByRole("button", { name: "Collapse agent activity" }),
     ).toBeVisible();
+    await expect(page.locator("[data-chat-activity-summary]")).toHaveText(
+      "Working · Search source files",
+    );
     await expect(
       page.getByText("Locate the relevant files first."),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Refines live agent activity so reasoning and tool progress feels native to the chat bubble instead of reading like a nested log panel.

1. **Conversational activity trace** — replaces the bordered card and row dividers with a compact summary and a soft vertical timeline that emphasizes only the active step.
2. **Calmer status language and motion** — adds friendly running, completed, paused, and attention summaries, an accessible live region, and a reduced-motion-safe pulse for active work.
3. **UI regression coverage** — verifies live and completed summary copy while preserving automatic expansion, completion collapse, and manual inspection behavior.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Chat visual hierarchy | Bordered activity panel nested inside the assistant bubble | Lightweight trace integrated with the surrounding conversation |
| Active work | Repeating spinner and table-like status column | Single pulsing marker and softly highlighted active step |
| Completed work | System-oriented activity count | Conversational step summary that stays collapsed by default |
| Accessibility | Expand/collapse semantics only | Polite live summary plus explicit running-status semantics |

## Design notes

- The `ChatActivity` data contract and `ChatPane` integration stay unchanged; this PR is limited to presentation and status copy.
- Running activity still expands automatically and collapses when the turn completes. The existing toggle remains keyboard and screen-reader accessible.
- Command and file details retain compact monospaced treatment, while reasoning details remain plain text to preserve conversational rhythm.
- All colors use existing Acorn theme tokens, and pulse animation is disabled when reduced motion is requested.

## Test plan

- [x] `pnpm run test` — 100 files, 1,144 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — production frontend build passed
- [x] `pnpm run test:e2e` — 266 tests passed
- [x] `pnpm exec vitest run src/components/ChatPane.test.tsx` — 35 tests passed after rebasing onto `origin/main`
- [x] `pnpm exec playwright test tests/e2e/chat-message-actions.spec.ts` — 3 tests passed after rebasing onto `origin/main`
- [x] Mocked Tauri chat-session screenshots reviewed in dark theme at full-app and focused-chat scales

## Notes

- Existing Vite chunk-size/dynamic-import warnings and known dialog accessibility console warnings still appear in the full suites; they are not caused by this PR and do not fail the tests.
