### PR TITLE
fix(status): reconcile completed Codex turns without stale working state

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -570,11 +570,14 @@ pub struct SessionStore {
     /// (Start/Stop/NeedsInput/Error) *this run*. Runtime-only. The status
     /// poll consults hook activity to decide whether hooks own the
     /// Working/Ready/WaitingForInput classification: once a session proves
-    /// its hook channel is live, the transcript-tail poll stops second-guessing
-    /// turn completion (a long or tool-heavy Claude turn often leaves no
-    /// `end_turn` line inside the tail window, so the tail keeps reading
-    /// Working long after the turn ended) and only keeps ownership of the
-    /// process-liveness edge after no agent remains.
+    /// its hook channel is live, the transcript-tail poll stops heuristically
+    /// second-guessing turn completion (a long or tool-heavy Claude turn often
+    /// leaves no `end_turn` line inside the tail window, so the tail keeps
+    /// reading Working long after the turn ended). The one in-run exception is
+    /// a Codex `task_complete` carrying the exact current hook turn id, which
+    /// can be reconciled under this ledger's lock without admitting a stale
+    /// previous-turn completion. The poll otherwise only keeps ownership of
+    /// the process-liveness edge after no agent remains.
     ///
     /// Hook activity itself also persists across restarts via the session's
     /// `hook_active` field; this ledger distinguishes "confirmed live this run"
@@ -798,6 +801,46 @@ impl SessionStore {
         }
         entry.status = status;
         state.status_source = source;
+        Ok(Some(state.advance_lifecycle_revision()))
+    }
+
+    /// Reconcile a Codex completion observed in its durable transcript while
+    /// the native hook channel still owns status. The completed turn id is
+    /// checked under the same runtime lock as the lifecycle fence so a new
+    /// `UserPromptSubmit` cannot race an old `task_complete` into a resting
+    /// status.
+    pub fn reconcile_codex_turn_completion_if_current(
+        &self,
+        id: &Uuid,
+        expected_source: Option<AgentStatusSource>,
+        expected_lifecycle_revision: u64,
+        completed_turn_id: &str,
+    ) -> SessionResult<Option<u64>> {
+        let completed_turn_id = completed_turn_id.trim();
+        if completed_turn_id.is_empty() {
+            return Ok(None);
+        }
+
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if entry.status != SessionStatus::Working
+            || state.status_source != expected_source
+            || state.lifecycle_revision != expected_lifecycle_revision
+            || !state.confirmed
+            || !entry.hook_active
+            || entry.hook_provider != Some(SessionAgentProvider::Codex)
+            || state.turn_id.as_deref() != Some(completed_turn_id)
+        {
+            return Ok(None);
+        }
+
+        entry.status = SessionStatus::WaitingForInput;
+        state.status_source = Some(AgentStatusSource::TranscriptFallback);
+        state.permission_waiting_at = None;
         Ok(Some(state.advance_lifecycle_revision()))
     }
 
@@ -1632,6 +1675,84 @@ mod tests {
             store.get(&session.id).expect("session exists").status,
             SessionStatus::Working
         );
+    }
+
+    #[test]
+    fn matching_codex_transcript_completion_reconciles_hook_status() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let requested_at = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(123_456);
+
+        store.begin_hook_turn(&session.id, Some("turn-1"));
+        store
+            .apply_native_status(
+                &session.id,
+                SessionAgentProvider::Codex,
+                SessionStatus::Working,
+            )
+            .expect("session exists");
+        store.mark_codex_permission_waiting_at(&session.id, requested_at);
+        let (_, source, _, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+
+        assert!(store
+            .reconcile_codex_turn_completion_if_current(
+                &session.id,
+                source,
+                lifecycle_revision,
+                "turn-1",
+            )
+            .expect("session exists")
+            .is_some());
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+        assert_eq!(store.codex_permission_waiting_at(&session.id), None);
+    }
+
+    #[test]
+    fn codex_transcript_completion_cannot_overwrite_a_new_turn() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+
+        store.begin_hook_turn(&session.id, Some("turn-1"));
+        store
+            .apply_native_status(
+                &session.id,
+                SessionAgentProvider::Codex,
+                SessionStatus::Working,
+            )
+            .expect("session exists");
+        let (_, source, _, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+
+        // `begin_hook_turn` deliberately precedes the native status write.
+        // The turn-id check must close that narrow window even before the
+        // lifecycle revision advances.
+        store.begin_hook_turn(&session.id, Some("turn-2"));
+        assert_eq!(
+            store
+                .reconcile_codex_turn_completion_if_current(
+                    &session.id,
+                    source,
+                    lifecycle_revision,
+                    "turn-1",
+                )
+                .expect("session exists"),
+            None
+        );
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::Working
+        );
+        assert_eq!(store.hook_turn_id(&session.id).as_deref(), Some("turn-2"));
     }
 
     #[test]

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -38,7 +38,7 @@ use std::path::PathBuf;
 
 use acorn_agent::AgentKind;
 use acorn_pty::ShellHint;
