### PR TITLE
fix(agent-status): derive Working from agent lifecycle signals

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -141,6 +141,9 @@ trash = { workspace = true }
 # markers; tests also use it for scratch directories.
 tempfile = { workspace = true }
 
+[dev-dependencies]
+tauri = { workspace = true, features = ["test"] }
+
 [target.'cfg(unix)'.dependencies]
 # `setsid()` and `getpid()` wrappers for detaching the daemon from the
 # spawning Acorn app's process group. Feature-flagged to only what we use

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -566,31 +566,6 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
-    /// Refresh status only when both the stored state and hook generation
-    /// still match the caller's observation. Hook handlers advance the
-    /// generation before waiting on the session row, so a concurrent event
-    /// either rejects this write or overwrites it afterward.
-    pub fn refresh_status_if_hook_revision(
-        &self,
-        id: &Uuid,
-        expected_status: SessionStatus,
-        expected_hook_revision: u64,
-        status: SessionStatus,
-    ) -> SessionResult<bool> {
-        let mut runtime = self.lock_hook_runtime();
-        let mut entry = self
-            .inner
-            .get_mut(id)
-            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
-        let state = runtime.entry(*id).or_default();
-        if entry.status != expected_status || state.revision != expected_hook_revision {
-            return Ok(false);
-        }
-        entry.status = status;
-        state.advance_lifecycle_revision();
-        Ok(true)
-    }
-
     /// Refresh status and lifecycle authority only if the complete state
     /// observed by a poll is still current. Comparing both source and hook
     /// generation rejects stale polls after a fallback transition, because
@@ -1304,62 +1279,6 @@ mod tests {
         store.mark_codex_permission_waiting_at(&session.id, requested_at);
         store.remove(&session.id).expect("session exists");
         assert_eq!(store.codex_permission_waiting_at(&session.id), None);
-    }
-
-    #[test]
-    fn hook_revision_guards_conditional_status_refresh() {
-        let store = SessionStore::new();
-        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
-        store
-            .refresh_status(&session.id, SessionStatus::WaitingForInput)
-            .expect("session exists");
-
-        let waiting_revision = store.hook_revision(&session.id);
-        assert!(store
-            .refresh_status_if_hook_revision(
-                &session.id,
-                SessionStatus::WaitingForInput,
-                waiting_revision,
-                SessionStatus::Working,
-            )
-            .expect("session exists"));
-        store
-            .refresh_status(&session.id, SessionStatus::WaitingForInput)
-            .expect("session exists");
-        store.mark_hook_active(&session.id, SessionAgentProvider::Codex);
-
-        assert!(!store
-            .refresh_status_if_hook_revision(
-                &session.id,
-                SessionStatus::WaitingForInput,
-                waiting_revision,
-                SessionStatus::Working,
-            )
-            .expect("session exists"));
-        assert_eq!(
-            store.get(&session.id).expect("session exists").status,
-            SessionStatus::WaitingForInput
-        );
-    }
-
-    #[test]
-    fn conditional_status_refresh_requires_the_expected_status() {
-        let store = SessionStore::new();
-        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
-        let revision = store.hook_revision(&session.id);
-
-        assert!(!store
-            .refresh_status_if_hook_revision(
-                &session.id,
-                SessionStatus::WaitingForInput,
-                revision,
-                SessionStatus::Working,
-            )
-            .expect("session exists"));
-        assert_eq!(
-            store.get(&session.id).expect("session exists").status,
-            SessionStatus::Ready
-        );
     }
 
     #[test]

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -223,6 +223,12 @@ impl AgentHookReducer {
                     reason: "missing lifecycle id after lifecycle attachment",
                 });
             }
+            if signal == CodexSignal::NativeToolResult {
+                return Ok(AgentHookApplyOutcome::Ignored {
+                    status: current_status,
+                    reason: "tool result is missing lifecycle correlation",
+                });
+            }
             let effects = unsequenced_codex_effects(signal, &event);
             let status = apply_validated_agent_hook_event(&self.sessions, event, effects)?;
             return Ok(AgentHookApplyOutcome::Applied(status));
@@ -268,6 +274,7 @@ fn unsequenced_codex_effects(signal: CodexSignal, event: &AgentHookEvent) -> Cod
             clear_permission_waiting: true,
             ..Default::default()
         },
