### PR TITLE
fix(projects): hide initial-commit option without Git identity

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5545,6 +5545,25 @@ fn get_last_project_parent_folder_from_dir(
     }
 }
 
+fn configured_git_identity(config: &git2::Config) -> Option<(String, String)> {
+    let name = config.get_string("user.name").ok()?;
+    let email = config.get_string("user.email").ok()?;
+    let name = name.trim();
+    let email = email.trim();
+    if name.is_empty() || email.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), email.to_string()))
+}
+
+#[tauri::command]
+pub fn has_git_identity() -> bool {
+    git2::Config::open_default()
+        .ok()
+        .and_then(|config| configured_git_identity(&config))
+        .is_some()
+}
+
 #[tauri::command]
 pub fn create_new_project(
     state: State<'_, AppState>,
@@ -5596,13 +5615,17 @@ pub fn create_new_project(
 }
 
 /// Create the empty initial commit that makes a freshly `init`-ed repo usable.
-/// Prefers the user's configured git identity, falling back to a generic Acorn
-/// signature when `user.name`/`user.email` are unset. Committing to the unborn
-/// `HEAD` symref creates whatever default branch git resolved (`main`/`master`).
+/// Committing to the unborn `HEAD` symref creates whatever default branch git
+/// resolved (`main`/`master`). A configured Git identity is required so Acorn
+/// never authors a commit under a synthetic identity.
 fn seed_initial_commit(repo: &git2::Repository) -> Result<(), git2::Error> {
-    let sig = repo
-        .signature()
-        .or_else(|_| git2::Signature::now("Acorn", "acorn@localhost"))?;
+    let config = repo.config()?;
+    let (name, email) = configured_git_identity(&config).ok_or_else(|| {
+        git2::Error::from_str(
+            "Git user.name and user.email must be configured to create an initial commit",
+        )
+    })?;
+    let sig = git2::Signature::now(&name, &email)?;
     let tree_id = {
         let mut index = repo.index()?;
         index.write_tree()?
@@ -9656,12 +9679,13 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 mod tests {
     use super::{
         auto_title_enabled_for_new_session, collect_memory_usage_from_roots,
-        create_unique_worktree, daemon_spawn_name_for_session, detach_requested_by_stale_renderer,
-        font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
-        memory_root_pids, normalize_session_goal, poll_defers_to_hook,
-        remove_linked_worktree_at_path, restore_pending_session_removal, seed_initial_commit,
-        should_remove_local_project_mirror, validate_editor_command, validate_new_project_name,
-        ChatProviderAdapter, ProcessMemorySnapshot,
+        configured_git_identity, create_unique_worktree, daemon_spawn_name_for_session,
+        detach_requested_by_stale_renderer, font_name_from_path,
+        infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
+        normalize_session_goal, poll_defers_to_hook, remove_linked_worktree_at_path,
+        restore_pending_session_removal, seed_initial_commit, should_remove_local_project_mirror,
+        validate_editor_command, validate_new_project_name, ChatProviderAdapter,
+        ProcessMemorySnapshot,
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingSessionRemoval};
@@ -12091,6 +12115,31 @@ mod tests {
     }
 
     #[test]
+    fn configured_git_identity_requires_non_empty_name_and_email() {
+        let config_dir = unique_repo_dir("git-identity-config");
+        let config_path = config_dir.join("config");
+        std::fs::write(&config_path, "").expect("create config file");
+        let mut config = git2::Config::open(&config_path).expect("open config");
+        assert!(configured_git_identity(&config).is_none());
+
+        config
+            .set_str("user.name", "Acorn Tester")
+            .expect("set name");
+        assert!(configured_git_identity(&config).is_none());
+
+        config.set_str("user.email", "   ").expect("set email");
+        assert!(configured_git_identity(&config).is_none());
+
+        config
+            .set_str("user.email", "tester@example.com")
+            .expect("set email");
+        assert_eq!(
+            configured_git_identity(&config),
+            Some(("Acorn Tester".to_string(), "tester@example.com".to_string()))
+        );
+    }
+
+    #[test]
     fn validate_new_project_name_rejects_path_like_names() {
         assert!(validate_new_project_name("", false).is_err());
         assert!(validate_new_project_name("../fresh-app", false).is_err());
@@ -12554,6 +12603,14 @@ mod tests {
         // seed_initial_commit must make the repo immediately worktree-capable.
         let repo_dir = unique_repo_dir("seed-initial-commit");
         let repo = git2::Repository::init(&repo_dir).expect("init repo");
+        let mut config = repo.config().expect("open repo config");
+        config
+            .set_str("user.name", "Acorn Tester")
+            .expect("set name");
+        config
+            .set_str("user.email", "tester@example.com")
+            .expect("set email");
+        drop(config);
         assert!(repo.head().is_err(), "fresh init must have unborn HEAD");
         seed_initial_commit(&repo).expect("seed initial commit");
         assert!(repo.head().is_ok(), "seeded repo must resolve HEAD");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -715,6 +715,7 @@ pub fn run() {
             commands::add_project,
             commands::select_project_parent_folder,
             commands::get_last_project_parent_folder,
+            commands::has_git_identity,
             commands::create_new_project,
             commands::remove_project,
             commands::get_project_settings,

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -43,7 +43,10 @@ export function NewProjectDialog({
   const [parentPath, setParentPath] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [ignoreSafeName, setIgnoreSafeName] = useState(false);
-  const [initCommit, setInitCommit] = useState(true);
+  const [initCommit, setInitCommit] = useState(false);
+  const [gitIdentityConfigured, setGitIdentityConfigured] = useState<
+    boolean | null
+  >(null);
   const [pending, setPending] = useState(false);
   const locationPickedRef = useRef(false);
 
@@ -55,7 +58,8 @@ export function NewProjectDialog({
     setParentPath("");
     setError(null);
     setIgnoreSafeName(false);
-    setInitCommit(true);
+    setInitCommit(false);
+    setGitIdentityConfigured(null);
     setPending(false);
     void api
       .getLastProjectParentFolder()
@@ -67,6 +71,20 @@ export function NewProjectDialog({
       .catch(() => {
         if (!cancelled && !locationPickedRef.current) {
           setParentPath("");
+        }
+      });
+    void api
+      .hasGitIdentity()
+      .then((configured) => {
+        if (!cancelled) {
+          setGitIdentityConfigured(configured);
+          setInitCommit(configured);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setGitIdentityConfigured(false);
+          setInitCommit(false);
         }
       });
     return () => {
@@ -96,6 +114,7 @@ export function NewProjectDialog({
         : dt(t, `dialogs.newProject.validation.${validation.reason}`);
   const canCreate =
     !pending &&
+    gitIdentityConfigured !== null &&
     parentPath !== "" &&
     (validation.kind === "ok" ||
       (validation.kind === "safe" && ignoreSafeName));
@@ -119,7 +138,12 @@ export function NewProjectDialog({
     setPending(true);
     setError(null);
     try {
-      await onCreate(parentPath, trimmedName, ignoreSafeName, initCommit);
+      await onCreate(
+        parentPath,
+        trimmedName,
+        ignoreSafeName,
+        initCommit && gitIdentityConfigured === true,
+      );
       onClose();
     } catch (err) {
       setError(errorMessage(err));
@@ -213,15 +237,21 @@ export function NewProjectDialog({
               </Button>
             </div>
           </Field>
-          <label className="flex items-center gap-2 text-xs text-fg-muted">
-            <input
-              type="checkbox"
-              checked={initCommit}
-              onChange={(e) => setInitCommit(e.target.checked)}
-              className="acorn-check"
-            />
-            <span>{dt(t, "dialogs.newProject.initCommit")}</span>
-          </label>
+          {gitIdentityConfigured === true ? (
+            <label className="flex items-center gap-2 text-xs text-fg-muted">
+              <input
+                type="checkbox"
+                checked={initCommit}
+                onChange={(e) => setInitCommit(e.target.checked)}
+                className="acorn-check"
+              />
+              <span>{dt(t, "dialogs.newProject.initCommit")}</span>
+            </label>
+          ) : gitIdentityConfigured === false ? (
+            <p className="text-xs text-fg-muted">
+              {dt(t, "dialogs.newProject.initCommitUnavailable")}
+            </p>
+          ) : null}
           {finalPath ? (
             <div className="space-y-1 text-xs">
               <div className="text-fg-muted">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -316,6 +316,9 @@ export const api = {
   getLastProjectParentFolder(): Promise<string | null> {
     return invoke<string | null>("get_last_project_parent_folder");
   },
+  hasGitIdentity(): Promise<boolean> {
+    return invoke<boolean>("has_git_identity");
+  },
   createNewProject(
     parentPath: string,
     name: string,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1989,6 +1989,7 @@
       "projectNameHint": "Use a single folder name.",
       "ignoreSafeName": "Ignore safe-name check",
       "initCommit": "Create an initial commit (needed for worktrees and GitHub)",
+      "initCommitUnavailable": "An initial commit is unavailable because Git user.name and user.email are not configured. The repository will be created without a commit.",
       "locationLabel": "Location",
       "locationPlaceholder": "Choose a parent folder",
       "locationAriaLabel": "Project location",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1989,6 +1989,7 @@
       "projectNameHint": "단일 폴더 이름을 사용하세요.",
       "ignoreSafeName": "안전한 이름 검사 무시",
       "initCommit": "초기 커밋 생성 (worktree·GitHub 사용에 필요)",
+      "initCommitUnavailable": "Git user.name과 user.email이 설정되지 않아 초기 커밋을 만들 수 없습니다. 저장소는 커밋 없이 생성됩니다.",
       "locationLabel": "위치",
       "locationPlaceholder": "상위 폴더 선택",
       "locationAriaLabel": "프로젝트 위치",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -114,6 +114,9 @@ export const tauriMockSource = `
     if (cmd === 'get_last_project_parent_folder') {
       return Promise.resolve(null);
     }
+    if (cmd === 'has_git_identity') {
+      return Promise.resolve(true);
+    }
     if (cmd === 'create_session_from_dialog') {
       return Promise.resolve(null);
     }

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -3761,6 +3761,63 @@ test.describe("sidebar: project lifecycle", () => {
     });
   });
 
+  test("New project hides the initial commit option when Git identity is missing", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("has_git_identity", () => false);
+    await tauri.handle("select_project_parent_folder", () => "/tmp/parent");
+    await tauri.handle("create_new_project", (args) => {
+      const w = window as unknown as { __newProjectCalls?: unknown[] };
+      w.__newProjectCalls = w.__newProjectCalls ?? [];
+      w.__newProjectCalls.push(args);
+      const a = args as { parentPath: string; name: string };
+      return {
+        repo_path: `${a.parentPath}/${a.name}`,
+        name: a.name,
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+
+    await expect(
+      page.getByLabel(
+        "Create an initial commit (needed for worktrees and GitHub)",
+      ),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText(
+        "An initial commit is unavailable because Git user.name and user.email are not configured. The repository will be created without a commit.",
+      ),
+    ).toBeVisible();
+
+    await page.getByLabel("Project name").fill("no-identity-app");
+    await page.getByRole("button", { name: "Choose" }).click();
+    await page.getByRole("button", { name: "Create project" }).click();
+
+    const calls = (await page.evaluate(
+      () =>
+        (window as unknown as { __newProjectCalls?: unknown[] })
+          .__newProjectCalls,
+    )) as Array<{
+      parentPath: string;
+      name: string;
+      ignoreSafeName: boolean;
+      initCommit: boolean;
+    }>;
+    expect(calls).toEqual([
+      {
+        parentPath: "/tmp/parent",
+        name: "no-identity-app",
+        ignoreSafeName: false,
+        initCommit: false,
+      },
+    ]);
+  });
+
   test("New project remembers the most recently selected parent folder", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

New projects now avoid synthetic commit authorship when the user has not configured a Git identity.

1. **Identity-aware UI** — Check `user.name` and `user.email` when the New project dialog opens, show the initial-commit checkbox only when both are configured, and otherwise explain that the repository will be created without a commit.
2. **Fail-closed project creation** — Submit `initCommit: false` unless the identity check explicitly succeeds, including when the capability query itself fails.
3. **No synthetic fallback** — Remove the `Acorn <acorn@localhost>` signature fallback from the Rust commit path and require a real configured identity whenever an initial commit is requested.
4. **Regression coverage** — Cover missing-identity behavior in Playwright and validate non-empty Git identity parsing plus worktree-capable seeded repositories in Rust tests.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Missing Git identity | Initial-commit checkbox was shown and Acorn authored an empty commit as `Acorn <acorn@localhost>` | Checkbox is hidden, the limitation is explained, and the repository is created with an unborn HEAD |
| Configured Git identity | Initial commit was selected by default | Existing default remains unchanged and uses the configured identity |
| Identity check failure | No capability check existed | Creation fails closed to `initCommit: false` |

## Design notes

- The frontend asks a small Tauri capability command whether both effective default Git config values are present and non-blank before enabling creation.
- The submit path still guards the boolean independently, so a stale UI state cannot request an initial commit unless the capability check succeeded.
- The Rust commit helper resolves the identity again from repository config. If a stale or external caller explicitly requests an initial commit after the identity disappears, the existing project-creation cleanup path returns the error and removes the partially created directory.
- Repositories created without the commit retain an unborn HEAD, so worktree and GitHub operations remain unavailable until the user configures Git and makes the first commit.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 102 files, 1,172 tests passed
- [x] `pnpm run build`
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "New project"` — 5 tests passed
- [x] `cargo test --quiet --manifest-path src-tauri/Cargo.toml -- --test-threads=1` — 639 passed, 1 ignored
- [x] `cargo test --manifest-path src-tauri/Cargo.toml configured_git_identity_requires_non_empty_name_and_email`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml seeded_repo_supports_worktree_creation`
- [x] `rustfmt --check --edition 2021 src-tauri/src/commands.rs`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `git diff --check`

## Notes

- A parallel local Rust run transiently failed three existing `agent_wrappers` tests because their wrapper capture was empty. The matching 8-test group passed when rerun serially, and the complete serial suite then passed; the failures are unrelated to the project-creation path changed here.
