### PR TITLE
fix(status): stop Claude sessions getting stuck on the wrong status

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -541,6 +541,14 @@ struct HookRuntimeState {
     tool_started_at: Option<SystemTime>,
     turn_id: Option<String>,
     permission_waiting_at: Option<SystemTime>,
+    /// When an attention request (permission prompt, elicitation dialog) was
+    /// raised by a hook that has no resolving counterpart. Claude emits
+    /// `Notification`/`PermissionRequest` when the dialog opens but nothing
+    /// when the user answers, so the poll needs this instant to recognise a
+    /// transcript turn line written afterwards as proof the agent resumed.
+    /// Kept apart from `permission_waiting_at`, whose clearing rules belong
+    /// to the Codex turn lifecycle.
+    attention_at: Option<SystemTime>,
 }
 
 impl HookRuntimeState {
@@ -560,6 +568,7 @@ impl HookRuntimeState {
         self.tool_started_at = None;
         self.turn_id = None;
         self.permission_waiting_at = None;
+        self.attention_at = None;
     }
 }
 
@@ -977,6 +986,65 @@ impl SessionStore {
         self.lock_hook_runtime()
             .get(id)
             .and_then(|state| state.tool_started_at)
+    }
+
+    /// Record that an attention request without a resolving hook is open.
+    pub fn mark_attention_at(&self, id: &Uuid, requested_at: SystemTime) {
+        self.lock_hook_runtime()
+            .entry(*id)
+            .or_default()
+            .attention_at = Some(requested_at);
+    }
+
+    pub fn attention_at(&self, id: &Uuid) -> Option<SystemTime> {
+        self.lock_hook_runtime()
+            .get(id)
+            .and_then(|state| state.attention_at)
+    }
+
+    pub fn clear_attention(&self, id: &Uuid) {
+        if let Some(state) = self.lock_hook_runtime().get_mut(id) {
+            state.attention_at = None;
+        }
+    }
+
+    /// Resolve an open attention request from transcript evidence.
+    ///
+    /// Claude raises `Notification`/`PermissionRequest` when a dialog opens
+    /// and emits nothing when it closes, so `WaitingForInput` would otherwise
+    /// hold until the turn ends — the session reads as "needs you" through
+    /// minutes of tool calls the user already approved. A turn line written
+    /// after the request is the missing close: the agent only reaches it by
+    /// getting past the dialog. The attention instant, the lifecycle fence
+    /// and the visible status are compared under one lock so a dialog opened
+    /// during the poll's transcript read cannot be cleared by this write.
+    pub fn resolve_attention_if_current(
+        &self,
+        id: &Uuid,
+        expected_source: Option<AgentStatusSource>,
+        expected_lifecycle_revision: u64,
+        resumed_at: SystemTime,
+    ) -> SessionResult<Option<u64>> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if entry.status != SessionStatus::WaitingForInput
+            || state.status_source != expected_source
+            || state.lifecycle_revision != expected_lifecycle_revision
+            || !state.confirmed
+            || !entry.hook_active
+            || state.attention_at.is_none_or(|at| resumed_at <= at)
+        {
+            return Ok(None);
+        }
+
+        entry.status = SessionStatus::Working;
+        state.status_source = Some(AgentStatusSource::TranscriptFallback);
+        state.attention_at = None;
+        Ok(Some(state.advance_lifecycle_revision()))
     }
 
     pub fn mark_codex_permission_waiting_at(&self, id: &Uuid, requested_at: SystemTime) {

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -74,6 +74,9 @@ pub struct StatusDetection {
     /// `TurnComplete`. Other providers and unscoped completion formats leave
     /// this empty.
     pub completed_provider_turn_id: Option<String>,
+    /// Provider timestamp of the transcript line this detection classified.
+    /// Only transcript evidence carries one.
+    pub turn_timestamp: Option<String>,
 }
 
 impl StatusDetection {
@@ -83,11 +86,17 @@ impl StatusDetection {
             reason,
             evidence,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         }
     }
 
     fn with_completed_provider_turn_id(mut self, provider_turn_id: Option<String>) -> Self {
         self.completed_provider_turn_id = provider_turn_id;
+        self
+    }
+
+    fn with_turn_timestamp(mut self, timestamp: Option<String>) -> Self {
+        self.turn_timestamp = timestamp;
         self
     }
 }
