### PR TITLE
fix(kanban): keep arrow-key focus on session cards

### DIFF
--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -1334,6 +1334,15 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
     onOpen(session.id, event.currentTarget);
   }
 
+  function handleArrowKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
+    if (editing || event.altKey || event.ctrlKey || event.metaKey) return;
+    const direction = kanbanCardFocusDirection(event.key);
+    if (!direction) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onFocusAdjacent(session.id, direction);
+  }
+
   function handleKeyDown(event: ReactKeyboardEvent<HTMLElement>) {
     if (editing) return;
     if (
@@ -1351,10 +1360,6 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
       onOpen(session.id, event.currentTarget);
       return;
     }
-    const direction = kanbanCardFocusDirection(event.key);
-    if (!direction) return;
-    event.preventDefault();
-    onFocusAdjacent(session.id, direction);
   }
 
   async function submitRename(next: string) {
@@ -1550,6 +1555,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           onClick={editing ? undefined : handleOpen}
           onPointerDown={handlePointerDown}
           onContextMenu={handleContextMenu}
+          onKeyDownCapture={handleArrowKeyDown}
           onKeyDown={handleKeyDown}
           className="group flex w-full cursor-pointer flex-col gap-2 rounded-md border border-border bg-bg-elevated/45 p-2 text-left transition hover:border-accent/45 hover:bg-bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           aria-label={openLabel}

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1360,6 +1360,64 @@ test.describe("workspace kanban mode", () => {
     await expect(runner).toBeFocused();
   });
 
+  test("keeps arrow-key focus on session cards from nested card actions", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      session("alpha", "alpha", "ready"),
+      session("shell", "shell", "ready"),
+    ]);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test",
+      items: [
+        {
+          number: 902,
+          title: "Shell keyboard navigation",
+          state: "OPEN",
+          author: "ian",
+          head_branch: "feat/shell",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/902",
+          updated_at: "2026-01-01T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Kanban" }).click();
+
+    const board = page.getByTestId("workspace-kanban");
+    await board.getByLabel("Sort sessions").selectOption("name-asc");
+    const alpha = board.getByRole("button", { name: "Open alpha" });
+    const shell = board.getByRole("button", { name: "Open shell" });
+    const shellPrAction = shell
+      .getByTestId("workspace-kanban-card-context")
+      .getByRole("button", { name: "Open PR #902" });
+    await expect(shellPrAction).toBeVisible();
+
+    await shellPrAction.focus();
+    await expect(shellPrAction).toBeFocused();
+    await shellPrAction.press("ArrowUp");
+
+    await expect(alpha).toBeFocused();
+    expect(
+      await alpha.evaluate((element) => element.matches(":focus-visible")),
+    ).toBe(true);
+
+    await alpha.press("ArrowDown");
+    await expect(shell).toBeFocused();
+    expect(
+      await shell.evaluate((element) => element.matches(":focus-visible")),
+    ).toBe(true);
+  });
+
   test("card context menu and terminal popover header can rename a session", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Fixes Kanban keyboard navigation so one arrow-key press always lands on the adjacent session card, even when a nested card action owns focus.

1. **Capture directional navigation** — handle card arrow keys during event capture so nested PR controls cannot swallow the navigation event.
2. **Preserve focused-session feedback** — move focus directly to the destination card root and retain its visible keyboard focus ring.
3. **Add regression coverage** — start from a real nested PR action and verify both upward and downward navigation stay on session cards.

## Expected impact

| Flow | Before | After |
| --- | --- | --- |
| Arrow key from a nested card action | Focus can remain on the inner action, requiring another key press | First press focuses the adjacent session card |
| Card-to-card keyboard navigation | Works only when the card root already owns focus | Works from the card root or any nested card action |
| Canvas keyboard behavior | Unchanged | Unchanged |

## Design notes

- Directional navigation runs in the card capture phase, ahead of nested controls that intentionally stop bubbled keyboard events.
- Rename editing keeps native input arrow behavior. `Alt`, `Ctrl`, and `Meta` combinations remain available to application-level shortcuts.
- The destination remains the existing focusable card root, so no new focus target or selection state is introduced.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:e2e tests/e2e/kanban.spec.ts` — 23 passed
- [x] `pnpm test` — 103 files, 1,180 tests passed
- [x] `pnpm build`

## Notes

- Canvas arrow navigation is intentionally unchanged.