### PR TITLE
fix(clipboard): route copy actions through native Tauri writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@shikijs/themes": "^4.3.1",
     "@tanstack/react-virtual": "^3.14.6",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.2",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-notification": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.1
         version: 2.11.1
+      '@tauri-apps/plugin-clipboard-manager':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.2
         version: 2.7.2
@@ -1557,6 +1560,9 @@ packages:
     resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
   '@tauri-apps/plugin-dialog@2.7.2':
     resolution: {integrity: sha512-pX0IGm1I3I6wc+zeKYcq1GSqogK6okCNX5fOdaNU5ab1AjGS6l1E5wFNjEb7meg7ZFSp0JUs+0jQGQNyOvLrsg==}
@@ -4364,6 +4370,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
+  '@tauri-apps/plugin-clipboard-manager@2.3.2':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.2':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-notification",
@@ -218,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -229,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -245,6 +246,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
 ]
 
 [[package]]
@@ -545,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +894,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1045,7 +1088,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1243,8 +1286,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
@@ -1272,6 +1321,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1319,6 +1374,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1587,6 +1648,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1864,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2122,6 +2204,20 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2604,6 +2700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2621,7 +2727,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2676,6 +2782,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2734,7 +2849,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2794,6 +2909,7 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
 ]
 
@@ -3039,6 +3155,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "osakit"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,6 +3243,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -3377,10 +3514,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3636,7 +3794,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3692,7 +3850,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4113,7 +4271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4495,6 +4653,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-clipboard-manager"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206dc20af4ed210748ba945c2774e60fd0acd52b9a73a028402caf809e9b6ecf"
+dependencies = [
+ "arboard",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4758,7 +4931,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4818,6 +4991,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5191,7 +5378,18 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.19",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom",
+ "petgraph",
 ]
 
 [[package]]
@@ -5220,7 +5418,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5539,6 +5737,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5650,6 +5918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5677,7 +5951,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6331,6 +6605,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.19",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6400,6 +6692,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"
@@ -6592,6 +6901,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -100,6 +100,7 @@ acorn-session = { path = "crates/acorn-session" }
 acorn-transcript = { path = "crates/acorn-transcript" }
 tauri = { workspace = true }
 tauri-plugin-opener = "2"
+tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:app:default",
     "core:resources:default",
     "core:window:allow-destroy",
+    "clipboard-manager:allow-write-text",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,7 @@ pub fn run() {
     }
     builder = builder
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -4,6 +4,7 @@ import { api, type AgentKind, type ResumeCandidate } from "../lib/api";
 import { buildAgentResumeCommand } from "../lib/agentProvider";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
+import { writeClipboardText } from "../lib/clipboardText";
 import { useTranslation } from "../lib/useTranslation";
 import { Button, CodeValue, Modal, ModalFooter, ModalHeader } from "./ui";
 