@@ -147,16 +156,20 @@ pub fn detect_with_reason(
         Some(TurnObservation {
             state: TurnState::Ready,
             provider_turn_id,
+            timestamp,
         }) => StatusDetection::new(
             SessionStatus::Ready,
             Some(StatusReason::TurnComplete),
             StatusEvidence::Transcript,
         )
-        .with_completed_provider_turn_id(provider_turn_id),
+        .with_completed_provider_turn_id(provider_turn_id)
+        .with_turn_timestamp(timestamp),
         Some(TurnObservation {
             state: TurnState::Working,
+            timestamp,
             ..
-        }) => StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript),
+        }) => StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
+            .with_turn_timestamp(timestamp),
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
         // to Ready. The next poll that lands on a real turn line corrects

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -35,6 +35,10 @@ pub struct TurnObservation {
     /// Codex completion events use this to correlate a durable `task_complete`
     /// with the native hook turn that currently owns session status.
     pub provider_turn_id: Option<String>,
+    /// Provider timestamp of the classified line. Attention recovery compares
+    /// it against the moment the hook raised the attention request: a turn
+    /// line written afterwards proves the agent resumed past the dialog.
+    pub timestamp: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -121,6 +125,7 @@ pub fn latest_turn_observation(
             return Some(TurnObservation {
                 state,
                 provider_turn_id: parsed.provider_turn_id,
+                timestamp: parsed.timestamp,
             });
         }
     }

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -1521,6 +1521,13 @@ fn event_can_switch_provider(event: &AgentHookEvent) -> bool {
     )
 }
 
+/// Whether this Claude event is a dialog that stays open until the user acts.
+/// `Stop` also reports `NeedsInput`, but its close is the next
+/// `UserPromptSubmit`, so only the dialog sources need transcript recovery.
+fn claude_event_opens_attention_dialog(event: &AgentHookEvent) -> bool {
+    event.event == AgentHookEventKind::NeedsInput && event.source.as_deref() == Some("native")
+}
+
 fn apply_validated_agent_hook_event(
     sessions: &SessionStore,
     event: AgentHookEvent,
@@ -1540,6 +1547,14 @@ fn apply_validated_agent_hook_event(
         }
         if effects.mark_tool_started {
             sessions.mark_hook_tool_started_at(&event.session_id, SystemTime::now());
+        }
+    }
+
+    if event.provider == SessionAgentProvider::Claude {
+        if claude_event_opens_attention_dialog(&event) {
+            sessions.mark_attention_at(&event.session_id, SystemTime::now());
+        } else {
+            sessions.clear_attention(&event.session_id);
         }
     }
 
@@ -2057,7 +2072,7 @@ fn parse_raw_claude_hook_request(
         // wake the turn later, but suppressing Stop for them left no event to
         // recover from: a stalled background agent or a session-lifetime cron
         // registration pinned the session at Working with nothing to clear it.
-        "Stop" => (AgentHookEventKind::NeedsInput, "native"),
+        "Stop" => (AgentHookEventKind::NeedsInput, "native_stop"),
         "Notification" | "PermissionRequest" => (AgentHookEventKind::NeedsInput, "native"),
         "Error" => (AgentHookEventKind::Error, "native"),
         // The settings file registers exactly the events above; anything
@@ -5379,6 +5394,174 @@ mod tests {
         )
         .starts_with("HTTP/1.1 400 Bad Request"));
         assert!(rx.recv_timeout(Duration::from_millis(50)).is_err());
