### PR TITLE
chore(release): v1.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.29.0",
+  "version": "1.29.1",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.29.0"
+version = "1.29.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.29.1 from the latest green `main` at `731fabe`, containing every merged change since v1.29.0.

1. **Version synchronization:** updates `package.json`, Tauri config, Cargo manifest, and Cargo lock metadata from `1.29.0` to `1.29.1`.
2. **Release scope:** includes the workflow and Rust dependency updates in #715 and #717, the patched `brace-expansion` override in #718, and the frontend dependency refresh plus `react-resizable-panels` v4 migration in #719.
3. **Publication path:** prepares the exact commit that will be tagged `v1.29.1` for signed Apple Silicon and Intel macOS artifacts plus `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Application version | All runtime and packaging metadata report `1.29.1`. |
| Reliability and security | Ships patched frontend transitive dependencies and current Rust runtime dependencies. |
| Pane resizing | Preserves existing layout behavior on `react-resizable-panels` v4 while reducing layout persistence writes to drag completion. |
| Updater | The Release workflow will publish cumulative bilingual notes and signed artifacts for both supported macOS architectures. |

## Design notes

- This is a patch release because the range contains dependency security hardening, reliability updates, and a behavior-preserving library migration without a new user-visible feature or breaking Acorn contract.
- The release commit contains version metadata only; the four implementation PRs were reviewed and merged independently before this bump.
- Generated notes contain only #715, #717, #718, and #719 in the v1.29.1 section and include the required Korean and English summary blockquotes.
- The release tag will be created only after this PR passes CI and is merged into `main`.

## Follow-up (not in this PR)

- Push `v1.29.1` after merge and verify both signed macOS architectures, updater archives and signatures, `latest.json`, and release-note parity.

## Test plan

- [x] Latest `main` CI run `30231067520` passed at `731fabe`.
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root package reports `1.29.1`
- [x] `node scripts/validate-release-version.mjs v1.29.1`
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 3 files, 15 tests passed
- [x] `REPO=im-ian/acorn TAG=v1.29.1 OUTPUT=/tmp/acorn-release-notes-v1.29.1.md node scripts/release-notes.mjs` — cumulative notes generated successfully
- [x] Release-note checks — bilingual summaries present and v1.29.1 contains exactly #715, #717, #718, and #719
- [x] `git diff --check`

## Notes

- `v1.29.1` does not yet exist as a local tag, remote tag, or GitHub release.
- This PR uses `skip-changelog` so the metadata-only bump is not listed as a product change.
