### PR TITLE
fix(settings): make Codex and Claude title sync opt-in

### DIFF
--- a/src-tauri/src/agent_session_names.rs
+++ b/src-tauri/src/agent_session_names.rs
@@ -36,17 +36,17 @@ enum ReaderEvent {
     Eof,
 }
 
-/// Queue a provider-native title update without delaying or failing the Acorn
-/// operation that produced it. Antigravity has no verified naming interface,
-/// so it is intentionally left unchanged.
-pub fn enqueue(target: LiveTranscript, title: impl Into<String>) {
-    if target.kind == AgentKind::Antigravity {
-        return;
+fn prepare_request(
+    enabled: bool,
+    target: LiveTranscript,
+    title: impl Into<String>,
+) -> Option<TitleSyncRequest> {
+    if !enabled || target.kind == AgentKind::Antigravity {
+        return None;
     }
-
     let title = title.into().trim().to_string();
     if title.is_empty() {
-        return;
+        return None;
     }
     if title.len() > MAX_PROVIDER_TITLE_BYTES {
         tracing::warn!(
@@ -55,13 +55,23 @@ pub fn enqueue(target: LiveTranscript, title: impl Into<String>) {
             title_bytes = title.len(),
             "skipping provider session name sync because the title is too large"
         );
-        return;
+        return None;
     }
+    Some(TitleSyncRequest { target, title })
+}
+
+/// Queue a provider-native title update without delaying or failing the Acorn
+/// operation that produced it. Disabled settings and Antigravity targets are
+/// intentionally left unchanged.
+pub fn enqueue(enabled: bool, target: LiveTranscript, title: impl Into<String>) {
+    let Some(request) = prepare_request(enabled, target, title) else {
+        return;
+    };
 
     let Some(sender) = worker_sender() else {
         return;
     };
-    if let Err(err) = sender.send(TitleSyncRequest { target, title }) {
+    if let Err(err) = sender.send(request) {
         tracing::warn!(error = %err, "provider session name worker is unavailable");
     }
 }
@@ -70,9 +80,9 @@ pub fn enqueue(target: LiveTranscript, title: impl Into<String>) {
 /// session id. Manual names apply to the newly-bound conversation; generated
 /// names apply only when they were generated from that exact transcript, so a
 /// `/new` conversation never inherits the previous conversation's title.
-pub fn enqueue_existing_title(session: &Session, target: LiveTranscript) {
+pub fn enqueue_existing_title(enabled: bool, session: &Session, target: LiveTranscript) {
     if should_sync_existing_title(session, &target.id) {
-        enqueue(target, session.name.clone());
+        enqueue(enabled, target, session.name.clone());
     }
 }
 
@@ -389,6 +399,14 @@ mod tests {
         );
         session.title_source = source;
         session
+    }
+
+    #[test]
+    fn disabled_setting_drops_title_sync_before_starting_the_worker() {
+        let id = "019c1464-9f4e-7302-bc0f-81a1449fc365";
+        let target = claude_target(Path::new("/tmp/transcript.jsonl"), id);
+
+        assert!(prepare_request(false, target, "release fix").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6011,8 +6011,14 @@ pub fn update_session_goal(
 }
 
 #[tauri::command]
-pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> AppResult<Session> {
+pub fn rename_session(
+    state: State<'_, AppState>,
+    id: String,
+    name: String,
+    sync_agent_session_titles: Option<bool>,
+) -> AppResult<Session> {
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
+    let sync_agent_session_titles = sync_agent_session_titles.unwrap_or(false);
     let trimmed = name.trim().to_string();
     if trimmed.is_empty() {
         return Err(AppError::Other("name must not be empty".to_string()));
@@ -6023,14 +6029,19 @@ pub fn rename_session(state: State<'_, AppState>, id: String, name: String) -> A
             "control-session owned tabs cannot be renamed".to_string(),
         ));
     }
-    let native_session = (current.kind == SessionKind::Regular
+    let native_session = (sync_agent_session_titles
+        && current.kind == SessionKind::Regular
         && current.mode == SessionMode::Terminal)
         .then(|| crate::session_titles::resolve_native_session(id))
         .flatten();
     let updated = state.sessions.rename(&id, trimmed)?;
     persist(&state);
     if let Some(native_session) = native_session {
-        crate::agent_session_names::enqueue(native_session, updated.name.clone());
+        crate::agent_session_names::enqueue(
+            sync_agent_session_titles,
+            native_session,
+            updated.name.clone(),
+        );
     }
     Ok(enrich_session(updated))
 }
@@ -6126,10 +6137,18 @@ pub async fn generate_session_title(
     ai: crate::ai::AiExecutionRequest,
     prompt: Option<String>,
     force: Option<bool>,
+    sync_agent_session_titles: Option<bool>,
 ) -> AppResult<GenerateSessionTitleResult> {
     let state = state.inner().clone();
     run_blocking("generate_session_title", move || {
-        generate_session_title_inner(state, id, ai, prompt, force.unwrap_or(false))
+        generate_session_title_inner(
+            state,
+            id,
+            ai,
+            prompt,
+            force.unwrap_or(false),
+            sync_agent_session_titles.unwrap_or(false),
+        )
     })
     .await
 }
@@ -6140,6 +6159,7 @@ fn generate_session_title_inner(
     ai: crate::ai::AiExecutionRequest,
     prompt: Option<String>,
     force: bool,
+    sync_agent_session_titles: bool,
 ) -> AppResult<GenerateSessionTitleResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
@@ -6189,7 +6209,11 @@ fn generate_session_title_inner(
         .set_generated_title(&id, generated, Some(transcript_id))?;
     persist(&state);
     if let Some(native_session) = native_session {
-        crate::agent_session_names::enqueue(native_session, updated.name.clone());
+        crate::agent_session_names::enqueue(
+            sync_agent_session_titles,
+            native_session,
+            updated.name.clone(),
+        );
     }
     Ok(GenerateSessionTitleResult {
         status: GenerateSessionTitleStatus::Generated,
@@ -7783,6 +7807,7 @@ fn git_context_for_path(path: &std::path::Path) -> Option<(String, String)> {
 pub async fn detect_session_statuses(
     state: State<'_, AppState>,
     ids: Vec<String>,
+    sync_agent_session_titles: Option<bool>,
 ) -> AppResult<Vec<SessionStatusEntry>> {
     let state = state.inner().clone();
     // The process-table refresh, per-session branch probes, and the daemon
@@ -7790,7 +7815,7 @@ pub async fn detect_session_statuses(
     // seconds) are all blocking — keep them off the async executor, or the
     // frontend's status poll stalls every other Tauri command.
     run_blocking("detect_session_statuses", move || {
-        detect_session_statuses_blocking(state, ids)
+        detect_session_statuses_blocking(state, ids, sync_agent_session_titles.unwrap_or(false))
     })
     .await
 }
@@ -7878,6 +7903,7 @@ fn hook_boot_reconciled_status(
 fn detect_session_statuses_blocking(
     state: AppState,
     ids: Vec<String>,
+    sync_agent_session_titles: bool,
 ) -> AppResult<Vec<SessionStatusEntry>> {
     // Fence every poll write against lifecycle events that arrive while the
     // process table and transcripts are being inspected. The clear-on-exit
@@ -8317,7 +8343,11 @@ fn detect_session_statuses_blocking(
             };
             if agent_metadata_applied && agent_binding_changed {
                 if let (Some(session), Some(transcript)) = (session.as_ref(), live.clone()) {
-                    crate::agent_session_names::enqueue_existing_title(session, transcript);
+                    crate::agent_session_names::enqueue_existing_title(
+                        sync_agent_session_titles,
+                        session,
+                        transcript,
+                    );
                 }
             }
             SessionStatusEntry {

--- a/src/components/ChatPane.test.tsx
+++ b/src/components/ChatPane.test.tsx
@@ -1990,6 +1990,7 @@ describe("ChatPane", () => {
     expect(mocks.renameSession).toHaveBeenCalledWith(
       "fork1",
       "Exploring chat runtime",
+      false,
     );
     const saved = mocks.saveChatSessionState.mock.calls[0]?.[0] as
       | ChatSessionState

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -1140,7 +1140,11 @@ export function ChatPane({
         worktreeMode === "same" && shouldAdoptSourceWorktree(session)
           ? await api.updateSessionWorktree(created.id, session!.worktree_path)
           : created;
-      const renamed = await api.renameSession(adopted.id, name);
+      const renamed = await api.renameSession(
+        adopted.id,
+        name,
+        settings.agents.syncAgentSessionTitles,
+      );
       const forkState = buildForkedChatState(state, renamed, forkMessages);
       await api.saveChatSessionState(forkState);
       await useAppStore.getState().refreshAll();

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1440,6 +1440,43 @@ describe("SettingsModal font controls", () => {
     });
   });
 
+  it("patches the agent session title sync toggle", async () => {
+    const patchAgents = vi.fn();
+    useSettings.setState({
+      settings: cloneSettings(),
+      patchAgents,
+    });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(<SettingsModal />);
+    });
+    openAgentsTab();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]'),
+    ).find((input) =>
+      input
+        .closest("label")
+        ?.textContent?.includes("Sync titles to Codex and Claude"),
+    );
+
+    expect(document.body.textContent).toContain("Agent title sync");
+    expect(toggle).toBeInstanceOf(HTMLInputElement);
+    expect(toggle?.checked).toBe(false);
+
+    act(() => {
+      toggle?.click();
+    });
+
+    expect(patchAgents).toHaveBeenCalledWith({
+      syncAgentSessionTitles: true,
+    });
+  });
+
   it("patches and resets the session title prompt", async () => {
     const patchAgents = vi.fn();
     useSettings.setState({

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2780,6 +2780,22 @@ function AgentSettings({
           </Tooltip>
         </div>
       </Field>
+      <Field
+        label={st(t, "settings.agents.sessionTitleSync.label")}
+        hint={st(t, "settings.agents.sessionTitleSync.hint")}
+      >
+        <label className="flex items-center gap-2 text-xs text-fg">
+          <input
+            type="checkbox"
+            checked={settings.agents.syncAgentSessionTitles}
+            onChange={(e) =>
+              patchAgents({ syncAgentSessionTitles: e.target.checked })
+            }
+            className="acorn-check"
+          />
+          {st(t, "settings.agents.sessionTitleSync.checkbox")}
+        </label>
+      </Field>
       <SessionTitlePromptModal
         open={sessionTitlePromptOpen}
         onClose={() => onSessionTitlePromptOpenChange(false)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -192,8 +192,16 @@ export const api = {
       goal,
     });
   },
-  renameSession(id: string, name: string): Promise<Session> {
-    return invoke<Session>("rename_session", { id, name });
+  renameSession(
+    id: string,
+    name: string,
+    syncAgentSessionTitles: boolean,
+  ): Promise<Session> {
+    return invoke<Session>("rename_session", {
+      id,
+      name,
+      syncAgentSessionTitles,
+    });
   },
   sessionTitleReadiness(id: string): Promise<SessionTitleReadinessResult> {
     return invoke<SessionTitleReadinessResult>("session_title_readiness", {
@@ -205,12 +213,14 @@ export const api = {
     ai: AiExecutionRequest,
     prompt: string,
     force = false,
+    syncAgentSessionTitles = false,
   ): Promise<GenerateSessionTitleResult> {
     return invoke<GenerateSessionTitleResult>("generate_session_title", {
       id,
       ai,
       prompt,
       force,
+      syncAgentSessionTitles,
     });
   },
   previewSessionTitle(
@@ -691,6 +701,7 @@ export const api = {
   },
   detectSessionStatuses(
     ids: string[],
+    syncAgentSessionTitles: boolean,
   ): Promise<
     {
       id: string;
@@ -734,7 +745,7 @@ export const api = {
         branch: string | null;
         auto_title_enabled?: boolean | null;
       }[]
-    >("detect_session_statuses", { ids });
+    >("detect_session_statuses", { ids, syncAgentSessionTitles });
   },
   /**
    * Inspect on-disk markers to determine which agent CLI (if any) the user has

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1493,6 +1493,10 @@ describe("AI commit command resolution", () => {
     expect(DEFAULT_SETTINGS.agents.autoGenerateSessionTitles).toBe(true);
   });
 
+  it("disables agent session title sync by default", () => {
+    expect(DEFAULT_SETTINGS.agents.syncAgentSessionTitles).toBe(false);
+  });
+
   it("loads a persisted automatic session title preference", async () => {
     localStorage.setItem(
       "acorn:settings:v1",
@@ -1505,6 +1509,20 @@ describe("AI commit command resolution", () => {
     expect(
       useSettings.getState().settings.agents.autoGenerateSessionTitles,
     ).toBe(false);
+  });
+
+  it("loads a persisted agent session title sync preference", async () => {
+    localStorage.setItem(
+      "acorn:settings:v1",
+      JSON.stringify({ agents: { syncAgentSessionTitles: true } }),
+    );
+
+    vi.resetModules();
+    const { useSettings } = await import("./settings");
+
+    expect(
+      useSettings.getState().settings.agents.syncAgentSessionTitles,
+    ).toBe(true);
   });
 
   it("keeps the default session title prompt in settings", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -351,6 +351,12 @@ export interface AcornSettings {
      */
     autoGenerateSessionTitles: boolean;
     /**
+     * Mirror Acorn's manual and generated terminal tab titles into matching
+     * Codex and Claude conversations. Default off because this changes
+     * provider-owned conversation metadata and transcript files.
+     */
+    syncAgentSessionTitles: boolean;
+    /**
      * Instructions prepended to transcript context when Acorn asks the
      * selected AI CLI to name a new session tab.
      */
@@ -556,6 +562,7 @@ export const DEFAULT_SETTINGS: AcornSettings = {
   agents: {
     selected: "claude",
     autoGenerateSessionTitles: true,
+    syncAgentSessionTitles: false,
     sessionTitlePrompt: DEFAULT_SESSION_TITLE_PROMPT,
     customCommand: "",
     ollama: { model: "" },
@@ -1173,6 +1180,7 @@ function loadSettings(): AcornSettings {
     const agentsRaw = (parsed.agents ?? {}) as {
       selected?: string;
       autoGenerateSessionTitles?: boolean;
+      syncAgentSessionTitles?: boolean;
       sessionTitlePrompt?: unknown;
       customCommand?: string;
       ollama?: { model?: string };
@@ -1341,6 +1349,10 @@ function loadSettings(): AcornSettings {
           typeof agentsRaw.autoGenerateSessionTitles === "boolean"
             ? agentsRaw.autoGenerateSessionTitles
             : DEFAULT_SETTINGS.agents.autoGenerateSessionTitles,
+        syncAgentSessionTitles:
+          typeof agentsRaw.syncAgentSessionTitles === "boolean"
+            ? agentsRaw.syncAgentSessionTitles
+            : DEFAULT_SETTINGS.agents.syncAgentSessionTitles,
         sessionTitlePrompt: normalizeSessionTitlePrompt(
           agentsRaw.sessionTitlePrompt,
           DEFAULT_SETTINGS.agents.sessionTitlePrompt,
@@ -1528,6 +1540,7 @@ interface SettingsState {
     patch: Partial<{
       selected: SelectedAgent;
       autoGenerateSessionTitles: boolean;
+      syncAgentSessionTitles: boolean;
       sessionTitlePrompt: string;
       customCommand: string;
       ollama: Partial<AcornSettings["agents"]["ollama"]>;
@@ -1698,6 +1711,9 @@ export const useSettings = create<SettingsState>((set, get) => ({
           ...(patch.selected !== undefined ? { selected: patch.selected } : {}),
           ...(patch.autoGenerateSessionTitles !== undefined
             ? { autoGenerateSessionTitles: patch.autoGenerateSessionTitles }
+            : {}),
+          ...(patch.syncAgentSessionTitles !== undefined
+            ? { syncAgentSessionTitles: patch.syncAgentSessionTitles }
             : {}),
           ...(patch.sessionTitlePrompt !== undefined
             ? {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -687,6 +687,11 @@
         "hint": "When enabled, acorn sends transcript context from a new agent session to the selected AI CLI and replaces the default tab name with a concise title.",
         "checkbox": "Auto-generate session titles"
       },
+      "sessionTitleSync": {
+        "label": "Agent title sync",
+        "hint": "When enabled, Acorn mirrors manual and generated terminal tab titles to the matching Codex or Claude conversation.",
+        "checkbox": "Sync titles to Codex and Claude"
+      },
       "sessionTitlePrompt": {
         "label": "Session title prompt",
         "hint": "Instructions sent before the transcript context. Leave blank to use the default prompt.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -687,6 +687,11 @@
         "hint": "켜면 새 에이전트 세션의 transcript context를 선택한 AI CLI로 보내고 기본 탭 이름을 간결한 제목으로 바꿉니다.",
         "checkbox": "세션 제목 자동 생성"
       },
+      "sessionTitleSync": {
+        "label": "에이전트 제목 동기화",
+        "hint": "켜면 수동 및 자동 생성된 터미널 탭 제목을 연결된 Codex 또는 Claude 대화 이름에 반영합니다.",
+        "checkbox": "Codex 및 Claude에 제목 동기화"
+      },
       "sessionTitlePrompt": {
         "label": "세션 제목 프롬프트",
         "hint": "transcript context 앞에 함께 보낼 지시문입니다. 비워 두면 기본 프롬프트를 사용합니다.",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2598,12 +2598,21 @@ describe("pollSessionStatuses", () => {
     mockApi.detectSessionStatuses.mockResolvedValueOnce([
       { id: "a2", status: "working", branch: "feat/a2-live" },
     ]);
+    useSettings.setState((state) => ({
+      settings: {
+        ...state.settings,
+        agents: {
+          ...state.settings.agents,
+          syncAgentSessionTitles: true,
+        },
+      },
+    }));
 
     await useAppStore
       .getState()
       .pollSessionStatuses(["a2", "missing", "a2"]);
 
-    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a2"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a2"], true);
     const sessions = useAppStore.getState().sessions;
     expect(sessions.find((s) => s.id === "a1")?.status).toBe("ready");
     expect(sessions.find((s) => s.id === "a2")?.status).toBe("working");
@@ -3020,13 +3029,21 @@ describe("pollSessionStatuses", () => {
     const second = useAppStore.getState().pollSessionStatuses(["a2"]);
 
     expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
-    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(1, ["a1"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(
+      1,
+      ["a1"],
+      false,
+    );
 
     releaseFirst();
     await Promise.all([first, second]);
 
     expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(2);
-    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(2, ["a2"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(
+      2,
+      ["a2"],
+      false,
+    );
     const sessions = useAppStore.getState().sessions;
     expect(sessions.find((s) => s.id === "a1")?.status).toBe("working");
     expect(sessions.find((s) => s.id === "a2")?.status).toBe("waiting_for_input");
@@ -3053,7 +3070,10 @@ describe("pollSessionStatuses", () => {
     const subset = useAppStore.getState().pollSessionStatuses(["a2"]);
 
     expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
-    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a1", "a2"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(
+      ["a1", "a2"],
+      false,
+    );
 
     releaseFull();
     await Promise.all([full, subset]);
@@ -3088,13 +3108,17 @@ describe("pollSessionStatuses", () => {
       .pollSessionStatuses(["a2"]);
 
     expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(1);
-    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a1"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenCalledWith(["a1"], false);
 
     releaseFull();
     await Promise.all([full, newSessionPoll]);
 
     expect(mockApi.detectSessionStatuses).toHaveBeenCalledTimes(2);
-    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(2, ["a2"]);
+    expect(mockApi.detectSessionStatuses).toHaveBeenNthCalledWith(
+      2,
+      ["a2"],
+      false,
+    );
     const sessions = useAppStore.getState().sessions;
     expect(sessions.find((s) => s.id === "a1")?.status).toBe("working");
     expect(sessions.find((s) => s.id === "a2")?.status).toBe("waiting_for_input");
@@ -3118,8 +3142,38 @@ describe("generateSessionTitle", () => {
     expect(mockApi.renameSession).not.toHaveBeenCalled();
   });
 
+  it("forwards the agent title sync preference when renaming", async () => {
+    await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    useSettings.setState((state) => ({
+      settings: {
+        ...state.settings,
+        agents: {
+          ...state.settings.agents,
+          syncAgentSessionTitles: true,
+        },
+      },
+    }));
+
+    await useAppStore.getState().renameSession("a1", "Manual title");
+
+    expect(mockApi.renameSession).toHaveBeenCalledWith(
+      "a1",
+      "Manual title",
+      true,
+    );
+  });
+
   it("merges the generated session title without refreshing all sessions", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
+    useSettings.setState((state) => ({
+      settings: {
+        ...state.settings,
+        agents: {
+          ...state.settings.agents,
+          syncAgentSessionTitles: true,
+        },
+      },
+    }));
     mockApi.generateSessionTitle.mockResolvedValueOnce(
       {
         status: "generated",
@@ -3141,6 +3195,7 @@ describe("generateSessionTitle", () => {
       ai,
       "Title prompt",
       false,
+      true,
     );
     expect(mockApi.listSessions).toHaveBeenCalledTimes(1);
     expect(useAppStore.getState().sessions[0]?.name).toBe(
@@ -3180,6 +3235,7 @@ describe("generateSessionTitle", () => {
       ai,
       "Title prompt",
       true,
+      false,
     );
     expect(useAppStore.getState().sessions[0]?.name).toBe("fresh-title");
   });

--- a/src/store.ts
+++ b/src/store.ts
@@ -1913,7 +1913,12 @@ export const useAppStore = create<AppStateModel>()(
           activeStatusPollAll = pollAll;
           activeStatusPollIds = new Set(idsToPoll);
           try {
-            const updates = await api.detectSessionStatuses(idsToPoll);
+            const syncAgentSessionTitles =
+              useSettings.getState().settings.agents.syncAgentSessionTitles;
+            const updates = await api.detectSessionStatuses(
+              idsToPoll,
+              syncAgentSessionTitles,
+            );
             const map = new Map(updates.map((u) => [u.id, u]));
             const pollObservedAt = new Date().toISOString();
             set((s) => {
@@ -3195,7 +3200,9 @@ export const useAppStore = create<AppStateModel>()(
     if (get().generatingSessionTitleIds[id]) return;
 
     try {
-      await api.renameSession(id, name);
+      const syncAgentSessionTitles =
+        useSettings.getState().settings.agents.syncAgentSessionTitles;
+      await api.renameSession(id, name, syncAgentSessionTitles);
       await get().refreshSessions();
       set({ error: null });
     } catch (e) {
@@ -3218,7 +3225,15 @@ export const useAppStore = create<AppStateModel>()(
       },
     }));
     try {
-      const result = await api.generateSessionTitle(id, ai, prompt, force);
+      const syncAgentSessionTitles =
+        useSettings.getState().settings.agents.syncAgentSessionTitles;
+      const result = await api.generateSessionTitle(
+        id,
+        ai,
+        prompt,
+        force,
+        syncAgentSessionTitles,
+      );
       resultStatus = result.status;
       const updated = result.session;
       if (result.status === "generated" && updated?.id) {

--- a/tests/e2e/background-sessions.spec.ts
+++ b/tests/e2e/background-sessions.spec.ts
@@ -209,8 +209,11 @@ test.describe("background sessions settings", () => {
       () =>
         (window as unknown as { __statusPollCalls?: unknown[] })
           .__statusPollCalls ?? [],
-    )) as Array<{ ids: string[] }>;
-    expect(statusPollCalls).toContainEqual({ ids: ["s-1"] });
+    )) as Array<{ ids: string[]; syncAgentSessionTitles: boolean }>;
+    expect(statusPollCalls).toContainEqual({
+      ids: ["s-1"],
+      syncAgentSessionTitles: false,
+    });
     await expect(
       page
         .locator('[data-panel-id="sidebar"]')

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1434,10 +1434,15 @@ test.describe("workspace kanban mode", () => {
     const calls = (await page.evaluate(
       () =>
         (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
-    )) as Array<{ id: string; name: string }>;
+    )) as Array<{
+      id: string;
+      name: string;
+      syncAgentSessionTitles: boolean;
+    }>;
     expect(calls[0]).toEqual({
       id: "rename-me",
       name: "renamed from kanban",
+      syncAgentSessionTitles: false,
     });
     await expect(
       board.getByRole("button", { name: "Open renamed from kanban" }),

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -28,7 +28,10 @@ test.describe("session lifecycle", () => {
     await page.addInitScript(() => {
       localStorage.setItem(
         "acorn:settings:v1",
-        JSON.stringify({ shortcuts: { renameItem: "F3" } }),
+        JSON.stringify({
+          shortcuts: { renameItem: "F3" },
+          agents: { syncAgentSessionTitles: true },
+        }),
       );
     });
     await tauri.respond("list_projects", [PROJECT]);
@@ -80,8 +83,16 @@ test.describe("session lifecycle", () => {
     const calls = (await page.evaluate(
       () =>
         (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
-    )) as Array<{ id: string; name: string }>;
-    expect(calls[0]).toEqual({ id: "s-1", name: "renamed" });
+    )) as Array<{
+      id: string;
+      name: string;
+      syncAgentSessionTitles: boolean;
+    }>;
+    expect(calls[0]).toEqual({
+      id: "s-1",
+      name: "renamed",
+      syncAgentSessionTitles: true,
+    });
   });
 
   test("double-clicking a project session row starts rename", async ({
@@ -114,10 +125,15 @@ test.describe("session lifecycle", () => {
     const calls = (await page.evaluate(
       () =>
         (window as unknown as { __renameCalls?: unknown[] }).__renameCalls,
-    )) as Array<{ id: string; name: string }>;
+    )) as Array<{
+      id: string;
+      name: string;
+      syncAgentSessionTitles: boolean;
+    }>;
     expect(calls[0]).toEqual({
       id: "s-1",
       name: "renamed from double click",
+      syncAgentSessionTitles: false,
     });
   });
 

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -49,6 +49,34 @@ test.describe("settings modal", () => {
     await expect(modal).toHaveCount(0);
   });
 
+  test("keeps agent title sync off by default and persists opt-in", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Agents|에이전트)$/ }).click();
+
+    const toggle = modal.getByRole("checkbox", {
+      name: /^(Sync titles to Codex and Claude|Codex 및 Claude에 제목 동기화)$/,
+    });
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw
+            ? JSON.parse(raw).agents?.syncAgentSessionTitles
+            : null;
+        }),
+      )
+      .toBe(true);
+  });
+
   test("downloads, selects, and removes a catalog theme", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

The provider-native title propagation introduced in #699 is now an explicit Settings opt-in and remains disabled by default.

1. **Persistent opt-in** — add `Settings → Agents → Agent title sync`, persist the choice in `acorn:settings:v1`, and default missing or new settings to `false`.
2. **Complete lifecycle gating** — carry the setting through manual rename, generated-title, and late transcript-binding paths so Codex and Claude are updated only after opt-in.
3. **Backend-safe default** — treat omitted Tauri arguments as disabled and drop disabled requests before the provider worker starts.
4. **Regression coverage** — cover defaults, persistence, UI interaction, invoke payloads, store forwarding, and the Rust worker gate.

## Expected impact

| Behavior | Before | After |
| --- | --- | --- |
| Fresh install or existing settings without the new key | Acorn titles automatically propagate to Codex and Claude | Provider-native titles remain unchanged |
| User enables Agent title sync | Always-on behavior | Manual and generated titles propagate across the full title lifecycle |
| Missing renderer argument | Native sync could still run through existing command behavior | Backend defaults to disabled |
| Acorn rename/title generation | Best-effort and non-blocking | Unchanged |

## Design notes

- The frontend settings store remains the persistence source of truth. Each title-producing/status-poll command carries the current value explicitly, avoiding a boot-time synchronization race with the first transcript-binding poll.
- The Rust gate sits ahead of worker creation, so disabled sessions do not launch Codex app-server or append Claude transcript metadata.
- Existing regular-terminal, user-owner, provider, transcript-id, and title-source checks remain intact.

## Test plan

- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 103 files, 1,180 tests passed
- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts tests/e2e/session-lifecycle.spec.ts` — 23 passed
- [x] `pnpm run build:frontend` — passed
- [x] `env -u ACORN_DATA_DIR -u ACORN_IPC_SOCKET cargo test --manifest-path src-tauri/Cargo.toml --workspace --quiet -- --test-threads=1` — workspace passed; main crate 642 passed, 1 ignored
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_session_names.rs src-tauri/src/commands.rs`
- [x] `git diff --check`

## Notes

- The Rust workspace test clears host Acorn data/socket overrides so the existing profile-resolution tests run against their own test profile rather than the active control session.