-use acorn_transcript::{latest_turn_state, read_tail, TurnState};
+use acorn_transcript::{latest_turn_observation, read_tail, TurnObservation, TurnState};
 use serde::Serialize;
 
 use crate::session::SessionStatus;
@@ -65,11 +65,15 @@ pub enum StatusEvidence {
     Previous,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StatusDetection {
     pub status: SessionStatus,
     pub reason: Option<StatusReason>,
     pub evidence: StatusEvidence,
+    /// Codex turn identity carried by the completion event that produced
+    /// `TurnComplete`. Other providers and unscoped completion formats leave
+    /// this empty.
+    pub completed_provider_turn_id: Option<String>,
 }
 
 impl StatusDetection {
@@ -78,7 +82,13 @@ impl StatusDetection {
             status,
             reason,
             evidence,
+            completed_provider_turn_id: None,
         }
+    }
+
+    fn with_completed_provider_turn_id(mut self, provider_turn_id: Option<String>) -> Self {
+        self.completed_provider_turn_id = provider_turn_id;
+        self
     }
 }
 
@@ -131,17 +141,22 @@ pub fn detect_with_reason(
 
     let classified = read_tail(&path, TAIL_BYTES)
         .ok()
-        .and_then(|tail| latest_turn_state(kind, &tail.text, tail.read_full));
+        .and_then(|tail| latest_turn_observation(kind, &tail.text, tail.read_full));
 
     match classified {
-        Some(TurnState::Ready) => StatusDetection::new(
+        Some(TurnObservation {
+            state: TurnState::Ready,
+            provider_turn_id,
+        }) => StatusDetection::new(
             SessionStatus::Ready,
             Some(StatusReason::TurnComplete),
             StatusEvidence::Transcript,
-        ),
-        Some(TurnState::Working) => {
-            StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
-        }
+        )
+        .with_completed_provider_turn_id(provider_turn_id),
+        Some(TurnObservation {
+            state: TurnState::Working,
+            ..
+        }) => StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript),
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
         // to Ready. The next poll that lands on a real turn line corrects
@@ -202,7 +217,7 @@ mod tests {
     }
 
     fn classify_tail(kind: AgentKind, tail: &str, read_full: bool) -> Option<TurnState> {
-        latest_turn_state(kind, tail, read_full)
+        acorn_transcript::latest_turn_state(kind, tail, read_full)
     }
 
     #[test]
@@ -493,6 +508,7 @@ mod tests {
         assert_eq!(detection.status, SessionStatus::Ready);
         assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
         assert_eq!(detection.evidence, StatusEvidence::Transcript);
+        assert_eq!(detection.completed_provider_turn_id.as_deref(), Some("t1"));
     }
 
     #[test]

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -47,8 +47,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, U
 mod line;
 
 pub use line::{
-    assistant_message_text, collapse_preview, latest_turn_state, parse_transcript_line,
-    parse_transcript_value, read_tail, ParsedTranscriptLine, TailRead, TranscriptRole, TurnState,
+    assistant_message_text, collapse_preview, latest_turn_observation, latest_turn_state,
+    parse_transcript_line, parse_transcript_value, read_tail, ParsedTranscriptLine, TailRead,
+    TranscriptRole, TurnObservation, TurnState,
 };
 
 // Maximum age (mtime → now) of a transcript that will be paired with

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -29,6 +29,15 @@ pub enum TurnState {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TurnObservation {
+    pub state: TurnState,
+    /// Provider-scoped turn identity when the transcript event carries one.
+    /// Codex completion events use this to correlate a durable `task_complete`
+    /// with the native hook turn that currently owns session status.
+    pub provider_turn_id: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParsedTranscriptLine {
     /// Source timestamp for this transcript event, when the provider emits one.
     pub timestamp: Option<String>,
@@ -49,6 +58,7 @@ pub struct ParsedTranscriptLine {
     /// before any assistant role line has been seen.
     pub response_text: Option<String>,
     pub turn_state: Option<TurnState>,
+    pub provider_turn_id: Option<String>,
     pub session_id: Option<String>,
     pub cwd: Option<String>,
 }
@@ -65,6 +75,7 @@ impl Default for ParsedTranscriptLine {
             preview_text: None,
             response_text: None,
             turn_state: None,
+            provider_turn_id: None,
             session_id: None,
             cwd: None,
         }
@@ -94,12 +105,23 @@ pub fn parse_transcript_value(kind: AgentKind, value: &Value) -> ParsedTranscrip
 }
 
 pub fn latest_turn_state(kind: AgentKind, tail: &str, read_full: bool) -> Option<TurnState> {
+    latest_turn_observation(kind, tail, read_full).map(|observation| observation.state)
+}
+
+pub fn latest_turn_observation(
+    kind: AgentKind,
+    tail: &str,
+    read_full: bool,
+) -> Option<TurnObservation> {
     for line in tail_lines_newest_first(tail, read_full) {
         let Some(parsed) = parse_transcript_line(kind, line) else {
             continue;
         };
-        if parsed.turn_state.is_some() {
-            return parsed.turn_state;
+        if let Some(state) = parsed.turn_state {
+            return Some(TurnObservation {
+                state,
+                provider_turn_id: parsed.provider_turn_id,
+            });
         }
     }
     None
@@ -204,6 +226,10 @@ fn parse_codex_value(value: &Value) -> ParsedTranscriptLine {
         preview_text,
         response_text,
         turn_state: codex_turn_state(value),
+        provider_turn_id: string_at(Some(event), "turn_id")
+            .or_else(|| string_at(Some(event), "turn-id"))
+            .or_else(|| string_at(Some(value), "turn_id"))
+            .or_else(|| string_at(Some(value), "turn-id")),
         session_id: string_at(Some(event), "id")
             .or_else(|| string_at(Some(event), "session_id"))
             .or_else(|| string_at(Some(value), "session_id")),
@@ -1087,6 +1113,13 @@ mod tests {
         assert_eq!(
             classify(AgentKind::Codex, tail, true),
             Some(TurnState::Ready),
+        );
+        assert_eq!(
+            latest_turn_observation(AgentKind::Codex, tail, true),
+            Some(TurnObservation {
+                state: TurnState::Ready,
+                provider_turn_id: Some("t1".to_string()),
+            }),
         );
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7826,8 +7826,8 @@ pub async fn detect_session_statuses(
 /// Agent lifecycle hooks are the authoritative turn-boundary signal. While an
 /// agent process is alive under a hooked session the poll defers the entire
 /// Working/Ready/WaitingForInput distinction to the hook-set store value and
-/// does not consult the transcript tail at all, because the tail is stale in
-/// *both* directions around a turn boundary:
+/// does not apply ordinary transcript-tail classification, because the tail is
+/// stale in *both* directions around a turn boundary:
 /// - just after a turn ends, a long/tool-heavy turn's `end_turn` line may be
 ///   outside the 256 KiB window (or absent entirely), so the tail still reads
 ///   Working;
@@ -7842,8 +7842,9 @@ pub async fn detect_session_statuses(
 /// Once no matching agent process is live (the agent exited, another provider
 /// now owns the PTY, or an unrelated command owns the PTY), the poll drives
 /// status again.
-/// Trade-off: a dropped terminating hook can leave status lagging at the last
-/// hook value until the next hook or the agent exits.
+/// A scoped Codex `task_complete` can recover a dropped terminating hook when
+/// its turn id still matches the active hook turn. Providers without that
+/// correlation remain at the last hook value until the next hook or exit.
 fn poll_defers_to_hook(
     hook_active: bool,
     hook_provider: Option<AgentKind>,
@@ -7871,7 +7872,13 @@ fn fallback_agent_status_source(
     }
 }
 
-/// Recover a turn boundary that was crossed while the app was closed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum HookStatusReconciliation {
+    Boot,
+    CurrentCodexTurn(String),
+}
+
+/// Recover a hook-owned Working status from a durable turn-complete marker.
 ///
 /// `hook_active` persists across restarts, so right after boot the poll
 /// already defers to the persisted hook-set status. Durable hook delivery
@@ -7881,23 +7888,35 @@ fn fallback_agent_status_source(
 /// event of this run confirms the channel, allow exactly one recovery:
 /// Working -> WaitingForInput backed by a real turn-complete marker.
 ///
-/// One-directional on purpose: while the app is closed nobody can submit a
-/// prompt to the session, so a resting status cannot regress to Working
-/// offline and a stale-tail Working must never demote a persisted resting
-/// status. Once an event lands this run (`hook_confirmed_this_run`), hooks
-/// own both directions again and this reconciliation switches off — leaving
-/// it open in-run would recreate the UserPromptSubmit-vs-stale-tail race the
-/// full hook deference exists to close.
-fn hook_boot_reconciled_status(
+/// During the current run, Codex completion recovery is allowed only when the
+/// transcript carries a provider turn id. The store compares that id with the
+/// active native-hook turn under the lifecycle lock before applying it, so a
+/// new prompt cannot be overwritten by the previous turn's completion.
+fn hook_status_reconciliation(
     stored: SessionStatus,
     hook_confirmed_this_run: bool,
-    detection: session_status::StatusDetection,
-) -> Option<SessionStatus> {
-    (!hook_confirmed_this_run
-        && stored == SessionStatus::Working
-        && detection.status == SessionStatus::Ready
-        && detection.reason == Some(SessionStatusReason::TurnComplete))
-    .then_some(SessionStatus::WaitingForInput)
+    hook_provider: Option<AgentKind>,
+    detection: &session_status::StatusDetection,
+) -> Option<HookStatusReconciliation> {
+    if stored != SessionStatus::Working {
+        return None;
+    }
+    if detection.status != SessionStatus::Ready
+        || detection.reason != Some(SessionStatusReason::TurnComplete)
+        || detection.evidence != session_status::StatusEvidence::Transcript
+    {
+        return None;
+    }
+    if !hook_confirmed_this_run {
+        return Some(HookStatusReconciliation::Boot);
+    }
+    if hook_provider != Some(AgentKind::Codex) {
+        return None;
+    }
+    detection
+        .completed_provider_turn_id
+        .clone()
+        .map(HookStatusReconciliation::CurrentCodexTurn)
 }
 
 fn detect_session_statuses_blocking(
@@ -8207,27 +8226,45 @@ fn detect_session_statuses_blocking(
                         observed_hook_revision,
                         observed_lifecycle_revision,
                     ));
-                // Reconcile only while this app instance has not received a
-                // native event. The revision/source checks make the status
-                // and diagnostic provenance one conditional write.
-                let reconciliation_requested =
-                    hook_boot_reconciled_status(stored, hook_revision > 0, detection);
+                // Boot recovery is allowed before this app instance receives
+                // a native event. In-run recovery is limited to an exact
+                // Codex turn id; the store checks that id together with the
+                // revision/source fence in one conditional write.
+                let reconciliation_requested = hook_status_reconciliation(
+                    stored,
+                    hook_revision > 0,
+                    hook_provider,
+                    &detection,
+                );
                 let reconciled = parsed_id.and_then(|uuid| {
-                    reconciliation_requested.and_then(|reconciled| {
-                        state
-                            .sessions
-                            .refresh_status_and_source_if_lifecycle_revision(
-                                &uuid,
-                                stored,
-                                stored_source,
-                                lifecycle_revision,
-                                reconciled,
-                                Some(AgentStatusSource::TranscriptFallback),
-                            )
-                            .ok()
-                            .flatten()
-                            .map(|_| reconciled)
-                    })
+                    reconciliation_requested
+                        .as_ref()
+                        .and_then(|reconciliation| {
+                            let applied = match reconciliation {
+                                HookStatusReconciliation::Boot => state
+                                    .sessions
+                                    .refresh_status_and_source_if_lifecycle_revision(
+                                        &uuid,
+                                        stored,
+                                        stored_source,
+                                        lifecycle_revision,
+                                        SessionStatus::WaitingForInput,
+                                        Some(AgentStatusSource::TranscriptFallback),
+                                    ),
+                                HookStatusReconciliation::CurrentCodexTurn(completed_turn_id) => {
+                                    state.sessions.reconcile_codex_turn_completion_if_current(
+                                        &uuid,
+                                        stored_source,
+                                        lifecycle_revision,
+                                        completed_turn_id,
+                                    )
+                                }
+                            };
+                            applied
+                                .ok()
+                                .flatten()
+                                .map(|_| SessionStatus::WaitingForInput)
+                        })
                 });
                 if reconciliation_requested.is_some() && reconciled.is_none() {
                     metadata_write_allowed = false;
@@ -10345,14 +10382,16 @@ mod tests {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::Working,
                 false,
-                detection
+                None,
+                &detection,
             ),
-            Some(acorn_session::SessionStatus::WaitingForInput)
+            Some(super::HookStatusReconciliation::Boot)
         );
     }
 
@@ -10364,12 +10403,14 @@ mod tests {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::WaitingForInput,
                 false,
-                detection
+                None,
+                &detection,
             ),
             None
         );
@@ -10389,12 +10430,14 @@ mod tests {
             status: acorn_session::SessionStatus::Working,
             reason: None,
             evidence: super::session_status::StatusEvidence::Previous,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::WaitingForInput,
                 false,
-                detection
+                None,
+                &detection,
             ),
             None
         );
@@ -10406,32 +10449,75 @@ mod tests {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: Some("turn-1".to_string()),
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::WaitingForInput,
                 true,
-                detection
+                Some(super::AgentKind::Codex),
+                &detection,
             ),
             None
         );
     }
 
     #[test]
-    fn boot_reconciliation_is_off_once_a_hook_event_confirms_the_channel() {
-        // An event reached this run's hook server — hooks own both directions
-        // again; re-opening the transcript passthrough would recreate the
-        // UserPromptSubmit-vs-stale-tail race.
+    fn confirmed_hook_requires_a_scoped_codex_completion() {
+        // An unscoped completion cannot be correlated with the active turn,
+        // so it must not reopen the UserPromptSubmit-vs-stale-tail race.
         let detection = super::session_status::StatusDetection {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::Working,
                 true,
-                detection
+                Some(super::AgentKind::Codex),
+                &detection,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn confirmed_codex_hook_accepts_a_scoped_completion_candidate() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Ready,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: Some("turn-1".to_string()),
+        };
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                true,
+                Some(super::AgentKind::Codex),
+                &detection,
+            ),
+            Some(super::HookStatusReconciliation::CurrentCodexTurn(
+                "turn-1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn confirmed_non_codex_hook_rejects_a_scoped_completion() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::Ready,
+            reason: Some(super::SessionStatusReason::TurnComplete),
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: Some("turn-1".to_string()),
+        };
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                true,
+                Some(super::AgentKind::Claude),
+                &detection,
             ),
             None
         );
@@ -10445,12 +10531,14 @@ mod tests {
             status: acorn_session::SessionStatus::Working,
             reason: None,
             evidence: super::session_status::StatusEvidence::Previous,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::Ready,
                 false,
-                detection
+                None,
+                &detection,
             ),
             None
         );
@@ -10464,12 +10552,14 @@ mod tests {
             status: acorn_session::SessionStatus::Ready,
             reason: Some(super::SessionStatusReason::ShellPrompt),
             evidence: super::session_status::StatusEvidence::Process,
+            completed_provider_turn_id: None,
         };
         assert_eq!(
-            super::hook_boot_reconciled_status(
+            super::hook_status_reconciliation(
                 acorn_session::SessionStatus::Working,
                 false,
-                detection
+                None,
+                &detection,
             ),
             None
         );


### PR DESCRIPTION
## Summary
Codex sessions now recover from a missed terminating hook without remaining stuck in Working after the current turn has durably completed.

1. **Scoped transcript completion** — retain the provider turn ID from Codex completion records while preserving the existing turn-state API for other consumers.
2. **Race-safe reconciliation** — reconcile Working to WaitingForInput only when the transcript completion ID still matches the active native-hook turn under the session lifecycle lock.
3. **Provider isolation** — keep boot recovery intact, reject unscoped or stale completions, and leave Claude and Antigravity in-run hook behavior unchanged.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Codex completes but the terminating hook is missed | Session can remain Working until another hook arrives or the process exits | The next status poll reconciles the exact completed turn to WaitingForInput |
| A new prompt races an older transcript completion | In-run transcript recovery was disabled | The old completion is rejected by turn ID and lifecycle revision |
| Claude or Antigravity session | Hook-owned status behavior | Unchanged |

## Design notes

- Transcript parsing now exposes a provider-scoped turn observation while `latest_turn_state` remains available as the compatibility wrapper.
- The status detector carries a completion ID only when transcript evidence classified the turn as complete.
- `SessionStore` performs the status, provider, source, lifecycle revision, hook confirmation, and current turn-ID checks in one locked conditional update. This closes the narrow window between a new `begin_hook_turn` and its following native Working write.
- Successful reconciliation records `TranscriptFallback` provenance and clears stale Codex permission-waiting state.

## Follow-up (not in this PR)

- In-run recovery for providers without a safely correlated turn ID remains hook-only; adding parity requires a provider-specific identity or an Acorn-owned turn fence.

## Test plan

- [x] `rustfmt --edition 2021 --check` on the five changed Rust files
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-transcript codex_token_count_telemetry_is_skipped` — 1 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session codex_transcript_completion` — 2 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib reconciliation -- --test-threads=1` — 7 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib confirmed_ -- --test-threads=1` — 3 passed
- [x] `git diff --staged --check`

## Notes

- Workspace-wide `cargo fmt --all -- --check` currently reports pre-existing formatting drift in `acorn-daemon/src/protocol.rs`, `acorn-ipc/src/bin/acorn-ipc.rs`, and `src/pty_env.rs`; none of those files are changed by this PR.
