### PR TITLE
chore(release): v1.30.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.29.2",
+  "version": "1.30.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.29.2"
+version = "1.30.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.29.2"
+version = "1.30.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.29.2",
+  "version": "1.30.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.30.0 from the latest green `main` at `e986635`, containing every merged change since v1.29.2.

1. **Version synchronization:** updates `package.json`, Tauri config, Cargo manifest, and Cargo lock metadata from `1.29.2` to `1.30.0`.
2. **Release scope:** includes dynamic Codex quota-window classification in #725, completed-turn status reconciliation in #726, and full Simplified Chinese interface support in #727.
3. **Publication path:** prepares the exact commit that will be tagged `v1.30.0` for signed Apple Silicon and Intel macOS artifacts plus `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Application version | All runtime and packaging metadata report `1.30.0`. |
| Interface languages | Users can select and persist Simplified Chinese alongside English and Korean. |
| Codex status | Dynamic quota windows and completed turns no longer leave misleading working-state indicators. |
| Updater | The Release workflow will publish bilingual notes and signed artifacts for both supported macOS architectures. |

## Design notes

- This is a minor release because #727 adds a new user-visible interface language without a breaking contract, protocol change, or migration.
- The release commit contains version metadata only; #725, #726, and #727 were reviewed and merged independently before this bump.
- Generated notes contain exactly #725, #726, and #727 and include the required Korean and English summary blockquotes.
- The release tag will be created only after this PR passes CI and is merged into `main`.

## Follow-up (not in this PR)

- Push `v1.30.0` after merge and verify both signed macOS architectures, updater archives and signatures, `latest.json`, and release-note parity.

## Test plan

- [x] Latest `main` CI run `30525761097` passed at `e986635`.
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run typecheck`
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root package reports `1.30.0`.
- [x] `node scripts/validate-release-version.mjs v1.30.0`
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 3 files and 15 tests passed.
- [x] `REPO=im-ian/acorn TAG=v1.30.0 OUTPUT=/tmp/acorn-release-notes-v1.30.0.md node scripts/release-notes.mjs` — notes generated successfully.
- [x] Release-note checks — bilingual summaries are present and the notes contain exactly #725, #726, and #727.
- [x] `git diff --check`

## Notes

- `v1.30.0` does not yet exist as a local tag, remote tag, or GitHub release.
- This PR uses `skip-changelog` so the metadata-only bump is not listed as a product change.