+    }
+
+    fn claude_reducer_fixture() -> (
+        Arc<acorn_session::SessionStore>,
+        Uuid,
+        Arc<AgentHookReducer>,
+    ) {
+        let sessions = acorn_session::SessionStore::new();
+        let mut session = Session::new(
+            "Claude".to_string(),
+            "/tmp/repo".into(),
+            "/tmp/repo".into(),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.agent_provider = Some(SessionAgentProvider::Claude);
+        let session_id = session.id;
+        sessions.insert(session);
+        let reducer = Arc::new(AgentHookReducer::new(sessions.clone()));
+        (sessions, session_id, reducer)
+    }
+
+    fn claude_event(session_id: Uuid, event: AgentHookEventKind, source: &str) -> AgentHookEvent {
+        AgentHookEvent {
+            session_id,
+            provider: SessionAgentProvider::Claude,
+            event,
+            message: None,
+            source: Some(source.to_string()),
+            lifecycle_id: None,
+            provider_session_id: None,
+            provider_turn_id: None,
+            provider_tool_id: None,
+            provider_version: None,
+            native_hooks_enabled: None,
+            ownership: AgentHookOwnership::Owner,
+        }
+    }
+
+    #[test]
+    fn claude_dialog_marks_attention_and_turn_boundaries_clear_it() {
+        let (sessions, session_id, reducer) = claude_reducer_fixture();
+
+        // A permission prompt or elicitation dialog has no resolving hook, so
+        // the instant it opened is recorded for transcript recovery.
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::NeedsInput,
+                "native",
+            ))
+            .expect("dialog applies");
+        assert!(sessions.attention_at(&session_id).is_some());
+
+        // Answering the dialog is invisible to hooks, but the next prompt is
+        // not: a turn boundary retires the request outright.
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::Start,
+                "native",
+            ))
+            .expect("prompt applies");
+        assert_eq!(sessions.attention_at(&session_id), None);
+
+        // Stop reports NeedsInput too, yet its close (`UserPromptSubmit`) is
+        // reliable, so it must not leave a request behind for the poll.
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::NeedsInput,
+                "native_stop",
+            ))
+            .expect("stop applies");
+        assert_eq!(sessions.attention_at(&session_id), None);
+    }
+
+    #[test]
+    fn claude_attention_resolves_only_from_a_later_turn_line() {
+        let (sessions, session_id, reducer) = claude_reducer_fixture();
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::NeedsInput,
+                "native",
+            ))
+            .expect("dialog applies");
+        let attention_at = sessions
+            .attention_at(&session_id)
+            .expect("request recorded");
+        let (_, source, _, lifecycle_revision) =
+            sessions.lifecycle_snapshot(&session_id).expect("snapshot");
+
+        // The pending tool's own line predates the dialog it triggered.
+        assert_eq!(
+            sessions
+                .resolve_attention_if_current(
+                    &session_id,
+                    source,
+                    lifecycle_revision,
+                    attention_at - Duration::from_secs(1),
+                )
+                .expect("store reachable"),
+            None
+        );
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
+
+        // A line written afterwards proves the agent got past the dialog.
+        assert!(sessions
+            .resolve_attention_if_current(
+                &session_id,
+                source,
+                lifecycle_revision,
+                attention_at + Duration::from_secs(1),
+            )
+            .expect("store reachable")
+            .is_some());
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::Working
+        );
+        assert_eq!(sessions.attention_at(&session_id), None);
+    }
+
+    #[test]
+    fn claude_attention_resolution_loses_to_a_newer_lifecycle_write() {
+        let (sessions, session_id, reducer) = claude_reducer_fixture();
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::NeedsInput,
+                "native",
+            ))
+            .expect("dialog applies");
+        let attention_at = sessions
+            .attention_at(&session_id)
+            .expect("request recorded");
+        let (_, source, _, stale_revision) =
+            sessions.lifecycle_snapshot(&session_id).expect("snapshot");
+
+        // A second dialog opened while the poll was reading the transcript.
+        reducer
+            .apply(claude_event(
+                session_id,
+                AgentHookEventKind::NeedsInput,
+                "native",
+            ))
+            .expect("second dialog applies");
+
+        assert_eq!(
+            sessions
+                .resolve_attention_if_current(
+                    &session_id,
+                    source,
+                    stale_revision,
+                    attention_at + Duration::from_secs(1),
+                )
+                .expect("store reachable"),
+            None
+        );
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
     }
 
     fn codex_reducer_fixture() -> (

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -2052,11 +2052,11 @@ fn parse_raw_claude_hook_request(
             Some(_) => return Ok(None),
         },
         "UserPromptSubmit" => (AgentHookEventKind::Start, "native"),
-        // Claude can emit Stop while background tasks or session crons are
-        // still able to wake the parent turn. Those sessions stay Working;
-        // only a Stop with no pending background work is actually awaiting
-        // the user's next prompt.
-        "Stop" if claude_stop_has_pending_background_work(&payload) => return Ok(None),
+        // Stop means the main agent loop reached the prompt, so the terminal
+        // is the user's again. Background tasks and session crons can still
+        // wake the turn later, but suppressing Stop for them left no event to
+        // recover from: a stalled background agent or a session-lifetime cron
+        // registration pinned the session at Working with nothing to clear it.
         "Stop" => (AgentHookEventKind::NeedsInput, "native"),
         "Notification" | "PermissionRequest" => (AgentHookEventKind::NeedsInput, "native"),
         "Error" => (AgentHookEventKind::Error, "native"),
@@ -2088,15 +2088,6 @@ fn parse_raw_claude_hook_request(
         native_hooks_enabled: None,
         ownership: AgentHookOwnership::Owner,
     }))
