### PR TITLE
fix(terminal): detect and open local file URL links

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -77,6 +77,7 @@ import {
   type ClipboardImageFile,
 } from "../lib/terminalPaste";
 import { normalizeShellCommandWhitespace } from "../lib/shellCommandWhitespace";
+import { fileUrlToPath } from "../lib/paths";
 import { saveClipboardImageAttachment } from "../lib/clipboardImageAttachment";
 import {
   createTerminalFileLinkProvider,
@@ -678,11 +679,10 @@ export function Terminal({
     // sees live changes without rebuilding the terminal.
     let linkActivation: TerminalLinkActivation =
       initialSettings.terminal.linkActivation;
-    // Hand link clicks to the OS so URLs open in the user's default browser
-    // instead of trying to navigate the Tauri WebView (which is gated by the
-    // app's CSP and would either fail or replace the app shell). When the user
-    // opts into modifier-click activation, plain clicks are swallowed so a
-    // stray click on a URL in shell output doesn't steal focus.
+    // Hand web links to the OS instead of navigating the Tauri WebView. Explicit
+    // file URLs open in Acorn after the click grants that one external file;
+    // terminal output alone must not expand the viewer's filesystem scope.
+    // Modifier-click mode swallows plain clicks for both link kinds.
     let linkTooltipFrame: number | null = null;
     let linkTooltipHideTimer: number | null = null;
     const cancelLinkTooltipHide = () => {
@@ -726,12 +726,25 @@ export function Terminal({
         setLinkTooltip(null);
       }, LINK_TOOLTIP_HIDE_GRACE_MS);
     };
-    const activateExternalLink = (event: MouseEvent, uri: string) => {
+    const activateTerminalUri = (event: MouseEvent, uri: string) => {
       event.preventDefault();
       hideLinkTooltip(true);
       if (linkActivation === "modifier-click" && !modifierHeld(event)) {
         return;
       }
+      const filePath = fileUrlToPath(uri);
+      if (filePath) {
+        void api
+          .fsGrantExternalFile(filePath)
+          .then(() => {
+            useAppStore.getState().openCodeViewerTab(filePath, cwd);
+          })
+          .catch((err: unknown) => {
+            console.error("failed to open terminal file link", uri, err);
+          });
+        return;
+      }
+      if (/^file:/iu.test(uri)) return;
       void openUrl(uri).catch((err: unknown) => {
         console.error("failed to open terminal link", uri, err);
       });
@@ -748,7 +761,7 @@ export function Terminal({
       showLinkTooltip(uri, range);
     };
     term.options.linkHandler = {
-      activate: activateExternalLink,
+      activate: activateTerminalUri,
       hover: (_event, uri, range) => {
         hoverExternalLink(uri, range as IViewportRange);
       },
@@ -877,7 +890,7 @@ export function Terminal({
     };
     let webLinksDisposable: IDisposable | null = term.registerLinkProvider(
       createTerminalWebLinkProvider(term, {
-        activate: activateExternalLink,
+        activate: activateTerminalUri,
         hover: (_event, uri, link) => {
           hoverExternalLink(uri, link.range);
         },

--- a/src/lib/fileDrop.ts
+++ b/src/lib/fileDrop.ts
@@ -1,3 +1,5 @@
+import { fileUrlToPath } from "./paths";
+
 interface DataTransferItemLike {
   kind: string;
 }
@@ -40,25 +42,6 @@ function getTransferData(
   } catch {
     return "";
   }
-}
-
-function fileUrlToPath(value: string): string | null {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    return null;
-  }
-  if (url.protocol !== "file:") return null;
-
-  let path = decodeURIComponent(url.pathname);
-  if (/^\/[a-zA-Z]:\//u.test(path)) {
-    path = path.slice(1);
-  }
-  if (url.hostname && url.hostname !== "localhost") {
-    return `//${url.hostname}${path}`;
-  }
-  return path;
 }
 
 function collectUriListPaths(value: string, paths: string[]): void {

--- a/src/lib/paths.test.ts
+++ b/src/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { joinPath } from "./paths";
+import { fileUrlToPath, joinPath } from "./paths";
 
 describe("joinPath", () => {
   it("joins base and relative with a single separator", () => {
@@ -28,5 +28,38 @@ describe("joinPath", () => {
 
   it("handles empty relative", () => {
     expect(joinPath("/Users/me/repo", "")).toBe("/Users/me/repo/");
+  });
+});
+
+describe("fileUrlToPath", () => {
+  it("decodes local file URLs", () => {
+    expect(
+      fileUrlToPath(
+        "file:///Users/me/generated/preview%20image-%EC%9E%90%EB%A6%AC.png",
+      ),
+    ).toBe("/Users/me/generated/preview image-자리.png");
+  });
+
+  it("accepts localhost and case-insensitive file schemes", () => {
+    expect(fileUrlToPath("FILE://LOCALHOST/Users/me/report.txt")).toBe(
+      "/Users/me/report.txt",
+    );
+  });
+
+  it("keeps Windows drive paths usable", () => {
+    expect(fileUrlToPath("file:///C:/Users/me/Desktop/a.txt")).toBe(
+      "C:/Users/me/Desktop/a.txt",
+    );
+  });
+
+  it("maps non-local hosts to UNC paths", () => {
+    expect(fileUrlToPath("file://server/share/report.pdf")).toBe(
+      "//server/share/report.pdf",
+    );
+  });
+
+  it("rejects non-file and malformed URLs", () => {
+    expect(fileUrlToPath("https://example.test/file.png")).toBeNull();
+    expect(fileUrlToPath("file:///tmp/bad%escape.png")).toBeNull();
   });
 });

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -10,3 +10,27 @@ export function joinPath(base: string, rel: string): string {
   if (base.endsWith("/")) return `${base}${trimmed}`;
   return `${base}/${trimmed}`;
 }
+
+export function fileUrlToPath(value: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "file:") return null;
+
+  let path: string;
+  try {
+    path = decodeURIComponent(url.pathname);
+  } catch {
+    return null;
+  }
+  if (/^\/[a-zA-Z]:\//u.test(path)) {
+    path = path.slice(1);
+  }
+  if (url.hostname && url.hostname !== "localhost") {
+    return `//${url.hostname}${path}`;
+  }
+  return path;
+}

--- a/src/lib/terminalWebLinks.test.ts
+++ b/src/lib/terminalWebLinks.test.ts
@@ -81,9 +81,71 @@ describe("terminal web links", () => {
     });
   });
 
+  it.each([
+    [
+      "POSIX paths",
+      "file:///Users/jthefloor/.codex/generated_images/019fac49-00b2-75e0-864d-5c2d6951e441/exec-59ed6210-8c1d-440b-916d-26f791750b80.png",
+    ],
+    ["localhost paths", "file://localhost/Users/me/report.txt"],
+    ["Windows drive paths", "file:///C:/Users/me/report.txt"],
+    ["UNC paths", "file://server/share/report.txt"],
+    ["case-insensitive schemes", "FILE:///Users/me/report.txt"],
+    [
+      "parenthesized file names",
+      "file:///Users/me/Desktop/Screenshot%20(1).png",
+    ],
+  ])("provides local file URL links for %s", (_label, uri) => {
+    const provider = createTerminalWebLinkProvider(
+      makeTerminalWithLines([makeBufferLine(`Saved to: (${uri}).`)]),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links?.[0]?.text).toBe(uri);
+      expect(links?.[0]?.range).toEqual({
+        start: { x: 12, y: 1 },
+        end: { x: 11 + uri.length, y: 1 },
+      });
+    });
+  });
+
+  it("provides file URL links across wrapped terminal lines", () => {
+    const firstLine =
+      "Saved to: file:///Users/me/.codex/generated_images/";
+    const secondLine = "run/preview.png";
+    const provider = createTerminalWebLinkProvider(
+      makeTerminalWithLines([
+        makeBufferLine(firstLine),
+        makeBufferLine(secondLine, undefined, true),
+      ]),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(2, (links) => {
+      expect(links?.[0]?.text).toBe(
+        "file:///Users/me/.codex/generated_images/run/preview.png",
+      );
+      expect(links?.[0]?.range).toEqual({
+        start: { x: 11, y: 1 },
+        end: { x: secondLine.length, y: 2 },
+      });
+    });
+  });
+
   it("skips URL-shaped text that cannot parse as a URL", () => {
     const provider = createTerminalWebLinkProvider(
       makeTerminalWithLines([makeBufferLine("open https://")]),
+      { activate: () => undefined },
+    );
+
+    provider.provideLinks(1, (links) => {
+      expect(links).toBeUndefined();
+    });
+  });
+
+  it("skips file URLs that cannot convert to paths", () => {
+    const provider = createTerminalWebLinkProvider(
+      makeTerminalWithLines([makeBufferLine("open file:///tmp/bad%escape.png")]),
       { activate: () => undefined },
     );
 

--- a/src/lib/terminalWebLinks.ts
+++ b/src/lib/terminalWebLinks.ts
@@ -3,6 +3,7 @@ import type {
   ILinkProvider,
   Terminal as XTerm,
 } from "@xterm/xterm";
+import { fileUrlToPath } from "./paths";
 
 export interface TerminalWebLinkProviderOptions {
   activate: (event: MouseEvent, uri: string) => void;
@@ -12,7 +13,7 @@ export interface TerminalWebLinkProviderOptions {
 }
 
 const STRICT_URL_RE =
-  /(https?|HTTPS?):[/]{2}[^\s"'!*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]/;
+  /(?:https?:[/]{2}[^\s"'!*(){}|\\\^<>`]*[^\s"':,.!?{}|\\\^~\[\]`()<>]|file:[/]{2}[^\s"'<>`]+)/i;
 
 export function createTerminalWebLinkProvider(
   terminal: XTerm,
@@ -49,7 +50,7 @@ function computeWebLinks(
   let match: RegExpExecArray | null;
 
   while ((match = regex.exec(line)) !== null) {
-    const text = match[0];
+    const text = trimDetectedUrl(match[0]);
     if (!isUrl(text)) continue;
 
     const [startY, startX] = mapStringIndex(
@@ -90,6 +91,40 @@ function computeWebLinks(
   }
 
   return links;
+}
+
+function trimDetectedUrl(value: string): string {
+  if (!/^file:/iu.test(value)) return value;
+
+  // File URL serializers leave balanced brackets unescaped, while terminal
+  // prose commonly appends punctuation or one unmatched closing delimiter.
+  let end = value.length;
+  while (end > 0) {
+    const char = value[end - 1];
+    if (".,!?;:".includes(char)) {
+      end -= 1;
+      continue;
+    }
+    const opener =
+      char === ")" ? "(" : char === "]" ? "[" : char === "}" ? "{" : null;
+    if (
+      opener &&
+      countCharacter(value, char, end) > countCharacter(value, opener, end)
+    ) {
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+  return value.slice(0, end);
+}
+
+function countCharacter(value: string, target: string, end: number): number {
+  let count = 0;
+  for (let index = 0; index < end; index += 1) {
+    if (value[index] === target) count += 1;
+  }
+  return count;
 }
 
 function getWindowedLineStrings(
@@ -173,6 +208,7 @@ function mapStringIndex(
 function isUrl(value: string): boolean {
   try {
     const url = new URL(value);
+    if (url.protocol === "file:" && !fileUrlToPath(value)) return false;
     const parsedBase =
       url.password && url.username
         ? `${url.protocol}//${url.username}:${url.password}@${url.host}`

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -2231,6 +2231,118 @@ test.describe("terminal: spawn", () => {
     ).toHaveCount(0);
   });
 
+  test("opens terminal file URLs in Acorn after click", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __fileUrlLinkChannelId?: number;
+      };
+      w.__fileUrlLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_grant_external_file", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fileUrlGrants?: string[] };
+      w.__fileUrlGrants = [...(w.__fileUrlGrants ?? []), path];
+      return null;
+    });
+    await tauri.handle("fs_prepare_asset", (args) => {
+      const { path } = args as { path: string };
+      const w = window as unknown as { __fileUrlGrants?: string[] };
+      if (!w.__fileUrlGrants?.includes(path)) {
+        throw new Error(`terminal file URL was not granted: ${path}`);
+      }
+      return { size: 512 };
+    });
+    await tauri.handle("fs_read_file", () => {
+      throw new Error("terminal image file URLs should use the media viewer");
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __fileUrlLinkChannelId?: number })
+              .__fileUrlLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const uri =
+      "file:///Users/tester/.codex/generated_images/run/preview%20image%20(1).png";
+    const path =
+      "/Users/tester/.codex/generated_images/run/preview image (1).png";
+    await emitSubscribedPtyOutput(
+      page,
+      "__fileUrlLinkChannelId",
+      `Saved to: ${uri}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(uri);
+
+    const textRect = await terminalTextRect(page, uri);
+    expect(textRect).not.toBeNull();
+    const x = textRect!.left + Math.min(12, textRect!.width / 2);
+    const y = (textRect!.top + textRect!.bottom) / 2;
+    await page.mouse.move(x, y);
+    await page.waitForTimeout(50);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __fileUrlGrants?: string[] })
+            .__fileUrlGrants ?? [],
+      ),
+    ).toEqual([]);
+
+    await page.mouse.click(x, y);
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __fileUrlGrants?: string[] })
+              .__fileUrlGrants ?? [],
+        ),
+      )
+      .toContain(path);
+    await expect(
+      page.getByRole("button", { name: /preview image \(1\)\.png Close tab/ }),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-acorn-media-viewer="image"]'),
+    ).toBeVisible();
+    await expect(page.locator('img[alt="preview image (1).png"]')).toBeVisible();
+  });
+
   test("keeps modifier-click link tooltip mounted while output streams", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Terminal output now recognizes local `file://` URLs and opens them safely in Acorn.

1. **File URL detection** — recognize POSIX, localhost, Windows-drive, and UNC file URLs, including wrapped output and balanced parentheses in filenames.
2. **Safe local opening** — decode file URLs and grant external-file access only after the user activates the link, then route the target through Acorn's code/media viewer.
3. **Shared path conversion** — reuse one file-URL-to-path implementation for terminal links and native file drops.
4. **Regression coverage** — cover encoding, scheme casing, punctuation, wrapping, malformed URLs, permission timing, and media-viewer opening.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Generated-image output | `file:///...` text is not clickable | The generated file opens in Acorn |
| Encoded or parenthesized names | The URL can be missed or truncated | The complete decoded path opens correctly |
| Filesystem scope | External file URLs cannot open | Access is granted only when the user activates the link |

## Design notes

- Web URLs continue to use the OS opener; file URLs route through the existing Acorn file-viewer tab flow.
- Terminal output can point outside the project, such as `~/.codex/generated_images`. Detection and hover do not expand filesystem scope; `fs_grant_external_file` runs only after a valid activation gesture.
- The detector trims prose punctuation and only unmatched closing delimiters, preserving balanced parentheses and brackets that belong to a filename.

## Test plan

- [x] `pnpm run test` — 103 files, 1,193 tests passed
- [x] `pnpm run test:e2e` — 273 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — production build passed
