### PR TITLE
chore(deps): override brace-expansion to patched 5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "overrides": {
+      "brace-expansion": ">=5.0.8"
+    }
   },
   "type": "module",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: '>=5.0.8'
+
 importers:
 
   .:
@@ -1935,9 +1938,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.6:
     resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
@@ -4709,7 +4712,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5560,7 +5563,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Problem

`pnpm audit --audit-level=moderate` (CI `Frontend` job) started failing on every branch, including ones that touch no JavaScript at all. GHSA-mh99-v99m-4gvg was published against `brace-expansion <=5.0.7`, and that version reaches the tree transitively:

```
. > @storybook/react-vite@10.5.2 > @joshwooding/vite-plugin-react-docgen-typescript@0.7.0 > glob@13.0.6 > minimatch@10.2.5 > brace-expansion@5.0.7
```

`Frontend` is a required status check, so all three open Dependabot PRs (#715, #716, #717) are blocked — #715 only bumps an Actions SHA and still fails here. `main` itself would fail a re-run; its last green CI predates the advisory.

## Change

Pin the resolution to the patched line via a pnpm override rather than waiting for the whole Storybook dependency chain to re-release. The lockfile delta is limited to `brace-expansion` 5.0.7 → 5.0.8; `minimatch` is its only consumer, and the patch release only narrows the declared engines to `20 || >=22` (CI runs Node 22).

## Verification

- `pnpm audit --audit-level=moderate` locally: `No known vulnerabilities found`, exit 0
- Remaining CI checks on this PR

## Follow-up

This unblocks #715 and #717, which are otherwise green. #716 is a separate problem: it bundles `react-resizable-panels` 3.0.6 → 4.12.2, a breaking major that drops the `PanelGroup` / `PanelResizeHandle` exports and the `Panel` `order` prop, and needs a code migration.

The override can be dropped once the Storybook chain ships a `glob`/`minimatch` release that pulls in the patched version on its own.

https://claude.ai/code/session_01XVGPFS4yu1vsrrBzvjXiat