-}
-
-fn claude_stop_has_pending_background_work(payload: &Value) -> bool {
-    ["background_tasks", "session_crons"].iter().any(|key| {
-        payload
-            .get(*key)
-            .and_then(Value::as_array)
-            .is_some_and(|items| !items.is_empty())
-    })
 }
 
 fn parse_raw_codex_hook_request(head: &str, body: &[u8]) -> Result<Option<AgentHookEvent>, String> {
@@ -2844,7 +2835,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_claude_stop_with_background_work_emits_no_transition() {
+    fn raw_claude_stop_waits_even_with_background_work() {
         let (tx, rx) = mpsc::channel();
         let hooks = AgentHookServer::start_with_handler(move |event| {
             tx.send(event).expect("send event");
@@ -2852,6 +2843,9 @@ mod tests {
         .expect("hook server starts");
         let session_id = Uuid::new_v4();
 
+        // Background agents can stall and a cron registration lives for the
+        // whole session, so neither may withhold the turn boundary: the main
+        // loop is at the prompt and the terminal is the user's again.
         for payload in [
             serde_json::json!({
                 "hook_event_name": "Stop",
@@ -2863,33 +2857,24 @@ mod tests {
                 "background_tasks": [],
                 "session_crons": [{"id": "cron-1", "schedule": "in 1m", "recurring": false}],
             }),
+            serde_json::json!({
+                "hook_event_name": "Stop",
+                "background_tasks": [],
+                "session_crons": [],
+            }),
         ] {
             let response = post_raw_claude_hook(&hooks, session_id, &payload.to_string());
             assert!(
-                response.starts_with("HTTP/1.1 202 Accepted"),
-                "a Stop with pending background work is a pause, got {response:?}"
+                response.starts_with("HTTP/1.1 204 No Content"),
+                "every Stop is a turn boundary, got {response:?}"
             );
-            assert!(
-                rx.try_recv().is_err(),
-                "a background pause must not reach the reducer"
+            assert_eq!(
+                rx.recv_timeout(Duration::from_secs(1))
+                    .expect("Stop delivered")
+                    .event,
+                AgentHookEventKind::NeedsInput
             );
         }
-
-        // Decoy text inside a string field must not suppress the real wait.
-        let decoy = serde_json::json!({
-            "hook_event_name": "Stop",
-            "background_tasks": [],
-            "session_crons": [],
-            "last_assistant_message": "decoy: \"background_tasks\":[{\"status\":\"running\"}]",
-        });
-        let response = post_raw_claude_hook(&hooks, session_id, &decoy.to_string());
-        assert!(response.starts_with("HTTP/1.1 204 No Content"));
-        assert_eq!(
-            rx.recv_timeout(Duration::from_secs(1))
-                .expect("clean Stop delivered")
-                .event,
-            AgentHookEventKind::NeedsInput
-        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7898,6 +7898,15 @@ impl HookStatusReconciliation {
 /// written it without getting past the dialog. Requiring a Working
 /// classification keeps a finished turn on the `Stop` path, whose closing
 /// `UserPromptSubmit` is reliable.
+///
+/// ponytail: recency, not correlation. A tool the agent dispatched in the
+/// same batch and that finishes while a *different* tool's prompt is still
+/// open writes a line newer than the request, which clears the wait early.
+/// Elicitation dialogs block the loop outright, so the gap needs concurrent
+/// tool execution alongside a permission prompt to appear at all. Closing it
+/// needs what Codex has: the request's tool id (`provider_tool_id`) matched
+/// against the tool id on the transcript result, which `TurnObservation`
+/// would have to start carrying.
 fn claude_attention_resolution(
     hook_provider: Option<AgentKind>,
     detection: &session_status::StatusDetection,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7876,6 +7876,49 @@ fn fallback_agent_status_source(
 enum HookStatusReconciliation {
     Boot,
     CurrentCodexTurn(String),
+    ClaudeAttentionResolved(SystemTime),
+}
+
+impl HookStatusReconciliation {
+    fn target(&self) -> SessionStatus {
+        match self {
+            Self::Boot | Self::CurrentCodexTurn(_) => SessionStatus::WaitingForInput,
+            Self::ClaudeAttentionResolved(_) => SessionStatus::Working,
+        }
+    }
+}
+
+/// Recover a hook-owned `WaitingForInput` that no hook will ever clear.
+///
+/// Claude reports an open permission prompt or elicitation dialog through
+/// `Notification`/`PermissionRequest` and reports nothing when the user
+/// answers it, so the session keeps advertising "needs you" while the agent
+/// works through the tools it was just granted. A transcript turn line
+/// stamped after the request is the missing close — the agent could not have
+/// written it without getting past the dialog. Requiring a Working
+/// classification keeps a finished turn on the `Stop` path, whose closing
+/// `UserPromptSubmit` is reliable.
+fn claude_attention_resolution(
+    hook_provider: Option<AgentKind>,
+    detection: &session_status::StatusDetection,
+    attention_at: Option<SystemTime>,
+) -> Option<HookStatusReconciliation> {
+    if hook_provider != Some(AgentKind::Claude) {
+        return None;
+    }
+    let attention_at = attention_at?;
+    if detection.status != SessionStatus::Working
+        || detection.evidence != session_status::StatusEvidence::Transcript
+    {
+        return None;
+    }
+    let resumed_at: SystemTime =
+        chrono::DateTime::parse_from_rfc3339(detection.turn_timestamp.as_deref()?)
+            .ok()?
+            .into();
+    (resumed_at > attention_at).then_some(HookStatusReconciliation::ClaudeAttentionResolved(
+        resumed_at,
+    ))
 }
 
 /// Recover a hook-owned Working status from a durable turn-complete marker.
@@ -7897,7 +7940,11 @@ fn hook_status_reconciliation(
     hook_confirmed_this_run: bool,
     hook_provider: Option<AgentKind>,
     detection: &session_status::StatusDetection,
+    attention_at: Option<SystemTime>,
 ) -> Option<HookStatusReconciliation> {
+    if stored == SessionStatus::WaitingForInput {
+        return claude_attention_resolution(hook_provider, detection, attention_at);
+    }
     if stored != SessionStatus::Working {
         return None;
     }
@@ -8113,6 +8160,7 @@ fn detect_session_statuses_blocking(
                 parsed_id.and_then(|uuid| state.sessions.hook_tool_started_at(&uuid));
             let codex_permission_waiting_at =
                 parsed_id.and_then(|uuid| state.sessions.codex_permission_waiting_at(&uuid));
+            let attention_at = parsed_id.and_then(|uuid| state.sessions.attention_at(&uuid));
             let codex_activity_started_at =
                 match (codex_tool_started_at, codex_permission_waiting_at) {
                     (Some(tool), Some(permission)) => Some(tool.max(permission)),
@@ -8235,6 +8283,7 @@ fn detect_session_statuses_blocking(
                     hook_revision > 0,
                     hook_provider,
                     &detection,
+                    attention_at,
                 );
                 let reconciled = parsed_id.and_then(|uuid| {
                     reconciliation_requested
@@ -8259,11 +8308,16 @@ fn detect_session_statuses_blocking(
                                         completed_turn_id,
                                     )
                                 }
+                                HookStatusReconciliation::ClaudeAttentionResolved(resumed_at) => {
+                                    state.sessions.resolve_attention_if_current(
+                                        &uuid,
+                                        stored_source,
+                                        lifecycle_revision,
+                                        *resumed_at,
+                                    )
+                                }
                             };
-                            applied
-                                .ok()
-                                .flatten()
-                                .map(|_| SessionStatus::WaitingForInput)
+                            applied.ok().flatten().map(|_| reconciliation.target())
                         })
                 });
                 if reconciliation_requested.is_some() && reconciled.is_none() {
@@ -10383,6 +10437,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10390,8 +10445,98 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
             ),
             Some(super::HookStatusReconciliation::Boot)
+        );
+    }
+
+    #[test]
+    fn attention_resolution_needs_claude_working_transcript_evidence_after_the_request() {
+        use acorn_agent::AgentKind;
+        use std::time::Duration;
+
+        // 2023-11-14T22:13:20Z
+        let attention_at = std::time::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        let detection = |status, timestamp: &str| super::session_status::StatusDetection {
+            status,
+            reason: None,
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
+            turn_timestamp: Some(timestamp.to_string()),
+        };
+        let resolution = |detection, attention_at| {
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::WaitingForInput,
+                true,
+                Some(AgentKind::Claude),
+                &detection,
+                attention_at,
+            )
+        };
+
+        // A turn line written after the dialog opened is the close Claude
+        // never sends.
+        assert_eq!(
+            resolution(
+                detection(
+                    acorn_session::SessionStatus::Working,
+                    "2023-11-14T22:13:21Z"
+                ),
+                Some(attention_at),
+            ),
+            Some(super::HookStatusReconciliation::ClaudeAttentionResolved(
+                attention_at + Duration::from_secs(1)
+            ))
+        );
+
+        // The pending tool's own line predates the dialog it triggered, so it
+        // proves nothing.
+        assert_eq!(
+            resolution(
+                detection(
+                    acorn_session::SessionStatus::Working,
+                    "2023-11-14T22:13:19Z"
+                ),
+                Some(attention_at),
+            ),
+            None
+        );
+
+        // A finished turn belongs to Stop, whose closing prompt is reliable.
+        assert_eq!(
+            resolution(
+                detection(acorn_session::SessionStatus::Ready, "2023-11-14T22:13:21Z"),
+                Some(attention_at),
+            ),
+            None
+        );
+
+        // Nothing to resolve without an open request.
+        assert_eq!(
+            resolution(
+                detection(
+                    acorn_session::SessionStatus::Working,
+                    "2023-11-14T22:13:21Z"
+                ),
+                None,
+            ),
+            None
+        );
+
+        // Codex keeps its turn-id correlation; this path is Claude-only.
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::WaitingForInput,
+                true,
+                Some(AgentKind::Codex),
+                &detection(
+                    acorn_session::SessionStatus::Working,
+                    "2023-11-14T22:13:21Z"
+                ),
+                Some(attention_at),
+            ),
+            None
         );
     }
 
@@ -10404,6 +10549,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10411,6 +10557,7 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
             ),
             None
         );
@@ -10431,6 +10578,7 @@ mod tests {
             reason: None,
             evidence: super::session_status::StatusEvidence::Previous,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10438,6 +10586,7 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
             ),
             None
         );
@@ -10450,6 +10599,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: Some("turn-1".to_string()),
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10457,6 +10607,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Codex),
                 &detection,
+                None,
             ),
             None
         );
