### PR TITLE
chore(release): v1.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.29.1",
+  "version": "1.29.2",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.29.1"
+version = "1.29.2"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.29.1"
+version = "1.29.2"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.29.2 from the latest green `main` at `2c3b10a`, containing every merged change since v1.29.1.

1. **Version synchronization:** updates `package.json`, Tauri config, Cargo manifest, and Cargo lock metadata from `1.29.1` to `1.29.2`.
2. **Release scope:** includes local file URL opening in #721, reliable manual GitHub PR refresh in #722, and persistent active-session highlighting across workspace views in #723.
3. **Publication path:** prepares the exact commit that will be tagged `v1.29.2` for signed Apple Silicon and Intel macOS artifacts plus `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Application version | All runtime and packaging metadata report `1.29.2`. |
| Terminal links | Local `file://` URLs open safely in Acorn's file viewer. |
| GitHub PR refresh | Manual refresh can supersede in-flight polling and show a newly created PR immediately. |
| Sidebar navigation | The active session remains highlighted across Panes, Canvas, and Kanban. |
| Updater | The Release workflow will publish cumulative bilingual notes and signed artifacts for both supported macOS architectures. |

## Design notes

- This is a patch release because the range contains three user-visible bug fixes without a new feature, breaking contract, protocol change, or migration.
- The release commit contains version metadata only; #721, #722, and #723 were reviewed and merged independently before this bump.
- Generated notes contain exactly #721, #722, and #723 in the v1.29.2 section and include the required Korean and English summary blockquotes.
- The release tag will be created only after this PR passes CI and is merged into `main`.

## Follow-up (not in this PR)

- Push `v1.29.2` after merge and verify both signed macOS architectures, updater archives and signatures, `latest.json`, and release-note parity.

## Test plan

- [x] Latest `main` CI run `30430906328` passed at `2c3b10a`.
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root package reports `1.29.2`.
- [x] `node scripts/validate-release-version.mjs v1.29.2`
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 3 files and 15 tests passed.
- [x] `REPO=im-ian/acorn TAG=v1.29.2 OUTPUT=/tmp/acorn-release-notes-v1.29.2.md node scripts/release-notes.mjs` — cumulative notes generated successfully.
- [x] Release-note checks — bilingual summaries are present and v1.29.2 contains exactly #721, #722, and #723.
- [x] `git diff --check`

## Notes

- `v1.29.2` does not yet exist as a local tag, remote tag, or GitHub release.
- This PR uses `skip-changelog` so the metadata-only bump is not listed as a product change.