+        CodexSignal::NativeToolResult => CodexStoreEffects::default(),
         CodexSignal::NativePermission | CodexSignal::JsonlApproval => CodexStoreEffects {
             mark_permission_waiting: true,
             ..Default::default()
@@ -354,6 +361,7 @@ enum CodexSignal {
     NativeStop,
     NativePermission,
     NativeToolStart,
+    NativeToolResult,
     JsonlUser,
     JsonlTask,
     JsonlTool,
@@ -374,6 +382,9 @@ impl CodexSignal {
             }
             "native_tool_start" if event.event == AgentHookEventKind::Start => {
                 Self::NativeToolStart
+            }
+            "native_tool_result" if event.event == AgentHookEventKind::Start => {
+                Self::NativeToolResult
             }
             "jsonl_user" if event.event == AgentHookEventKind::Start => Self::JsonlUser,
             "jsonl_task" if event.event == AgentHookEventKind::Start => Self::JsonlTask,
@@ -665,6 +676,13 @@ impl CodexInvocation {
             CodexSignal::NativeToolStart => {
                 self.resume_from_tool(provider_turn_id, false, provider_tool_id)
             }
+            CodexSignal::NativeToolResult => {
+                if !self.matches_pending_permission(provider_turn_id, provider_tool_id) {
+                    CodexReduction::Ignore("tool result does not match the pending request")
+                } else {
+                    self.resume_from_tool_result(provider_tool_id)
+                }
+            }
             CodexSignal::JsonlTool => {
                 if self.has_native_tool_id(provider_turn_id, provider_tool_id)
                     && !self.duplicate_native_tool_resumes_permission(
@@ -879,6 +897,36 @@ impl CodexInvocation {
                 .then(|| provider_turn_id.map(str::to_string))
                 .flatten(),
             mark_tool_started: true,
+            clear_permission_waiting: true,
+            ..Default::default()
+        })
+    }
+
+    fn matches_pending_permission(
+        &self,
+        provider_turn_id: Option<&str>,
+        provider_tool_id: Option<&str>,
+    ) -> bool {
+        let Some(provider_tool_id) = provider_tool_id else {
+            return false;
+        };
+        self.turn.as_ref().is_some_and(|turn| {
+            turn.phase == CodexTurnPhase::AwaitingPermission
+                && !provider_ids_conflict(turn.provider_turn_id.as_deref(), provider_turn_id)
+                && turn.pending_permission_tool_id.as_deref() == Some(provider_tool_id)
+        })
+    }
+
+    fn resume_from_tool_result(&mut self, provider_tool_id: Option<&str>) -> CodexReduction {
+        let turn = self
+            .turn
+            .as_mut()
+            .expect("matching pending permission requires an active turn");
+        turn.phase = CodexTurnPhase::Working;
+        turn.pending_permission_tool_id = None;
+        mark_permission_receipts_resumed(&mut turn.native_permission_receipts, provider_tool_id);
+        mark_permission_receipts_resumed(&mut turn.fallback_permission_receipts, provider_tool_id);
+        CodexReduction::Apply(CodexStoreEffects {
             clear_permission_waiting: true,
             ..Default::default()
         })
@@ -1293,7 +1341,7 @@ pub fn apply_agent_hook_event(
     }
 
     // The TUI recorder is an asynchronous compatibility preview and can lag
-    // behind native UserPromptSubmit or Stop. PTY writes and native hooks own
+    // behind native UserPromptSubmit or Stop. Provider lifecycle signals own
     // the real transition, so a delayed preview must never overwrite them.
     if event.provider == SessionAgentProvider::Codex && event.source.as_deref() == Some("preview") {
         return Ok(session.status);
@@ -2120,6 +2168,7 @@ fn parse_raw_codex_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentH
             "native" => None,
             "native_prompt" => Some("UserPromptSubmit"),
             "native_tool_start" => Some("PreToolUse"),
+            "native_tool_result" => Some("PostToolUse"),
             "native_permission" => Some("PermissionRequest"),
             "native_stop" => Some("Stop"),
             _ => return Err(format!("unsupported Codex hook source: {raw_source}")),
@@ -2143,6 +2192,7 @@ fn parse_raw_codex_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentH
                 (AgentHookEventKind::NeedsInput, "native_permission")
             }
             "PreToolUse" => (AgentHookEventKind::Start, "native_tool_start"),
+            "PostToolUse" => (AgentHookEventKind::Start, "native_tool_result"),
             "PermissionRequest" => (AgentHookEventKind::NeedsInput, "native_permission"),
             "Stop" => (AgentHookEventKind::NeedsInput, "native_stop"),
             other => return Err(format!("unsupported Codex hook event: {other}")),
@@ -4686,6 +4736,79 @@ mod tests {
     }
 
     #[test]
+    fn reducer_matching_tool_result_resumes_request_user_input() {
+        let (sessions, session_id, reducer) = codex_reducer_fixture();
+        apply_codex(&reducer, session_id, "native_prompt", Some("turn-1"));
+
+        let mut request = codex_event(session_id, "native_permission", Some("turn-1"));
+        request.provider_tool_id = Some("input-1".to_string());
+        reducer.apply(request).expect("input request waits");
+
+        let mut answer = codex_event(session_id, "native_tool_result", Some("turn-1"));
+        answer.provider_tool_id = Some("input-1".to_string());
+        assert!(matches!(
+            reducer.apply(answer).expect("matching result applies"),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::Working
+        );
+        assert_eq!(sessions.codex_permission_waiting_at(&session_id), None);
+    }
+
+    #[test]
+    fn reducer_stale_tool_result_cannot_clear_a_newer_request() {
+        let (sessions, session_id, reducer) = codex_reducer_fixture();
+        apply_codex(&reducer, session_id, "native_prompt", Some("turn-1"));
+
+        let mut request = codex_event(session_id, "native_permission", Some("turn-1"));
+        request.provider_tool_id = Some("input-new".to_string());
+        reducer.apply(request).expect("input request waits");
+
+        let mut stale_answer = codex_event(session_id, "native_tool_result", Some("turn-1"));
+        stale_answer.provider_tool_id = Some("input-old".to_string());
+        assert!(matches!(
+            reducer
+                .apply(stale_answer)
+                .expect("stale result is classified"),
+            AgentHookApplyOutcome::Ignored { .. }
+        ));
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
+        assert!(sessions.codex_permission_waiting_at(&session_id).is_some());
+    }
+
+    #[test]
+    fn reducer_tool_result_does_not_claim_the_next_anonymous_permission() {
+        let (sessions, session_id, reducer) = codex_reducer_fixture();
+        apply_codex(&reducer, session_id, "native_prompt", Some("turn-1"));
+
+        let mut request = codex_event(session_id, "native_permission", Some("turn-1"));
+        request.provider_tool_id = Some("input-1".to_string());
+        reducer.apply(request).expect("input request waits");
+        let mut result = codex_event(session_id, "native_tool_result", Some("turn-1"));
+        result.provider_tool_id = Some("input-1".to_string());
+        reducer.apply(result).expect("input result resumes");
+
+        apply_codex(&reducer, session_id, "native_permission", Some("turn-1"));
+        let mut delayed_result = codex_event(session_id, "native_tool_result", Some("turn-1"));
+        delayed_result.provider_tool_id = Some("input-1".to_string());
+        assert!(matches!(
+            reducer
+                .apply(delayed_result)
+                .expect("delayed result is classified"),
+            AgentHookApplyOutcome::Ignored { .. }
+        ));
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
+    }
+
+    #[test]
     fn reducer_matching_jsonl_tool_resumes_when_fallback_permission_arrives_first() {
         let (sessions, session_id, reducer) = codex_reducer_fixture();
         apply_codex(&reducer, session_id, "native_prompt", Some("turn-1"));
@@ -5024,6 +5147,31 @@ mod tests {
             assert_eq!(event.event, expected_kind);
             assert!(event.provider_turn_id.is_some());
         }
+    }
+
+    #[test]
+    fn raw_post_tool_use_preserves_correlation_ids() {
+        let (tx, rx) = mpsc::channel();
+        let hooks = AgentHookServer::start_with_handler(move |event| {
+            tx.send(event).expect("send event");
+        })
+        .expect("hook server starts");
+        let body = serde_json::json!({
+            "session_id": "019f6338-6021-77d0-9120-54428d3e2a42",
+            "turn_id": "turn-1",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "request_user_input",
+            "tool_use_id": "input-1"
+        })
+        .to_string();
+
+        assert!(post_raw_codex_hook(&hooks, Uuid::new_v4(), &body)
+            .starts_with("HTTP/1.1 204 No Content"));
+        let event = rx.recv_timeout(Duration::from_secs(1)).expect("event");
+        assert_eq!(event.event, AgentHookEventKind::Start);
+        assert_eq!(event.source.as_deref(), Some("native_tool_result"));
+        assert_eq!(event.provider_turn_id.as_deref(), Some("turn-1"));
+        assert_eq!(event.provider_tool_id.as_deref(), Some("input-1"));
     }
 
     #[test]

--- a/src-tauri/src/agent_wrappers.rs
+++ b/src-tauri/src/agent_wrappers.rs
@@ -108,7 +108,7 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
   # Codex requires command hooks to carry their exact trusted fingerprint.
   # Keep this session-scoped: user/project config remains untouched, and the
   # legacy notify callback below remains available to older Codex releases.
-  _acorn_codex_hooks='hooks={UserPromptSubmit=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],PreToolUse=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],PermissionRequest=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],Stop=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],state={"/<session-flags>/config.toml:pre_tool_use:0:0"={enabled=true,trusted_hash="sha256:b7f07d6514fc12ca8e976ae4bd5b6e61ca13d61c174616789ab3b4464200b1d3"},"/<session-flags>/config.toml:permission_request:0:0"={enabled=true,trusted_hash="sha256:074c27d6eb1e0c1aad3e4fd979c6f80b6ffe5a00a9d2993c857850e7e55b2d64"},"/<session-flags>/config.toml:user_prompt_submit:0:0"={enabled=true,trusted_hash="sha256:71869cae863c34d6bc113940040d9e5e3f0d6173e1f8ff50c77d2c479ecd70a1"},"/<session-flags>/config.toml:stop:0:0"={enabled=true,trusted_hash="sha256:9162891a8f1d1790bc6752f46c9ca2a7e8cc0c6440d496ba9331eecc20a16865"}}}'
+  _acorn_codex_hooks='hooks={UserPromptSubmit=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],PreToolUse=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],PermissionRequest=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],PostToolUse=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],Stop=[{hooks=[{type="command",command="sh \"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"",timeout=5}]}],state={"/<session-flags>/config.toml:pre_tool_use:0:0"={enabled=true,trusted_hash="sha256:b7f07d6514fc12ca8e976ae4bd5b6e61ca13d61c174616789ab3b4464200b1d3"},"/<session-flags>/config.toml:permission_request:0:0"={enabled=true,trusted_hash="sha256:074c27d6eb1e0c1aad3e4fd979c6f80b6ffe5a00a9d2993c857850e7e55b2d64"},"/<session-flags>/config.toml:post_tool_use:0:0"={enabled=true,trusted_hash="sha256:ecd139e174de9a8d3cd7f9503b359587fade68c65f838bb0cddc785f438909cc"},"/<session-flags>/config.toml:user_prompt_submit:0:0"={enabled=true,trusted_hash="sha256:71869cae863c34d6bc113940040d9e5e3f0d6173e1f8ff50c77d2c479ecd70a1"},"/<session-flags>/config.toml:stop:0:0"={enabled=true,trusted_hash="sha256:9162891a8f1d1790bc6752f46c9ca2a7e8cc0c6440d496ba9331eecc20a16865"}}}'
   _acorn_codex_notify_config="notify=[\"bash\",\"$ACORN_AGENT_WRAPPER_DIR/acorn-codex-notify\"]"
   _acorn_codex_version=$("$REAL_BIN" --version 2>/dev/null |
     sed -n 's/^[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' |
@@ -218,7 +218,10 @@ if [ -n "${ACORN_AGENT_HOOK_SESSION_ID-}" ] &&
         *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"'*'_approval_request"'*)
           printf '%s\n' "$_acorn_line" | "$_acorn_notify" "" jsonl_approval >/dev/null 2>&1 || true
           ;;
-        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"exec_command_begin"'*)
+        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"exec_command_begin"'*|\
+        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"patch_apply_begin"'*|\
+        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"mcp_tool_call_begin"'*|\
+        *'"dir":"to_tui"'*'"kind":"codex_event"'*'"msg":{"type":"web_search_begin"'*)
           printf '%s\n' "$_acorn_line" | "$_acorn_notify" "" jsonl_tool >/dev/null 2>&1 || true
           ;;
       esac
@@ -2306,8 +2309,12 @@ done
         assert!(wrapper.contains("UserPromptSubmit"));
         assert!(wrapper.contains("PreToolUse"));
         assert!(wrapper.contains("PermissionRequest"));
+        assert!(wrapper.contains("PostToolUse"));
         assert!(wrapper.contains("Stop"));
         assert!(wrapper.contains("trusted_hash"));
+        assert!(wrapper.contains(
+            "post_tool_use:0:0\"={enabled=true,trusted_hash=\"sha256:ecd139e174de9a8d3cd7f9503b359587fade68c65f838bb0cddc785f438909cc\"}"
+        ));
         assert!(wrapper.contains("/<session-flags>/config.toml"));
         assert!(!wrapper.contains("SubagentStop"));
         assert!(!wrapper.contains("dangerously-bypass-hook-trust"));
@@ -2385,6 +2392,27 @@ done
 
     #[cfg(unix)]
     #[test]
+    fn codex_wrapper_reports_all_provider_tool_begin_events_as_activity() {
+        for event_type in [
+            "exec_command_begin",
+            "patch_apply_begin",
+            "mcp_tool_call_begin",
+            "web_search_begin",
+        ] {
+            let line = format!(
+                r#"{{"dir":"to_tui","kind":"codex_event","msg":{{"type":"{event_type}","turn_id":"turn-1","call_id":"call-1"}}}}"#
+            );
+            let (notifications, _) = codex_wrapper_notifications_for_tui_line(&line);
+            assert_eq!(
+                notifications,
+                format!("jsonl_tool\t{line}\n"),
+                "{event_type}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn codex_native_hooks_forward_raw_payloads_for_rust_validation() {
         let turn_id = "019f6338-6250-7303-88a6-a7add31dba1d";
         let owner_fields = serde_json::json!({
@@ -2394,7 +2422,12 @@ done
             "agent_type": null,
         });
 
-        for hook_event_name in ["UserPromptSubmit", "PreToolUse", "PermissionRequest"] {
+        for hook_event_name in [
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PermissionRequest",
+            "PostToolUse",
+        ] {
             let mut payload = owner_fields.clone();
             payload["hook_event_name"] = hook_event_name.into();
             let posted =

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6486,16 +6486,11 @@ pub fn pty_unsubscribe_output(
 }
 
 #[tauri::command]
-pub fn pty_write<R: Runtime>(
-    app: AppHandle<R>,
-    state: State<'_, AppState>,
-    session_id: String,
-    data: String,
-) -> AppResult<()> {
+pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let bytes = decode_b64(&data)?;
-    let submit_revision =
-        is_terminal_submit_frame(&bytes).then(|| state.sessions.hook_revision(&id));
+    // Terminal input is transport-only: keystrokes express user intent, not
+    // confirmed agent lifecycle. Native hooks and runtime evidence own status.
     // Daemon-managed sessions route stdin through the control socket.
     // Keystrokes are small; one RPC round-trip per keystroke is well
     // under the typing-feedback threshold and avoids managing a second
@@ -6513,33 +6508,7 @@ pub fn pty_write<R: Runtime>(
             .write(&id, &bytes)
             .map_err(|e| AppError::Pty(e.to_string()))?;
     }
-
-    if let Some(revision) = submit_revision {
-        match state.sessions.refresh_status_if_hook_revision(
-            &id,
-            SessionStatus::WaitingForInput,
-            revision,
-            SessionStatus::Working,
-        ) {
-            Ok(true) => {
-                persist(&state);
-                if let Err(err) =
-                    app.emit(crate::agent_hooks::AGENT_HOOK_STATUS_EVENT, id.to_string())
-                {
-                    tracing::warn!(%id, error = %err, "terminal submit status emit failed");
-                }
-            }
-            Ok(false) => {}
-            Err(err) => {
-                tracing::warn!(%id, error = %err, "terminal submit status refresh failed");
-            }
-        }
-    }
     Ok(())
-}
-
-fn is_terminal_submit_frame(bytes: &[u8]) -> bool {
-    matches!(bytes, b"\r" | b"\n" | b"\r\n")
 }
 
 #[tauri::command]
@@ -8948,10 +8917,16 @@ mod tests {
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingSessionRemoval};
+    #[cfg(unix)]
+    use acorn_session::{AgentStatusSource, SessionStatus};
     use acorn_session::{Session, SessionAgentProvider, SessionKind, SessionMode};
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
+    #[cfg(unix)]
+    use std::sync::Arc;
     use std::sync::Mutex;
+    #[cfg(unix)]
+    use tauri::Manager;
     use uuid::Uuid;
 
     fn scoped_session(id: &str, repo_path: &str, project_scoped: bool) -> Session {
@@ -9228,20 +9203,68 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
-    fn terminal_submit_frame_requires_a_standalone_line_ending() {
-        assert!(super::is_terminal_submit_frame(b"\r"));
-        assert!(super::is_terminal_submit_frame(b"\n"));
-        assert!(super::is_terminal_submit_frame(b"\r\n"));
+    fn pty_write_does_not_infer_lifecycle_from_terminal_bytes() {
+        let app = tauri::test::mock_builder()
+            .manage(AppState::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let state = app.state::<AppState>();
+        state.daemon_bridge.set_enabled(false);
 
-        for input in [
-            b"answer".as_slice(),
-            b"\x1b[A".as_slice(),
-            b"answer\r".as_slice(),
-            b"\x1b[200~line one\nline two\x1b[201~".as_slice(),
+        let session = state
+            .sessions
+            .insert(scoped_session("pty-lifecycle", "/tmp", false));
+        state
+            .sessions
+            .refresh_status_with_source(
+                &session.id,
+                SessionStatus::WaitingForInput,
+                Some(AgentStatusSource::Hook),
+            )
+            .expect("mark session waiting on a lifecycle hook");
+        state
+            .pty
+            .spawn(
+                app.handle().clone(),
+                Arc::new(|_, _, _| {}),
+                session.id,
+                std::env::temp_dir(),
+                "/bin/cat".to_string(),
+                Vec::new(),
+                |_| {},
+                80,
+                24,
+            )
+            .expect("spawn test PTY");
+
+        let before = state
+            .sessions
+            .lifecycle_snapshot(&session.id)
+            .expect("read lifecycle before terminal input");
+        for (label, data) in [
+            ("carriage return", "DQ=="),
+            ("line feed", "Cg=="),
+            ("text followed by carriage return", "YW5zd2VyDQ=="),
         ] {
-            assert!(!super::is_terminal_submit_frame(input));
+            super::pty_write(
+                app.state::<AppState>(),
+                session.id.to_string(),
+                data.to_string(),
+            )
+            .unwrap_or_else(|error| panic!("write {label} to PTY: {error}"));
+            assert_eq!(
+                state
+                    .sessions
+                    .lifecycle_snapshot(&session.id)
+                    .expect("read lifecycle after terminal input"),
+                before,
+                "terminal transport changed lifecycle for {label}"
+            );
         }
+
+        state.pty.kill(&session.id).expect("kill test PTY");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Acorn now derives `Working` from provider lifecycle evidence instead of treating Enter as proof that an agent resumed.

1. **Transport-only terminal input** — keep `pty_write` responsible only for decoding and forwarding bytes; CR, LF, and submitted text no longer mutate session lifecycle.
2. **Correlated Codex resume signals** — register the trusted `PostToolUse` hook and resume only when its turn/tool IDs match the pending request.
3. **Broader runtime evidence** — recognize command, patch, MCP, and web-search begin events as actual agent activity.
4. **Lifecycle regression coverage** — exercise real PTY writes through a Tauri mock app and protect newer waits from stale tool results.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Enter or Shift+Enter while waiting | Immediately changed the session to `Working` | Leaves lifecycle unchanged |
| Prompt/tool execution | Could depend on a terminal-byte heuristic | Uses provider hooks and runtime tool activity |
| Delayed tool result | No correlated resume path | Cannot clear a newer or different input request |

## Design notes
- `pty_write` no longer takes an app handle, persists status, or emits lifecycle events.
- Codex `PostToolUse` is accepted as resume evidence only for the exact pending permission/input tool. Missing or stale correlation IDs fail closed.
- A matching tool result clears the pending wait without seeding tool receipts that could claim the next anonymous permission.
- The obsolete hook-revision-only terminal status helper is removed from `acorn-session`.
- Tauri mock runtime support is enabled only for tests.

## Follow-up (not in this PR)
- Add provider-specific immediate post-input signals for other agents when they expose stable correlation IDs. Until then, Acorn waits for provider/runtime evidence instead of guessing from terminal bytes.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn -p acorn-session -- --test-threads=1` — `acorn`: 637 passed, 1 ignored; `acorn-session`: 69 passed
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_hooks.rs src-tauri/src/agent_wrappers.rs src-tauri/src/commands.rs src-tauri/crates/acorn-session/src/session.rs`
- [x] `git diff --check`
- [x] Codex 0.145.0 reports the new `PostToolUse` hook fingerprint as trusted
- [x] GitHub Actions CI green

## Notes
- Providers without a correlated post-input event intentionally remain waiting until native or runtime lifecycle evidence arrives; terminal input is never used as status authority.