### PR TITLE
fix(terminal): preserve text and colors after the IME cursor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,6 +163,11 @@
   background-color: transparent !important;
 }
 
+.acorn-terminal .composition-view .acorn-ime-composition-text {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .acorn-terminal-inactive .xterm-cursor,
 .acorn-terminal-inactive .xterm-cursor.xterm-cursor-block {
   outline: 1px solid color-mix(in oklab, var(--color-fg-muted) 70%, transparent);

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -258,6 +258,15 @@ function terminalCellDims(term: XTerm): { width: number; height: number } | null
   return cell ? { width: cell.width, height: cell.height } : null;
 }
 
+function terminalLineTailFromCursor(term: XTerm): string {
+  const buffer = term.buffer.active;
+  return (
+    buffer
+      .getLine(buffer.baseY + buffer.cursorY)
+      ?.translateToString(true, buffer.cursorX) ?? ""
+  );
+}
+
 function suppressCurrentXtermLinkUnderline(term: XTerm): void {
   const link = (term as unknown as TerminalRenderInternals)._core?.linkifier
     ?.currentLink?.link;
@@ -1404,15 +1413,15 @@ export function Terminal({
       const cell = core?._renderService?.dimensions?.css?.cell;
       return cell ? { width: cell.width, height: cell.height } : null;
     };
-    const showComposing = (text: string) => {
+    const compositionTextView = document.createElement("span");
+    compositionTextView.className = "acorn-ime-composition-text";
+    const compositionTailView = document.createElement("span");
+    compositionTailView.className = "acorn-ime-line-tail";
+    let composingText = "";
+
+    const positionComposing = () => {
       if (!compositionView) return;
-      if (text.length === 0) {
-        compositionView.classList.remove("active");
-        compositionView.textContent = "";
-        return;
-      }
       const cell = getCellDims();
-      compositionView.textContent = text;
       if (cell) {
         const buf = term.buffer.active;
         // xterm's visible cursor row = `baseY + cursorY - viewportY`
@@ -1432,6 +1441,19 @@ export function Terminal({
         compositionView.style.minHeight = `${cell.height}px`;
         compositionView.style.lineHeight = `${cell.height}px`;
       }
+    };
+    const renderComposing = () => {
+      if (!compositionView || composingText.length === 0) return;
+      compositionTextView.textContent = composingText;
+      // Until the PTY receives a committed composition, its buffer still has
+      // the text under and after the cursor in the old position. Mirror that
+      // tail after the preview so mid-line composition reads as insertion.
+      compositionTailView.textContent = terminalLineTailFromCursor(term);
+      compositionView.replaceChildren(
+        compositionTextView,
+        compositionTailView,
+      );
+
       // Sync font with the current xterm options so the preview uses the
       // user's configured terminal font/size, not the default sans inherited
       // from the parent.
@@ -1451,12 +1473,31 @@ export function Terminal({
       if (typeof fontWeight === "number" || typeof fontWeight === "string") {
         compositionView.style.fontWeight = String(fontWeight);
       }
-      compositionView.classList.add("active");
+      const theme = term.options.theme;
+      if (theme?.foreground) {
+        compositionView.style.color = theme.foreground;
+      }
+      const background = theme?.cursorAccent ?? theme?.background;
+      if (background) {
+        compositionView.style.backgroundColor = background;
+      }
     };
     const hideComposing = () => {
+      composingText = "";
       if (!compositionView) return;
       compositionView.classList.remove("active");
-      compositionView.textContent = "";
+      compositionView.replaceChildren();
+    };
+    const showComposing = (text: string) => {
+      if (!compositionView) return;
+      if (text.length === 0) {
+        hideComposing();
+        return;
+      }
+      composingText = text;
+      renderComposing();
+      positionComposing();
+      compositionView.classList.add("active");
     };
 
     // WKWebView delivers a single Korean syllable across a mix of
@@ -2181,13 +2222,8 @@ export function Terminal({
       if (!compositionView || !compositionView.classList.contains("active")) {
         return;
       }
-      const cell = getCellDims();
-      if (!cell) return;
-      const buf = term.buffer.active;
-      // See `showComposing` for the full derivation of this formula.
-      const cursorViewportY = buf.baseY + buf.cursorY - buf.viewportY;
-      compositionView.style.left = `${buf.cursorX * cell.width}px`;
-      compositionView.style.top = `${cursorViewportY * cell.height}px`;
+      renderComposing();
+      positionComposing();
     };
     const renderDisposable = term.onRender(repositionComposing);
     // PTY output that arrives while the user is mid-composition can scroll

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -258,13 +258,108 @@ function terminalCellDims(term: XTerm): { width: number; height: number } | null
   return cell ? { width: cell.width, height: cell.height } : null;
 }
 
-function terminalLineTailFromCursor(term: XTerm): string {
+function terminalLineTailEndColumn(term: XTerm): number {
   const buffer = term.buffer.active;
-  return (
-    buffer
-      .getLine(buffer.baseY + buffer.cursorY)
-      ?.translateToString(true, buffer.cursorX) ?? ""
+  const line = buffer.getLine(buffer.baseY + buffer.cursorY);
+  if (!line) return buffer.cursorX;
+
+  const maxColumn = Math.min(term.cols, line.length);
+  for (let column = maxColumn - 1; column >= buffer.cursorX; column -= 1) {
+    const cell = line.getCell(column);
+    if (cell?.getChars()) {
+      return Math.min(
+        maxColumn,
+        column + Math.max(1, cell.getWidth()),
+      );
+    }
+  }
+  return buffer.cursorX;
+}
+
+function renderTerminalLineTail(
+  term: XTerm,
+  container: HTMLElement,
+  tailView: HTMLElement,
+): void {
+  const buffer = term.buffer.active;
+  const line = buffer.getLine(buffer.baseY + buffer.cursorY);
+  const endColumn = terminalLineTailEndColumn(term);
+  const cursorViewportY = buffer.baseY + buffer.cursorY - buffer.viewportY;
+  const sourceRows = container.querySelector<HTMLElement>(
+    ".xterm-screen > .xterm-rows",
   );
+  const sourceRow = sourceRows?.children.item(cursorViewportY) as
+    | HTMLElement
+    | null;
+  if (!line || !sourceRow || endColumn <= buffer.cursorX) {
+    tailView.replaceChildren();
+    return;
+  }
+
+  // Reuse the DOM renderer's resolved spans instead of reimplementing xterm's
+  // ANSI, true-color, inverse, dim, and decoration rules. The cloned text is
+  // rebuilt from buffer cells so only the tail at/after the cursor is shown.
+  const sourceSpans = Array.from(
+    sourceRow.querySelectorAll<HTMLElement>("span"),
+  ).map((span) => ({ span, rect: span.getBoundingClientRect() }));
+  const rowRect = sourceRow.getBoundingClientRect();
+  const renderedCellWidth = rowRect.width / term.cols;
+  if (renderedCellWidth <= 0 || sourceSpans.length === 0) {
+    tailView.textContent = line.translateToString(true, buffer.cursorX);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  let previousStyleKey = "";
+  let previousClone: HTMLElement | null = null;
+  for (let column = buffer.cursorX; column < endColumn; ) {
+    const cell = line.getCell(column);
+    if (!cell) break;
+    const width = Math.max(1, cell.getWidth());
+    if (cell.getWidth() === 0) {
+      column += 1;
+      continue;
+    }
+
+    const chars = cell.getChars();
+    const text = cell.isInvisible()
+      ? " ".repeat(width)
+      : chars.length > 0
+        ? chars
+        : " ";
+
+    const cellCenter =
+      rowRect.left + (column + width / 2) * renderedCellWidth;
+    const source =
+      sourceSpans.find(
+        ({ rect }) =>
+          rect.left - 0.5 <= cellCenter && cellCenter < rect.right + 0.5,
+      )?.span ?? null;
+    const clone = source
+      ? (source.cloneNode(false) as HTMLElement)
+      : document.createElement("span");
+    for (const className of Array.from(clone.classList)) {
+      // The source cell is where xterm paints its block/bar cursor. Its text
+      // style is still the right one; only the transient cursor classes must
+      // not move into the shifted tail preview.
+      if (className.startsWith("xterm-cursor")) {
+        clone.classList.remove(className);
+      }
+    }
+    clone.removeAttribute("id");
+    clone.classList.add("acorn-ime-tail-run");
+    const styleKey = clone.outerHTML;
+    if (previousClone && previousStyleKey === styleKey) {
+      previousClone.textContent = `${previousClone.textContent ?? ""}${text}`;
+    } else {
+      clone.textContent = text;
+      fragment.append(clone);
+      previousStyleKey = styleKey;
+      previousClone = clone;
+    }
+    column += width;
+  }
+  tailView.replaceChildren(fragment);
 }
 
 function suppressCurrentXtermLinkUnderline(term: XTerm): void {
@@ -1416,7 +1511,7 @@ export function Terminal({
     const compositionTextView = document.createElement("span");
     compositionTextView.className = "acorn-ime-composition-text";
     const compositionTailView = document.createElement("span");
-    compositionTailView.className = "acorn-ime-line-tail";
+    compositionTailView.className = "acorn-ime-line-tail xterm-rows";
     let composingText = "";
 
     const positionComposing = () => {
@@ -1448,7 +1543,7 @@ export function Terminal({
       // Until the PTY receives a committed composition, its buffer still has
       // the text under and after the cursor in the old position. Mirror that
       // tail after the preview so mid-line composition reads as insertion.
-      compositionTailView.textContent = terminalLineTailFromCursor(term);
+      renderTerminalLineTail(term, container, compositionTailView);
       compositionView.replaceChildren(
         compositionTextView,
         compositionTailView,

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -210,6 +210,123 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     await expect(composition).toHaveText("한트");
   });
 
+  test("composition preserves the dim color of a prompt placeholder", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    const placeholder = "Use /skills to list available skills";
+    // Render the placeholder dimmed, then return to the first placeholder
+    // column. This matches agent prompts that paint guidance after the cursor.
+    await emitPtyOutput(
+      page,
+      `› \x1b[2m${placeholder}\x1b[0m\x1b[3G`,
+    );
+    await expect(page.locator(".xterm-screen > .xterm-rows")).toContainText(
+      placeholder,
+    );
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "한",
+        taValue: "한",
+      },
+    ]);
+
+    const colors = await page.evaluate((expectedPlaceholder) => {
+      const tailRun = document.querySelector<HTMLElement>(
+        ".composition-view.active .acorn-ime-tail-run",
+      );
+      const sourceRow = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          ".xterm-screen > .xterm-rows > div",
+        ),
+      ).find((row) => row.textContent?.includes(expectedPlaceholder));
+      const sourceSpan = Array.from(
+        sourceRow?.querySelectorAll<HTMLElement>("span") ?? [],
+      ).find((span) => span.textContent?.includes("/skills"));
+      const compositionText = document.querySelector<HTMLElement>(
+        ".composition-view.active .acorn-ime-composition-text",
+      );
+      if (!tailRun || !sourceSpan || !compositionText) {
+        throw new Error("IME placeholder style nodes missing");
+      }
+      return {
+        tailText: tailRun.textContent,
+        tail: getComputedStyle(tailRun).color,
+        source: getComputedStyle(sourceSpan).color,
+        composition: getComputedStyle(compositionText).color,
+      };
+    }, placeholder);
+
+    expect(colors.tailText).toBe(placeholder);
+    expect(colors.tail).toBe(colors.source);
+    expect(colors.tail).not.toBe(colors.composition);
+  });
+
+  test("composition preserves each ANSI color after the cursor", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    await emitPtyOutput(
+      page,
+      "› \x1b[31mred\x1b[32mgreen\x1b[34mblue\x1b[0m\x1b[3G",
+    );
+    await expect(page.locator(".xterm-screen > .xterm-rows")).toContainText(
+      "redgreenblue",
+    );
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "한",
+        taValue: "한",
+      },
+    ]);
+
+    const colors = await page.evaluate(() => {
+      const row = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          ".xterm-screen > .xterm-rows > div",
+        ),
+      ).find((candidate) => candidate.textContent?.includes("redgreenblue"));
+      if (!row) throw new Error("colored source row missing");
+      const sourceSpans = Array.from(
+        row.querySelectorAll<HTMLElement>("span"),
+      );
+      const sourceColor = (text: string) => {
+        const span = sourceSpans.find((candidate) =>
+          candidate.textContent?.includes(text),
+        );
+        if (!span) throw new Error(`colored source span missing: ${text}`);
+        return getComputedStyle(span).color;
+      };
+      const tailRuns = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          ".composition-view.active .acorn-ime-tail-run",
+        ),
+      );
+      return {
+        tailText: tailRuns.map((run) => run.textContent).join(""),
+        tail: tailRuns.map((run) => getComputedStyle(run).color),
+        source: [sourceColor("ed"), sourceColor("green"), sourceColor("blue")],
+      };
+    });
+
+    expect(colors.tailText).toBe("redgreenblue");
+    expect(colors.tail).toEqual(colors.source);
+  });
+
   test("Korean syllable + spacebar terminator emits the syllable exactly once", async ({
     page,
     tauri,

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -63,6 +63,12 @@ async function seed(tauri: TauriMock): Promise<void> {
   ]);
   // Spawn is a no-op for these tests — we only care about pty_write.
   await tauri.handle("pty_spawn", () => null);
+  await tauri.handle("pty_subscribe_output", (args: unknown) => {
+    const { channel } = args as { channel: { id: number } };
+    const w = window as unknown as { __imeOutputChannelId?: number };
+    w.__imeOutputChannelId = channel.id;
+    return 1;
+  });
   // Record every pty_write call as a decoded UTF-8 string on `window`.
   // Handlers are serialized into page context — no closures over Node-side
   // helpers, so the base64 decode is inlined here.
@@ -146,7 +152,64 @@ async function getWrites(page: Page): Promise<string[]> {
   );
 }
 
+async function emitPtyOutput(page: Page, text: string): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __imeOutputChannelId?: number })
+            .__imeOutputChannelId ?? null,
+      ),
+    )
+    .not.toBeNull();
+  await page.evaluate((output) => {
+    const w = window as unknown as {
+      __imeOutputChannelId?: number;
+      [key: string]: unknown;
+    };
+    const id = w.__imeOutputChannelId;
+    if (typeof id !== "number") throw new Error("IME output channel missing");
+    const callback = w[`_${id}`] as
+      | ((payload: { index: number; message: number[] }) => void)
+      | undefined;
+    if (!callback) throw new Error("IME output callback missing");
+    callback({
+      index: 0,
+      message: Array.from(new TextEncoder().encode(output)),
+    });
+  }, text);
+}
+
 test.describe("terminal: IME (PR #104 regression)", () => {
+  test("mid-line Korean composition previews as insertion without hiding the following text", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+
+    // Render "테스트" and place the terminal cursor immediately before "트".
+    await emitPtyOutput(page, "› 테스트\x1b[2D");
+    await expect(page.locator(".xterm-rows")).toContainText("› 테스트");
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "한",
+        taValue: "한",
+      },
+    ]);
+
+    const composition = page.locator(".composition-view.active");
+    await expect(composition.locator(".acorn-ime-composition-text")).toHaveText(
+      "한",
+    );
+    await expect(composition.locator(".acorn-ime-line-tail")).toHaveText("트");
+    await expect(composition).toHaveText("한트");
+  });
+
   test("Korean syllable + spacebar terminator emits the syllable exactly once", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Mid-line CJK IME composition now previews as an insertion without flattening the styling of existing terminal content.

1. **Preserve the line tail** — mirror terminal cells at and after the cursor beside the live composition text so following characters remain visible instead of appearing overwritten.
2. **Preserve terminal styling** — reuse xterm's rendered DOM spans so dim placeholders, ANSI/true-color runs, backgrounds, inverse text, and decorations retain their resolved styles while transient cursor classes are removed.
3. **Lock regression coverage** — extend the terminal IME Playwright fixture to inject PTY output and assert insertion preview, dim placeholder color, and multiple ANSI tail colors.

## Expected impact

| Terminal behavior | Before | After |
| --- | --- | --- |
| Mid-line Korean/CJK composition | Text after the cursor appeared hidden or overwritten | The live composition is shown as an insertion and the line tail remains visible |
| Prompt placeholders and colored output | Mirrored tail inherited one foreground color | Each existing cell keeps its xterm-rendered style |
| IME regression coverage | Commit behavior only | Commit behavior plus visual tail content and color fidelity |

## Design notes

- The terminal buffer remains the source of truth for tail text and cell widths.
- Styling is cloned from the active xterm DOM row instead of reimplementing ANSI, true-color, dim, inverse, background, or decoration resolution.
- The copied source cursor span has only transient cursor classes removed, preventing the block/bar cursor from appearing in the shifted preview.
- The implementation continues to use xterm's DOM renderer, which Acorn already requires for correct macOS/Linux IME positioning.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 104 files, 1,198 tests passed
- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts` — 14 tests passed
- [x] `pnpm run build`
