### PR TITLE
chore(release): v1.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.29.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.28.0"
+version = "1.29.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.28.0"
+version = "1.29.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.29.0 from the final green `main` at `fe2042d`, containing every merged change since v1.28.0.

1. **Version synchronization:** updates `package.json`, Tauri config, Cargo manifest, and Cargo lock metadata from `1.28.0` to `1.29.0`.
2. **Release scope:** includes five user-visible feature PRs for live agent activity, its conversational timeline, new-project initialization, autonomous Goal sessions, and the review-ready PR/CI-gated merge pipeline, plus eight session, history, agent-status, and Git-identity fixes.
3. **Publication path:** prepares the exact commit that will be tagged `v1.29.0` for signed Apple Silicon and Intel macOS artifacts plus `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Application version | All runtime and packaging metadata report `1.29.0`. |
| User-visible changes | Goal delivery workflows, live agent activity with a conversational timeline, initial project commits, and the accumulated fixes become available in the stable channel. |
| Updater | The Release workflow will publish bilingual notes and signed artifacts for both supported macOS architectures. |

## Design notes

- This is a minor release because the range contains user-visible features in #700, #703, #705, #706, and #709.
- The release commit contains version metadata only; the 13 implementation PRs were reviewed and merged independently before this bump.
- Generated notes group the range into five Features and eight Fixes and include the required Korean and English summary blockquotes.
- The release tag is created only after this PR passes CI and is merged into `main`.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 102 files, 1,174 tests passed
- [x] `pnpm run build`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1`
- [x] `node scripts/validate-release-version.mjs v1.29.0`
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 15 tests passed
- [x] `REPO=im-ian/acorn TAG=v1.29.0 OUTPUT=/tmp/acorn-release-notes-v1.29.0.md node scripts/release-notes.mjs` — bilingual summaries and Features/Fixes headings verified
- [x] `git diff --check`

## Notes

- Final pre-release PR CI passed for `fe2042d`: Frontend plus both E2E shards.
- `v1.29.0` does not yet exist as a local tag, remote tag, or GitHub release.
- This PR uses `skip-changelog` so the metadata-only bump is not listed as a product change.