@@ -10471,6 +10622,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10478,6 +10630,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Codex),
                 &detection,
+                None,
             ),
             None
         );
@@ -10490,6 +10643,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: Some("turn-1".to_string()),
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10497,6 +10651,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Codex),
                 &detection,
+                None,
             ),
             Some(super::HookStatusReconciliation::CurrentCodexTurn(
                 "turn-1".to_string()
@@ -10511,6 +10666,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::TurnComplete),
             evidence: super::session_status::StatusEvidence::Transcript,
             completed_provider_turn_id: Some("turn-1".to_string()),
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10518,6 +10674,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Claude),
                 &detection,
+                None,
             ),
             None
         );
@@ -10532,6 +10689,7 @@ mod tests {
             reason: None,
             evidence: super::session_status::StatusEvidence::Previous,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10539,6 +10697,7 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
             ),
             None
         );
@@ -10553,6 +10712,7 @@ mod tests {
             reason: Some(super::SessionStatusReason::ShellPrompt),
             evidence: super::session_status::StatusEvidence::Process,
             completed_provider_turn_id: None,
+            turn_timestamp: None,
         };
         assert_eq!(
             super::hook_status_reconciliation(
@@ -10560,6 +10720,7 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
             ),
             None
         );


### PR DESCRIPTION
## Problem

