### PR TITLE
fix(github): let manual PR refresh supersede polling

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -3307,6 +3307,7 @@ function PullRequestsTab({
         <RefreshButton
           onClick={() => void fetchActivePrs()}
           loading={loading}
+          allowWhileLoading
           size={12}
         />
       </div>

--- a/src/components/ui/RefreshButton.tsx
+++ b/src/components/ui/RefreshButton.tsx
@@ -8,6 +8,8 @@ interface RefreshButtonProps {
   onClick: () => void | Promise<void>;
   /** Parent-owned in-flight flag. true → spin, false→true edge → show ✓. */
   loading: boolean;
+  /** Keep the action available when the caller can safely supersede an older request. */
+  allowWhileLoading?: boolean;
   /** Icon size in px. Default 14. */
   size?: number;
   /** Tooltip + accessible name. */
@@ -28,6 +30,7 @@ const FADE_MS = 250;
 export function RefreshButton({
   onClick,
   loading,
+  allowWhileLoading = false,
   size = 14,
   title = "Refresh",
   ariaLabel,
@@ -65,7 +68,7 @@ export function RefreshButton({
     <Tooltip label={title} side="bottom">
       <IconButton
         onClick={onClick}
-        disabled={loading}
+        disabled={loading && !allowWhileLoading}
         aria-label={ariaLabel ?? title}
         size="sm"
         className={cn("relative", className)}

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -139,6 +139,101 @@ test.describe("right panel: tab switching", () => {
     expect(colors.border).not.toBe("rgb(0, 0, 0)");
   });
 
+  test("manual PR refresh supersedes an in-flight automatic refresh", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.handle("list_pull_requests", (args) => {
+      const state = (args as { state?: string }).state;
+      if (state !== "open") {
+        return { kind: "ok", account: "test-account", items: [] };
+      }
+
+      const w = window as unknown as {
+        __openPrListCalls?: number;
+        __allowFreshPrList?: boolean;
+        __releaseStalePrLists?: boolean;
+        __settledStalePrLists?: number;
+      };
+      w.__openPrListCalls = (w.__openPrListCalls ?? 0) + 1;
+      const listing = (number: number, title: string) => ({
+        kind: "ok",
+        account: "test-account",
+        items: [
+          {
+            number,
+            title,
+            state: "OPEN",
+            author: "im-ian",
+            head_branch: `fix/pr-${number}`,
+            base_branch: "main",
+            url: `https://github.com/im-ian/acorn/pull/${number}`,
+            updated_at: `2026-07-28T08:${number}:00Z`,
+            closed_at: null,
+            merged_at: null,
+            is_draft: false,
+            checks: null,
+            labels: [],
+          },
+        ],
+      });
+
+      if (!w.__allowFreshPrList) {
+        return new Promise((resolve) => {
+          const finishWhenReleased = () => {
+            if (w.__releaseStalePrLists) {
+              w.__settledStalePrLists = (w.__settledStalePrLists ?? 0) + 1;
+              resolve(listing(35, "Stale pull request list"));
+              return;
+            }
+            setTimeout(finishWhenReleased, 20);
+          };
+          finishWhenReleased();
+        });
+      }
+
+      return listing(36, "Fresh pull request list");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __openPrListCalls?: number })
+              .__openPrListCalls ?? 0,
+        ),
+      )
+      .toBeGreaterThan(0);
+
+    const refresh = page.getByRole("button", { name: "Refresh" });
+    await expect(refresh).toBeEnabled();
+    await page.evaluate(() => {
+      (window as unknown as { __allowFreshPrList?: boolean })
+        .__allowFreshPrList = true;
+    });
+    await refresh.click();
+    await expect(page.getByText("Fresh pull request list")).toBeVisible();
+
+    await page.evaluate(() => {
+      (window as unknown as { __releaseStalePrLists?: boolean })
+        .__releaseStalePrLists = true;
+    });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __settledStalePrLists?: number })
+              .__settledStalePrLists ?? 0,
+        ),
+      )
+      .toBeGreaterThan(0);
+    await expect(page.getByText("Stale pull request list")).toHaveCount(0);
+    await expect(page.getByText("Fresh pull request list")).toBeVisible();
+  });
+
   test("double-clicking a commit opens the diff modal before the diff finishes loading", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Manual PR refresh now remains actionable while an automatic GitHub list request is still in flight, so a newly created pull request can be fetched immediately instead of waiting for the next polling cycle.

1. **Manual refresh precedence** — opt the PR list into overlapping refreshes while preserving the shared refresh button's existing loading behavior everywhere else.
2. **Race regression coverage** — hold older automatic requests open, fetch a newer PR list manually, then resolve the stale requests and verify they cannot replace the fresh list.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| User refreshes while automatic PR polling is running | Refresh action is disabled and the click is dropped | A forced PR request starts immediately |
| Older automatic response finishes after manual refresh | User may remain on the older list until another poll | Existing request sequencing keeps the manual result visible |
| Other refresh buttons | Disabled while their request is running | Unchanged |

## Design notes

- `RefreshButton` gains an opt-in `allowWhileLoading` prop that defaults to `false`, so existing callers keep their current duplicate-request protection.
- `PullRequestsTab` already force-bypasses stale cache and guards responses by request sequence. The change exposes that existing safe supersession path to the user without adding backend retries or changing GitHub API behavior.

## Test plan

- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 103 files, 1,193 tests passed
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts` — 33 tests passed
- [x] `pnpm run build` — production frontend build passed