@@ -104,8 +105,7 @@ export function AgentResumeModal({
   };
 
   const handleCopy = () => {
-    void navigator.clipboard
-      .writeText(candidate.uuid)
+    void writeClipboardText(candidate.uuid)
       .then(() => showToast(dt(t, "dialogs.agentResume.sessionIdCopied")))
       .catch(() => showToast(dt(t, "dialogs.agentResume.copyFailed")));
     onDismiss();

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -40,6 +40,7 @@ import {
   isSessionAgentProvider,
 } from "../lib/agentProvider";
 import { pathRelativeToCwd } from "../lib/fileMention";
+import { writeClipboardText } from "../lib/clipboardText";
 import { EDIT_AUTONOMOUS_GOAL_SESSION_EVENT } from "../lib/autonomousGoal";
 import { useDialogShortcuts } from "../lib/dialog";
 import { useAppStore } from "../store";
@@ -1000,7 +1001,7 @@ export function ChatPane({
   async function handleCopyMessage(messageId: string, content: string) {
     if (!content.trim()) return;
     try {
-      await navigator.clipboard.writeText(content);
+      await writeClipboardText(content);
       setCopiedMessageId(messageId);
       if (copyResetTimer.current !== null) {
         window.clearTimeout(copyResetTimer.current);

--- a/src/components/CommandRunDialog.tsx
+++ b/src/components/CommandRunDialog.tsx
@@ -5,6 +5,7 @@ import { useToasts } from "../lib/toasts";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
+import { writeClipboardText } from "../lib/clipboardText";
 import { Button, CodeValue, Modal, ModalFooter, ModalHeader, Notice } from "./ui";
 import {
   applySessionCreateRequest,
@@ -124,7 +125,7 @@ export function CommandRunDialog({
 
   async function handleCopy() {
     try {
-      await navigator.clipboard.writeText(command);
+      await writeClipboardText(command);
       showToast(`${dt(t, "dialogs.commandRun.copiedPrefix")} ${command}`);
       onClose();
     } catch (e) {

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -36,6 +36,7 @@ import {
   hasDetectedAgent,
 } from "../lib/agentContextMenu";
 import { cn } from "../lib/cn";
+import { writeClipboardText } from "../lib/clipboardText";
 import { retainRecentGitStatPaths } from "../lib/fileExplorerGitStats";
 import { matchesHotkeyEvent } from "../lib/hotkeys";
 import {
@@ -1092,7 +1093,7 @@ export function FileExplorer({
         mode === "absolute" ? p : relativeTo(rootPath, p),
       );
       try {
-        await navigator.clipboard.writeText(lines.join("\n"));
+        await writeClipboardText(lines.join("\n"));
         showToast(t("toasts.files.pathsCopied"));
       } catch {
         setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
@@ -1317,7 +1318,7 @@ export function FileExplorer({
         label: fileExplorerText(t, "fileExplorer.menu.copyRelativePath"),
         icon: <Link2 size={13} />,
         onClick: () => {
-          void navigator.clipboard.writeText(rel).catch(() => {
+          void writeClipboardText(rel).catch(() => {
             setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },
@@ -1326,7 +1327,7 @@ export function FileExplorer({
         label: fileExplorerText(t, "fileExplorer.menu.copyAbsolutePath"),
         icon: <Copy size={13} />,
         onClick: () => {
-          void navigator.clipboard.writeText(entry.path).catch(() => {
+          void writeClipboardText(entry.path).catch(() => {
             setError(fileExplorerText(t, "fileExplorer.errors.clipboardWriteFailed"));
           });
         },

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -36,6 +36,7 @@ import { createPortal } from "react-dom";
 import { selectSessionsById, useAppStore } from "../store";
 import { FileViewer } from "./FileViewer";
 import { mediaKindFromPath } from "../lib/mediaFiles";
+import { writeClipboardText } from "../lib/clipboardText";
 import { ChatPane } from "./ChatPane";
 import { WorkSummaryView } from "./WorkSummaryView";
 import { api } from "../lib/api";
@@ -1932,7 +1933,7 @@ function buildPaneMenuItems({
 
 async function copyToClipboard(text: string): Promise<void> {
   try {
-    await navigator.clipboard.writeText(text);
+    await writeClipboardText(text);
   } catch (err) {
     console.warn("[Pane] clipboard write failed", err);
   }

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -24,6 +24,7 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { Panel, PanelGroup } from "react-resizable-panels";
 import { api } from "../lib/api";
+import { writeClipboardText } from "../lib/clipboardText";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -1600,7 +1601,7 @@ function CommitListItem({
     {
       label: dt(t, "dialogs.pullRequestDetail.copySha"),
       icon: <Copy size={12} />,
-      onClick: () => void navigator.clipboard.writeText(commit.oid),
+      onClick: () => void writeClipboardText(commit.oid),
     },
   ];
 
@@ -1765,7 +1766,7 @@ function CommitDetailView({
         <button
           type="button"
           onClick={() => {
-            void navigator.clipboard.writeText(commit.oid);
+            void writeClipboardText(commit.oid);
           }}
           className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -47,6 +47,7 @@ import { Panel, PanelGroup } from "react-resizable-panels";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
+import { writeClipboardText } from "../lib/clipboardText";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
 import {
@@ -1445,7 +1446,7 @@ function AgentHistoryTab({
 
   async function copy(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (e) {
       setError(String(e));
     }
@@ -2064,7 +2065,7 @@ function CommitsTab({
         <Tooltip label={rt(t, "rightPanel.tooltips.copySha")} side="bottom">
           <button
             type="button"
-            onClick={() => void navigator.clipboard.writeText(c.sha)}
+            onClick={() => void writeClipboardText(c.sha)}
             className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
             {c.short_sha}
@@ -2147,7 +2148,7 @@ function CommitsTab({
 
   async function copyToClipboard(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (e) {
       setError(String(e));
     }
@@ -2531,7 +2532,7 @@ function StagedTab({
 
   async function copyText(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (e) {
       setListError(String(e));
     }
@@ -2812,7 +2813,7 @@ function usePrRowActions(
 
   async function copyText(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (e) {
       setError(String(e));
     }
@@ -3443,7 +3444,7 @@ function useIssueRowActions(onOpenDetail: (number: number) => void) {
 
   async function copyText(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (e) {
       setError(String(e));
     }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -71,6 +71,7 @@ import {
   createEmptySessionAgentDetection,
 } from "../lib/agentContextMenu";
 import { api, type SessionRemoval } from "../lib/api";
+import { writeClipboardText } from "../lib/clipboardText";
 import {
   EDIT_AUTONOMOUS_GOAL_SESSION_EVENT,
   NEW_AUTONOMOUS_GOAL_SESSION_EVENT,
@@ -2112,7 +2113,7 @@ function ProjectGroupView({
 
   async function copyText(text: string) {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch {
       // ignore
     }
@@ -3535,7 +3536,7 @@ function SessionStatusMarker({
 
 async function copyToClipboard(text: string): Promise<void> {
   try {
-    await navigator.clipboard.writeText(text);
+    await writeClipboardText(text);
   } catch (err) {
     console.warn("[Sidebar] clipboard write failed", err);
   }

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -25,6 +25,7 @@ import {
   type FsGitDiffStatsRequest,
   type FsGitStatus,
 } from "../lib/api";
+import { writeClipboardText } from "../lib/clipboardText";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { fsChangeTouchesRoot } from "../lib/workSummaryInvalidation";
@@ -265,7 +266,7 @@ export function WorkSummaryView({
 
   const copyText = useCallback(async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await writeClipboardText(text);
     } catch (err) {
       console.warn("[WorkSummaryView] clipboard write failed", err);
     }

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -48,6 +48,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { api } from "../lib/api";
+import { writeClipboardText } from "../lib/clipboardText";
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { cn } from "../lib/cn";
 import { openInConfiguredEditor } from "../lib/editor";
@@ -3083,7 +3084,7 @@ function cssAttributeEscape(value: string): string {
 
 async function copyToClipboard(text: string): Promise<void> {
   try {
-    await navigator.clipboard.writeText(text);
+    await writeClipboardText(text);
   } catch (err) {
     console.warn("[WorkspaceMain] clipboard write failed", err);
   }

--- a/src/components/chat/ChatCodeBlock.tsx
+++ b/src/components/chat/ChatCodeBlock.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "../../lib/cn";
+import { writeClipboardText } from "../../lib/clipboardText";
 import { diffGutterWidth, parseDiff, type ParsedLine } from "../../lib/diff";
 import { highlightCode, langFromPath } from "../../lib/highlight";
 import { useSettings } from "../../lib/settings";
@@ -132,7 +133,7 @@ export function ChatCodeBlock({
   }, [isDiff, label, normalizedCode, sourceLines.length, themeMode]);
 
   async function copyCode() {
-    await navigator.clipboard.writeText(normalizedCode);
+    await writeClipboardText(normalizedCode);
     setCopied(true);
     if (copyResetTimer.current !== null) {
       window.clearTimeout(copyResetTimer.current);

--- a/src/lib/clipboardText.test.ts
+++ b/src/lib/clipboardText.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  nativeWriteText: vi.fn<(text: string) => Promise<void>>(),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: mocks.nativeWriteText,
+}));
+
+import { writeClipboardText } from "./clipboardText";
+
+const originalTauriInternals = Object.getOwnPropertyDescriptor(
+  window,
+  "__TAURI_INTERNALS__",
+);
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+
+afterEach(() => {
+  mocks.nativeWriteText.mockReset();
+  if (originalTauriInternals) {
+    Object.defineProperty(
+      window,
+      "__TAURI_INTERNALS__",
+      originalTauriInternals,
+    );
+  } else {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  }
+  if (originalClipboard) {
+    Object.defineProperty(navigator, "clipboard", originalClipboard);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+});
+
+describe("writeClipboardText", () => {
+  it("uses the native clipboard in the Tauri runtime", async () => {
+    const browserWriteText = vi.fn<(text: string) => Promise<void>>();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: browserWriteText },
+    });
+    mocks.nativeWriteText.mockResolvedValue();
+
+    await writeClipboardText("#708");
+
+    expect(mocks.nativeWriteText).toHaveBeenCalledWith("#708");
+    expect(browserWriteText).not.toHaveBeenCalled();
+  });
+
+  it("keeps browser-only development on the Clipboard API", async () => {
+    const browserWriteText = vi.fn<(text: string) => Promise<void>>();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: browserWriteText },
+    });
+    browserWriteText.mockResolvedValue();
+
+    await writeClipboardText("browser text");
+
+    expect(browserWriteText).toHaveBeenCalledWith("browser text");
+    expect(mocks.nativeWriteText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/clipboardText.ts
+++ b/src/lib/clipboardText.ts
@@ -1,0 +1,23 @@
+import { writeText as writeNativeText } from "@tauri-apps/plugin-clipboard-manager";
+
+type TauriRuntimeWindow = Window & { __TAURI_INTERNALS__?: unknown };
+
+function isTauriRuntime(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in (window as TauriRuntimeWindow)
+  );
+}
+
+/**
+ * Write plain text through the native clipboard in the desktop app. Browser
+ * development keeps the standard API fallback because no Tauri runtime is
+ * present there.
+ */
+export async function writeClipboardText(text: string): Promise<void> {
+  if (isTauriRuntime()) {
+    await writeNativeText(text);
+    return;
+  }
+  await navigator.clipboard.writeText(text);
+}

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -56,6 +56,7 @@ export const tauriMockSource = `
     if (cmd === 'plugin:notification|is_permission_granted') return Promise.resolve(true);
     if (cmd === 'plugin:notification|request_permission') return Promise.resolve('granted');
     if (cmd === 'plugin:notification|notify') return Promise.resolve(undefined);
+    if (cmd === 'plugin:clipboard-manager|write_text') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|destroy') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|close') return Promise.resolve(undefined);
     if (cmd === 'plugin:window|scale_factor') return Promise.resolve(1);

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -832,6 +832,79 @@ test.describe("right panel: tab switching", () => {
     ).toHaveClass(/acorn-tab-active-bg/);
   });
 
+  test("copies a pull request number through the native clipboard", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: () =>
+            Promise.reject(
+              new DOMException(
+                "The request is not allowed by the user agent or the platform in the current context.",
+                "NotAllowedError",
+              ),
+            ),
+        },
+      });
+    });
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 91,
+          title: "Copy this pull request number",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "fix/native-clipboard",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/91",
+          updated_at: "2026-07-22T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("plugin:clipboard-manager|write_text", (args) => {
+      const w = window as unknown as {
+        __nativeClipboardWrites?: unknown[];
+      };
+      w.__nativeClipboardWrites = w.__nativeClipboardWrites ?? [];
+      w.__nativeClipboardWrites.push(args);
+      return undefined;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+
+    const prRow = page
+      .getByText("Copy this pull request number")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await prRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Copy PR number" }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              (window as unknown as {
+                __nativeClipboardWrites?: Array<{ text?: string }>;
+              }).__nativeClipboardWrites ?? []
+            ).at(-1)?.text,
+        ),
+      )
+      .toBe("#91");
+    await expect(page.getByText(/NotAllowedError/)).toHaveCount(0);
+    await expect(prRow).toBeVisible();
+  });
+
   test("posting from the pull request detail modal appends a conversation comment", async ({
     page,
     tauri,
@@ -2358,18 +2431,11 @@ test.describe("right panel: groups", () => {
     page,
     tauri,
   }) => {
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: {
-          writeText: (text: string) => {
-            const w = window as unknown as { __clipboardWrites?: string[] };
-            w.__clipboardWrites = w.__clipboardWrites ?? [];
-            w.__clipboardWrites.push(text);
-            return Promise.resolve();
-          },
-        },
-      });
+    await tauri.handle("plugin:clipboard-manager|write_text", (args) => {
+      const w = window as unknown as { __clipboardWrites?: string[] };
+      w.__clipboardWrites = w.__clipboardWrites ?? [];
+      w.__clipboardWrites.push((args as { text?: string })?.text ?? "");
+      return undefined;
     });
     await seedActiveSession(tauri);
     await tauri.handle("list_agent_history", () => [

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -607,16 +607,10 @@ test.describe("sidebar: project lifecycle", () => {
     tauri,
   }) => {
     const transcriptPath = "/Users/me/.codex/sessions/copyable.jsonl";
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: {
-          writeText: async (text: string) => {
-            (window as unknown as { __copiedText?: string }).__copiedText =
-              text;
-          },
-        },
-      });
+    await tauri.handle("plugin:clipboard-manager|write_text", (args) => {
+      (window as unknown as { __copiedText?: string }).__copiedText =
+        (args as { text?: string })?.text;
+      return undefined;
     });
     await tauri.respond("list_projects", [
       {


### PR DESCRIPTION
## Summary
Desktop copy actions now bypass WebKit clipboard permission state and write through Tauri's native clipboard API.

1. **Native clipboard writes** — register the official clipboard-manager plugin with the narrow `allow-write-text` capability.
2. **Shared copy path** — route every text-copy action through one helper while preserving the browser Clipboard API fallback for Vite-only development.
3. **Regression coverage** — reproduce a rejected WebKit Clipboard API and verify “Copy PR number” still writes `#91` through the native command; update existing transcript-copy coverage to assert the same path.

## Expected impact
| Behavior | Before | After |
| --- | --- | --- |
| Desktop text-copy actions | Depended on WKWebView Clipboard API permission/context state | Use the native system clipboard |
| Browser-only development | Used the browser Clipboard API | Unchanged |
| Clipboard privilege | WebView API behavior varied by platform state | Explicit write-text-only Tauri capability |

## Design notes
- The helper chooses the native plugin only when Tauri internals are present, so `pnpm run dev` continues to work in a normal browser.
- All production `navigator.clipboard.writeText` call sites use the shared helper, preventing the same platform failure from resurfacing in commit, issue, path, transcript, chat, and code-copy actions.
- The capability grants only plain-text writes; clipboard reads, image writes, HTML writes, and clearing remain unavailable to the frontend.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1,176 tests pass
- [x] `pnpm run build:frontend`
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts tests/e2e/sidebar.spec.ts` — 78 tests pass
- [x] `cargo check -p acorn --lib --locked`
- [x] `pnpm run build:sidecar`