Two Claude sessions were reporting a status the agent had already left, in opposite directions. Both come from the same shape: a hook sets the status, no hook ever clears it, and `poll_defers_to_hook` bars the poll from correcting a hook-owned value.

**Working that never ends.** A `Stop` whose payload carried a non-empty `background_tasks` or `session_crons` array was dropped outright, so the session kept whatever status it had. Nothing else could clear it. A background agent that stalls (and has to be killed) or a cron registration — which lives for the whole session once `/loop`, `ScheduleWakeup`, or `CronCreate` runs — pinned the tab at Working while the main loop sat at the prompt. Observed live: the transcript ended in `assistant end_turn` at 09:37:42 and Claude's own session state flipped to `idle`, while Acorn still said `working` at 09:38:15; it only recovered after `system agents_killed` at 09:44:31 let the next `Stop` through.

**WaitingForInput that never ends.** Claude raises `Notification`/`PermissionRequest` when a permission prompt or elicitation dialog opens and emits nothing when the user answers it, so the session advertised "needs you" through minutes of tool calls the user had already approved. Observed live: Claude's own state said `busy`, the transcript was filling with tool results, and Acorn said `waiting_for_input` for seven minutes after the dialog was answered.

## Change

`Stop` now always maps to `needs_input`. The main agent loop reaching the prompt is what the status describes, and background work that later wakes the turn emits its own `UserPromptSubmit`/`Stop` pair.

