### PR TITLE
fix(sidebar): highlight active project sessions across workspace views

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2370,10 +2370,7 @@ function ProjectGroupView({
                   <SessionRow
                     key={item.id}
                     session={item.session}
-                    active={
-                      workspaceViewMode === "panes" &&
-                      item.session.id === activeSessionId
-                    }
+                    active={item.session.id === activeSessionId}
                     onSelect={() =>
                       onSelectSession(item.folderId, item.session.id)
                     }
@@ -2387,9 +2384,7 @@ function ProjectGroupView({
                     key={item.id}
                     folderGroup={item.folderGroup}
                     projectFolders={projectFoldersForRows}
-                    activeSessionId={
-                      workspaceViewMode === "panes" ? activeSessionId : null
-                    }
+                    activeSessionId={activeSessionId}
                     active={
                       workspaceViewMode === "panes" &&
                       activeProjectFolderId === item.folderGroup.folder.id
@@ -3276,7 +3271,7 @@ function SessionRow({
         density: "sidebar",
         interactive: true,
         selected: active,
-        selectedClassName: "bg-bg-elevated shadow-sm",
+        selectedClassName: "acorn-tab-active-bg text-fg shadow-sm",
         surface: "sidebar",
         className: cn(
           "group flex w-full cursor-pointer items-start gap-1.5 text-left",
@@ -4631,7 +4626,7 @@ function LocalSessionRow({
         density: "sidebar",
         interactive: true,
         selected: active,
-        selectedClassName: "bg-bg-elevated shadow-sm",
+        selectedClassName: "acorn-tab-active-bg text-fg shadow-sm",
         surface: "sidebar",
         className: cn(
           "group flex w-full cursor-pointer items-start gap-1.5 text-left",

--- a/tests/e2e/sessions.spec.ts
+++ b/tests/e2e/sessions.spec.ts
@@ -1,6 +1,69 @@
 import { test, expect } from "./support";
 
 test.describe("sessions: list rendering", () => {
+  test("highlights the active session in the Projects panel", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "s-alpha",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+      {
+        id: "s-beta",
+        name: "beta",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:04Z",
+        last_message: null,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const projectsPanel = page.locator("aside").first();
+    const alpha = projectsPanel
+      .getByRole("button", { name: /^alpha main · Ready/ })
+      .first();
+    const beta = projectsPanel
+      .getByRole("button", { name: /^beta main · Ready/ })
+      .first();
+
+    await alpha.click();
+    await expect(alpha).toHaveClass(/acorn-tab-active-bg/);
+    await expect(beta).not.toHaveClass(/acorn-tab-active-bg/);
+
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+    await expect(alpha).toHaveClass(/acorn-tab-active-bg/);
+    await expect(beta).not.toHaveClass(/acorn-tab-active-bg/);
+
+    await beta.click();
+    await expect(beta).toHaveClass(/acorn-tab-active-bg/);
+    await expect(alpha).not.toHaveClass(/acorn-tab-active-bg/);
+  });
+
   test("each status renders its label", async ({ page, tauri }) => {
     await tauri.handle("list_projects", () => [
       {


### PR DESCRIPTION
## Summary
This makes the current session easier to identify in the Projects panel.

1. **Persistent active state** — keep the active session row selected in Panes, Canvas, and Kanban instead of limiting the indication to Panes.
2. **Subtle visual treatment** — reuse the existing theme-adaptive active-tab background, foreground, and shadow for project and local session rows.
3. **Regression coverage** — verify that the highlight follows selection and remains visible after switching to Canvas.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Projects panel | The active session could lose its selected appearance outside Panes | The active session stays subtly highlighted in every workspace view |
| Visual consistency | Sidebar selection used the generic elevated surface | Sidebar sessions reuse the established active-tab treatment |

## Design notes
- `activeSessionId` remains the single source of truth for the current session.
- Project-folder selection remains scoped to Panes; only session-row highlighting now persists across workspace views.
- The implementation reuses `acorn-tab-active-bg`, avoiding a new theme token or sidebar-specific CSS path.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 103 files, 1,193 tests passed
- [x] `pnpm run build`
- [x] `pnpm exec playwright test tests/e2e/sessions.spec.ts` — 4 passed