### PR TITLE
fix(terminal): remove IME preview underline beside cursor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,11 +163,6 @@
   background-color: transparent !important;
 }
 
-.acorn-terminal .composition-view .acorn-ime-composition-text {
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
 /* The native cursor stays at the pre-composition buffer position, underneath
    the IME overlay. Replace it with a marker immediately after the live
    composition text so the caret tracks what the user is currently building. */

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -329,6 +329,9 @@ test.describe("terminal: IME (PR #104 regression)", () => {
       "data-acorn-ime-cursor-style",
       "underline",
     );
+    await expect(
+      page.locator(".composition-view.active .acorn-ime-composition-text"),
+    ).toHaveCSS("text-decoration-line", "none");
     const marker = await imeCursor.evaluate((element) => {
       const computed = getComputedStyle(element, "::after");
       return {


### PR DESCRIPTION
## Summary

Korean IME composition previews now stay visually distinct from the active cursor without drawing a second underline across the composing text.

1. **Preview styling** — remove Acorn's custom underline from the live IME composition text so underline cursor presets no longer form an awkward continuous mark.
2. **Regression coverage** — assert that composition text has no text decoration while an application-owned underline cursor remains active.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Korean IME with an underline cursor | Composition text and cursor both draw baseline marks | Only the cursor draws an underline |
| ANSI-underlined terminal output | Rendered by xterm | Unchanged |

## Design notes

- The change targets only Acorn's `.acorn-ime-composition-text` preview styling. It does not suppress xterm's ANSI underline classes or alter cursor rendering.
- The existing composition cursor remains the visual position indicator for uncommitted IME text.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts` — 15 tests passed in Chromium
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — production frontend build passed
- [x] `git diff --check` — passed
