### PR TITLE
fix(status): classify dynamic Codex quota windows from duration metadata

### DIFF
--- a/src-tauri/src/token_usage.rs
+++ b/src-tauri/src/token_usage.rs
@@ -74,36 +74,20 @@ fn read_agent_token_usage() -> AgentTokenUsageSnapshot {
     let claude = read_claude_rate_limits();
 
     let mut metrics = Vec::with_capacity(4);
-    push_metric(
+    push_provider_metrics(
         &mut metrics,
         AgentTokenProvider::Codex,
-        AgentTokenWindow::FiveHour,
-        codex.five_hour,
+        codex,
         "~/.codex/sessions rate_limits",
         "No Codex 5h rate-limit event found",
-    );
-    push_metric(
-        &mut metrics,
-        AgentTokenProvider::Codex,
-        AgentTokenWindow::Weekly,
-        codex.weekly,
-        "~/.codex/sessions rate_limits",
         "No Codex weekly rate-limit event found",
     );
-    push_metric(
+    push_provider_metrics(
         &mut metrics,
         AgentTokenProvider::Claude,
-        AgentTokenWindow::FiveHour,
-        claude.five_hour,
+        claude,
         "~/.claude/token-widget/claude-rate-limits.json",
         "No Claude 5h statusline rate-limit capture found",
-    );
-    push_metric(
-        &mut metrics,
-        AgentTokenProvider::Claude,
-        AgentTokenWindow::Weekly,
-        claude.weekly,
-        "~/.claude/token-widget/claude-rate-limits.json",
         "No Claude weekly statusline rate-limit capture found",
     );
 
@@ -111,6 +95,57 @@ fn read_agent_token_usage() -> AgentTokenUsageSnapshot {
         metrics,
         updated_at,
     }
+}
+
+fn push_provider_metrics(
+    metrics: &mut Vec<AgentTokenUsageMetric>,
+    provider: AgentTokenProvider,
+    rate_limits: ProviderRateLimits,
+    fallback_source: &str,
+    five_hour_fallback_error: &str,
+    weekly_fallback_error: &str,
+) {
+    let has_reported_window = rate_limits.five_hour.is_some() || rate_limits.weekly.is_some();
+    if has_reported_window {
+        if let Some(five_hour) = rate_limits.five_hour {
+            push_metric(
+                metrics,
+                provider,
+                AgentTokenWindow::FiveHour,
+                Some(five_hour),
+                fallback_source,
+                five_hour_fallback_error,
+            );
+        }
+        if let Some(weekly) = rate_limits.weekly {
+            push_metric(
+                metrics,
+                provider,
+                AgentTokenWindow::Weekly,
+                Some(weekly),
+                fallback_source,
+                weekly_fallback_error,
+            );
+        }
+        return;
+    }
+
+    push_metric(
+        metrics,
+        provider,
+        AgentTokenWindow::FiveHour,
+        None,
+        fallback_source,
+        five_hour_fallback_error,
+    );
+    push_metric(
+        metrics,
+        provider,
+        AgentTokenWindow::Weekly,
+        None,
+        fallback_source,
+        weekly_fallback_error,
+    );
 }
 
 fn push_metric(
@@ -239,20 +274,33 @@ fn read_codex_rate_limits_from_sqlite() -> ProviderRateLimits {
 }
 
 fn parse_codex_rate_limits(value: &Value, source: &str) -> ProviderRateLimits {
-    ProviderRateLimits {
-        five_hour: parse_rate_limit_window(
-            value.get("primary"),
+    let mut parsed = ProviderRateLimits::default();
+    for (key, fallback_window) in [
+        ("primary", AgentTokenWindow::FiveHour),
+        ("secondary", AgentTokenWindow::Weekly),
+    ] {
+        let Some(value) = value.get(key) else {
+            continue;
+        };
+        let Some(rate_limit) = parse_rate_limit_window(
+            Some(value),
             &["used_percent"],
             &["reset_at", "resets_at"],
             source,
-        ),
-        weekly: parse_rate_limit_window(
-            value.get("secondary"),
-            &["used_percent"],
-            &["reset_at", "resets_at"],
-            source,
-        ),
+        ) else {
+            continue;
+        };
+        let window = match number(value.get("window_minutes")) {
+            Some(300.0) => AgentTokenWindow::FiveHour,
+            Some(10_080.0) => AgentTokenWindow::Weekly,
+            _ => fallback_window,
+        };
+        match window {
+            AgentTokenWindow::FiveHour => parsed.five_hour = Some(rate_limit),
+            AgentTokenWindow::Weekly => parsed.weekly = Some(rate_limit),
+        }
     }
+    parsed
 }
 
 fn read_claude_rate_limits() -> ProviderRateLimits {
@@ -625,8 +673,16 @@ mod tests {
     #[test]
     fn parses_codex_primary_and_secondary_windows() {
         let value: Value = serde_json::json!({
-            "primary": { "used_percent": 12, "resets_at": 1779860400 },
-            "secondary": { "used_percent": 34.5, "reset_at": 1779930000 }
+            "primary": {
+                "used_percent": 12,
+                "window_minutes": 300,
+                "resets_at": 1779860400
+            },
+            "secondary": {
+                "used_percent": 34.5,
+                "window_minutes": 10080,
+                "reset_at": 1779930000
+            }
         });
 
         let limits = parse_codex_rate_limits(&value, "codex");
@@ -637,6 +693,84 @@ mod tests {
         assert_eq!(five_hour.reset_at, Some(1779860400.0));
         assert_eq!(weekly.used_percent, 34.5);
         assert_eq!(weekly.reset_at, Some(1779930000.0));
+    }
+
+    #[test]
+    fn parses_weekly_codex_limit_from_primary_window_metadata() {
+        let value: Value = serde_json::json!({
+            "primary": {
+                "used_percent": 36,
+                "window_minutes": 10080,
+                "resets_at": 1785902976
+            },
+            "secondary": null
+        });
+
+        let limits = parse_codex_rate_limits(&value, "codex");
+
+        assert_eq!(limits.five_hour, None);
+        let weekly = limits.weekly.unwrap();
+        assert_eq!(weekly.used_percent, 36.0);
+        assert_eq!(weekly.reset_at, Some(1785902976.0));
+    }
+
+    #[test]
+    fn parses_five_hour_codex_limit_when_it_is_the_only_window() {
+        let value: Value = serde_json::json!({
+            "primary": {
+                "used_percent": 21,
+                "window_minutes": 300,
+                "resets_at": 1785902976
+            },
+            "secondary": null
+        });
+
+        let limits = parse_codex_rate_limits(&value, "codex");
+
+        let five_hour = limits.five_hour.unwrap();
+        assert_eq!(five_hour.used_percent, 21.0);
+        assert_eq!(five_hour.reset_at, Some(1785902976.0));
+        assert_eq!(limits.weekly, None);
+    }
+
+    #[test]
+    fn preserves_positional_fallback_for_codex_events_without_window_metadata() {
+        let value: Value = serde_json::json!({
+            "primary": { "used_percent": 12 },
+            "secondary": { "used_percent": 34.5 }
+        });
+
+        let limits = parse_codex_rate_limits(&value, "codex");
+
+        assert_eq!(limits.five_hour.unwrap().used_percent, 12.0);
+        assert_eq!(limits.weekly.unwrap().used_percent, 34.5);
+    }
+
+    #[test]
+    fn omits_unreported_windows_when_provider_has_usage() {
+        let mut metrics = Vec::new();
+        let limits = ProviderRateLimits {
+            five_hour: None,
+            weekly: Some(RateLimitWindow {
+                used_percent: 36.0,
+                reset_at: Some(1785902976.0),
+                source: "codex".to_string(),
+            }),
+        };
+
+        push_provider_metrics(
+            &mut metrics,
+            AgentTokenProvider::Codex,
+            limits,
+            "codex",
+            "missing 5h",
+            "missing weekly",
+        );
+
+        assert_eq!(metrics.len(), 1);
+        assert_eq!(metrics[0].window, AgentTokenWindow::Weekly);
+        assert_eq!(metrics[0].remaining_percent, Some(64.0));
+        assert_eq!(metrics[0].error, None);
     }
 
     #[test]
@@ -658,15 +792,15 @@ mod tests {
         writeln!(file).expect("end prefix line");
         writeln!(
             file,
-            r#"{{"payload":{{"type":"event_msg","rate_limits":{{"primary":{{"used_percent":42,"resets_at":1779860400}}}}}}}}"#
+            r#"{{"payload":{{"type":"event_msg","rate_limits":{{"primary":{{"used_percent":42,"window_minutes":10080,"resets_at":1779860400}},"secondary":null}}}}}}"#
         )
         .expect("write rate limit event");
         drop(file);
 
         let parsed = read_codex_rate_limits_from_session_file(&path).expect("rate limits");
 
-        assert_eq!(parsed.five_hour.unwrap().used_percent, 42.0);
-        assert_eq!(parsed.weekly, None);
+        assert_eq!(parsed.five_hour, None);
+        assert_eq!(parsed.weekly.unwrap().used_percent, 42.0);
         let tail = read_tail(&path, CODEX_SESSION_TAIL_BYTES)
             .expect("read tail")
             .text;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -558,8 +558,12 @@ function renderAgentTokenSummary(
     <>
       <span>{agentTokensPrefix(t)}</span>
       <span className="inline-flex items-center gap-2">
-        <TokenWindowReadout label="5h" value={fiveHourText ?? "-"} />
-        <TokenWindowReadout label="w" value={weeklyText ?? "-"} />
+        {fiveHourText ? (
+          <TokenWindowReadout label="5h" value={fiveHourText} />
+        ) : null}
+        {weeklyText ? (
+          <TokenWindowReadout label="w" value={weeklyText} />
+        ) : null}
       </span>
     </>
   );
@@ -606,9 +610,15 @@ function renderAgentTokenTooltip(
     );
   }
 
+  const reportedWindows = TOKEN_WINDOWS.filter(
+    (window) => tokenMetric(snapshot, provider, window) !== null,
+  );
+  const displayedWindows =
+    reportedWindows.length > 0 ? reportedWindows : TOKEN_WINDOWS;
+
   return (
     <span className="flex w-64 max-w-full flex-col gap-2">
-      {TOKEN_WINDOWS.map((window) => {
+      {displayedWindows.map((window) => {
         const metric = tokenMetric(snapshot, provider, window);
         return (
           <AgentTokenTooltipWindow

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -149,7 +149,7 @@ test.describe("status bar", () => {
     });
   }
 
-  test("shows only Codex token usage for an active Codex tab", async ({
+  test("shows both Codex windows when the 5h limit is reported", async ({
     page,
     tauri,
   }) => {
@@ -184,6 +184,45 @@ test.describe("status bar", () => {
     await expect(tooltip).toContainText("resets in 19h 27m");
     await expect(tooltip.locator("svg")).toHaveCount(5);
     await expect(tooltip).not.toContainText(/used|12%|34%/);
+  });
+
+  test("shows only the weekly Codex window when the 5h limit is absent", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      { ...BASE_SESSION, name: "codex", agent_provider: "codex" },
+    ]);
+    await tauri.respond("get_agent_token_usage", {
+      updated_at: 1779860000,
+      metrics: [
+        {
+          provider: "codex",
+          window: "weekly",
+          used_percent: 36,
+          remaining_percent: 64,
+          reset_at: 1779930000,
+          source: "~/.codex/sessions rate_limits",
+          error: null,
+        },
+      ],
+    });
+
+    await page.goto("/");
+    await enableAgentTokenUsage(page);
+
+    const tokenBadge = page.locator("footer").getByTestId("agent-token-usage");
+    await expect(tokenBadge).toContainText("tokens:");
+    await expect(tokenBadge).toContainText("w");
+    await expect(tokenBadge).toContainText("64%");
+    await expect(tokenBadge).not.toContainText("5h");
+
+    await tokenBadge.hover();
+    const tooltip = page.getByRole("tooltip");
+    await expect(tooltip).toContainText("weekly");
+    await expect(tooltip).toContainText("64% left");
+    await expect(tooltip).not.toContainText("5h");
   });
 
   test("shows only Claude token usage for an active Claude tab", async ({


### PR DESCRIPTION
## Summary
This keeps the status-bar quota readout aligned with the rate-limit windows Codex actually reports.

1. **Duration-aware classification** — classify Codex windows from `window_minutes` so a weekly-only `primary` limit is no longer mislabeled as 5h.
2. **Dynamic window rendering** — emit and render only reported quota windows while preserving 5h-only and 5h-plus-weekly states when the shorter limit is available.
3. **Regression coverage** — cover weekly-only, 5h-only, combined, and metadata-free Codex payloads plus the user-visible status-bar output.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Codex reports only the weekly limit | Weekly remaining percentage appears under `5h` | Only the weekly `w` readout appears |
| Codex restores the 5h limit | Relies on fixed primary/secondary positions | The 300-minute window appears as `5h`, alongside weekly when both are reported |
| Provider omits a quota window | Missing window remains visible as a placeholder/error | Only reported windows are shown when usable quota data exists |

## Design notes

- `window_minutes = 300` maps to the 5h window and `window_minutes = 10080` maps to the weekly window, regardless of whether Codex places it under `primary` or `secondary`.
- Payloads without `window_minutes` retain the established positional fallback for compatibility with older Codex session logs.
- The frontend continues to support both window types and replaces the complete usage snapshot on each poll, so a returning 5h window is restored without persisted state or migration work.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml token_usage::tests::` — 17 passed
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 103 files, 1,193 tests passed
- [x] `pnpm run build`
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts` — 9 passed