For attention requests the reducer records the instant the dialog opened, and the poll treats a transcript turn line stamped after it as the close Claude never sends — the agent could not have written that line without getting past the dialog. Recovery requires a Working classification from transcript evidence, so a finished turn stays on the `Stop` path, whose closing `UserPromptSubmit` is reliable, and the write goes through the existing lifecycle fence so a dialog opened during the poll's transcript read survives.

Claude `Stop` moves to its own `native_stop` source, mirroring Codex, so the turn boundary stays distinguishable from a dialog now that both report `NeedsInput`.

## Trade-offs

Suppressing `Stop` on pending background work landed in 9eab4b7 to stop a session reading as "waiting" while a background agent was still working. That behaviour comes back: a `/loop` or scheduled session will show `waiting_for_input` between cycles. That is the honest reading — the prompt really is the user's — and if the resulting notifications are noisy, the fix belongs in notification policy rather than in the status itself. The failure it replaces was an unbounded lie with no event able to end it.

Attention recovery matches on recency, not correlation. A tool dispatched in the same batch that finishes while a *different* tool's prompt is still open writes a line newer than the request and clears the wait early. Elicitation dialogs block the loop outright, so this needs concurrent tool execution alongside a permission prompt to appear at all. The ceiling and its upgrade path — the request's tool id matched against the transcript result's, as Codex already does — are named at `claude_attention_resolution`.

## Verification

- `cargo test --lib` — 652 passed, 1 ignored (`--test-threads=4`; `agent_wrappers::tests::codex_wrapper_*` flake under full parallelism on `main` too).
- New coverage: every `Stop` shape delivers `NeedsInput`; a dialog marks the request while `Start`/`native_stop` retire it; resolution accepts only a turn line newer than the request and loses to a newer lifecycle write; the classifier rejects Ready detections, missing requests, and non-Claude providers.
- `cargo clippy` introduces no new warnings.
- Claude reaches `apply_validated_agent_hook_event` on a single path, so no event bypasses the marking; no frontend code reads hook source strings.

https://claude.ai/code/session_01N6ZpvuJibrBMnUCiB9vApF
