### PR TITLE
feat(canvas): taller defaults + inherited and synchronized node sizing

### DIFF
--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -10,6 +10,7 @@ import {
   PanelsTopLeft,
   Plus,
   RotateCcw,
+  Scaling,
   Scan,
   Sparkles,
   Terminal as TerminalIcon,
@@ -741,6 +742,33 @@ export function WorkspaceCanvas({
     [activateNode],
   );
 
+  const matchOtherSessionSizes = useCallback(
+    (sourceSessionId: string) => {
+      updateCanvas((current) => {
+        const source = current.nodes[sourceSessionId];
+        if (!source) return current;
+        let changed = false;
+        const nodes = Object.fromEntries(
+          Object.entries(current.nodes).map(([sessionId, node]) => {
+            if (
+              sessionId === sourceSessionId ||
+              (node.width === source.width && node.height === source.height)
+            ) {
+              return [sessionId, node];
+            }
+            changed = true;
+            return [
+              sessionId,
+              { ...node, width: source.width, height: source.height },
+            ];
+          }),
+        );
+        return changed ? { ...current, nodes } : current;
+      }, "now");
+    },
+    [updateCanvas],
+  );
+
   const resetLayout = useCallback(() => {
     const previous = canvasRef.current;
     const next = resetWorkspaceCanvasState(reconciliationIds);
@@ -810,6 +838,12 @@ export function WorkspaceCanvas({
         onClick: () => openInPanes(contextSession.id),
       });
       items.push({
+        label: canvasText(t, "workspace.canvas.matchOtherSessionSizes"),
+        icon: <Scaling size={12} />,
+        disabled: canvasSessions.length < 2,
+        onClick: () => matchOtherSessionSizes(contextSession.id),
+      });
+      items.push({
         label: canvasText(t, "workspace.canvas.closeSession"),
         icon: <X size={12} />,
         onClick: () => requestRemoveSession(contextSession.id),
@@ -838,6 +872,7 @@ export function WorkspaceCanvas({
   }, [
     contextSession,
     fitAll,
+    matchOtherSessionSizes,
     openExpanded,
     openInPanes,
     requestRemoveSession,

--- a/src/components/WorkspaceMain.test.tsx
+++ b/src/components/WorkspaceMain.test.tsx
@@ -301,12 +301,12 @@ describe("WorkspaceMain", () => {
     firePointer(window, "pointerup", { clientX: 180, clientY: 160 });
 
     expect(alpha!.dataset.canvasNodeWidth).toBe("700");
-    expect(alpha!.dataset.canvasNodeHeight).toBe("460");
+    expect(alpha!.dataset.canvasNodeHeight).toBe("500");
     expect(alpha!.dataset.canvasNodeX).toBe("60");
     expect(alpha!.dataset.canvasNodeY).toBe("40");
     expect(
       useAppStore.getState().workspaces[REPO].canvas?.nodes.alpha,
-    ).toMatchObject({ width: 700, height: 460 });
+    ).toMatchObject({ width: 700, height: 500 });
   });
 
   it("renders chat sessions as interactive canvas nodes", () => {

--- a/src/lib/workspaceCanvas.test.ts
+++ b/src/lib/workspaceCanvas.test.ts
@@ -86,10 +86,10 @@ describe("workspaceCanvas", () => {
       x: 0,
       y: 0,
       width: 620,
-      height: 400,
+      height: 440,
     });
     expect(WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH).toBe(620);
-    expect(WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT).toBe(400);
+    expect(WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT).toBe(440);
     for (const node of Object.values(result.nodes)) {
       expect(node.x % WORKSPACE_CANVAS_GRID_SIZE).toBe(0);
       expect(node.y % WORKSPACE_CANVAS_GRID_SIZE).toBe(0);
@@ -120,7 +120,7 @@ describe("workspaceCanvas", () => {
       x: 680,
       y: 0,
       width: 620,
-      height: 400,
+      height: 440,
       zIndex: 2,
     });
   });
@@ -142,8 +142,8 @@ describe("workspaceCanvas", () => {
     expect(result.nodes.new).toEqual({
       x: 860,
       y: 200,
-      width: 620,
-      height: 400,
+      width: 700,
+      height: 460,
       zIndex: 5,
     });
   });

--- a/src/lib/workspaceCanvas.ts
+++ b/src/lib/workspaceCanvas.ts
@@ -72,7 +72,7 @@ export const WORKSPACE_CANVAS_GRID_SIZE = 20;
 export const WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH =
   WORKSPACE_CANVAS_GRID_SIZE * 31;
 export const WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT =
-  WORKSPACE_CANVAS_GRID_SIZE * 20;
+  WORKSPACE_CANVAS_GRID_SIZE * 22;
 
 const WORKSPACE_CANVAS_MAX_NODE_WIDTH = 2_400;
 const WORKSPACE_CANVAS_MAX_NODE_HEIGHT = 1_600;
@@ -204,19 +204,25 @@ export function normalizeWorkspaceCanvasState(
   };
 }
 
-function defaultNodeAt(index: number, zIndex: number): WorkspaceCanvasNode {
+function defaultNodeAt(
+  index: number,
+  zIndex: number,
+  size: WorkspaceCanvasSize = {
+    width: WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+    height: WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+  },
+): WorkspaceCanvasNode {
   const column = index % WORKSPACE_CANVAS_DEFAULT_COLUMNS;
   const row = Math.floor(index / WORKSPACE_CANVAS_DEFAULT_COLUMNS);
   return {
     x:
       WORKSPACE_CANVAS_NODE_ORIGIN +
-      column *
-        (WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH + WORKSPACE_CANVAS_NODE_GAP),
+      column * (size.width + WORKSPACE_CANVAS_NODE_GAP),
     y:
       WORKSPACE_CANVAS_NODE_ORIGIN +
-      row * (WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT + WORKSPACE_CANVAS_NODE_GAP),
-    width: WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
-    height: WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+      row * (size.height + WORKSPACE_CANVAS_NODE_GAP),
+    width: size.width,
+    height: size.height,
     zIndex,
   };
 }
@@ -236,14 +242,15 @@ function nodesOverlap(
 function nextOpenNode(
   existing: readonly WorkspaceCanvasNode[],
   zIndex: number,
+  size?: WorkspaceCanvasSize,
 ): WorkspaceCanvasNode {
   for (let index = 0; index < 10_000; index += 1) {
-    const candidate = defaultNodeAt(index, zIndex);
+    const candidate = defaultNodeAt(index, zIndex, size);
     if (!existing.some((node) => nodesOverlap(candidate, node))) {
       return candidate;
     }
   }
-  return defaultNodeAt(existing.length, zIndex);
+  return defaultNodeAt(existing.length, zIndex, size);
 }
 
 function snapWorkspaceCanvasUp(value: number): number {
@@ -263,6 +270,7 @@ function nextOpenNodeNear(
   anchor: WorkspaceCanvasNode,
   zIndex: number,
 ): WorkspaceCanvasNode {
+  const size = { width: anchor.width, height: anchor.height };
   const alignedX = snapWorkspaceCanvasValue(anchor.x);
   const alignedY = snapWorkspaceCanvasValue(anchor.y);
   const rightX = snapWorkspaceCanvasUp(
@@ -272,12 +280,10 @@ function nextOpenNodeNear(
     anchor.y + anchor.height + WORKSPACE_CANVAS_NODE_GAP,
   );
   const leftX = snapWorkspaceCanvasDown(
-    anchor.x - WORKSPACE_CANVAS_NODE_GAP - WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
+    anchor.x - WORKSPACE_CANVAS_NODE_GAP - size.width,
   );
   const aboveY = snapWorkspaceCanvasDown(
-    anchor.y -
-      WORKSPACE_CANVAS_NODE_GAP -
-      WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+    anchor.y - WORKSPACE_CANVAS_NODE_GAP - size.height,
   );
   const positions: readonly WorkspaceCanvasPoint[] = [
     { x: rightX, y: alignedY },
@@ -293,8 +299,7 @@ function nextOpenNodeNear(
   for (const position of positions) {
     const candidate = clampWorkspaceCanvasNode({
       ...position,
-      width: WORKSPACE_CANVAS_DEFAULT_NODE_WIDTH,
-      height: WORKSPACE_CANVAS_DEFAULT_NODE_HEIGHT,
+      ...size,
       zIndex,
     });
     if (!existing.some((node) => nodesOverlap(candidate, node))) {
@@ -302,7 +307,7 @@ function nextOpenNodeNear(
     }
   }
 
-  return nextOpenNode(existing, zIndex);
+  return nextOpenNode(existing, zIndex, size);
 }
 
 export function reconcileWorkspaceCanvasState(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1028,6 +1028,7 @@
       "contextLayout": "Layout",
       "moveSession": "Move {name}",
       "resizeSession": "Resize {name}",
+      "matchOtherSessionSizes": "Match other sessions to this size",
       "expandSession": "Expand {name}",
       "openInPanes": "Open {name} in panes",
       "closeSession": "Close session",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1028,6 +1028,7 @@
       "contextLayout": "レイアウト",
       "moveSession": "{name} を移動",
       "resizeSession": "{name} のサイズを変更する",
+      "matchOtherSessionSizes": "他のセッションをこのサイズに揃える",
       "expandSession": "{name} を展開します",
       "openInPanes": "ペインで {name} を開きます",
       "closeSession": "セッションを閉じる",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1028,6 +1028,7 @@
       "contextLayout": "레이아웃",
       "moveSession": "{name} 이동",
       "resizeSession": "{name} 크기 조절",
+      "matchOtherSessionSizes": "다른 세션을 이 크기로 맞추기",
       "expandSession": "{name} 크게 보기",
       "openInPanes": "패널에서 {name} 열기",
       "closeSession": "세션 닫기",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1028,6 +1028,7 @@
       "contextLayout": "布局",
       "moveSession": "移动 {name}",
       "resizeSession": "调整 {name} 的大小",
+      "matchOtherSessionSizes": "将其他会话调整为此大小",
       "expandSession": "展开 {name}",
       "openInPanes": "在窗格中打开 {name}",
       "closeSession": "关闭会话",

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -171,6 +171,8 @@ test.describe("workspace canvas mode", () => {
     await expect(node).toBeVisible();
     await expect(node).toHaveAttribute("data-canvas-node-x", "0");
     await expect(node).toHaveAttribute("data-canvas-node-y", "0");
+    await expect(node).toHaveAttribute("data-canvas-node-width", "620");
+    await expect(node).toHaveAttribute("data-canvas-node-height", "440");
     const calls = await page.evaluate(
       () =>
         (
@@ -202,6 +204,14 @@ test.describe("workspace canvas mode", () => {
       node.locator('[data-acorn-terminal-slot="canvas-created"]'),
     ).toBeAttached();
 
+    const resizeNode = node.getByTestId(
+      "workspace-canvas-node-resize-handle",
+    );
+    await resizeNode.press("Shift+ArrowRight");
+    await resizeNode.press("Shift+ArrowDown");
+    await expect(node).toHaveAttribute("data-canvas-node-width", "660");
+    await expect(node).toHaveAttribute("data-canvas-node-height", "480");
+
     await createButton.click();
     await page
       .getByRole("menuitem", { name: "New chat session", exact: true })
@@ -209,8 +219,10 @@ test.describe("workspace canvas mode", () => {
 
     const chatNode = canvas.locator('[data-canvas-session-id="canvas-chat"]');
     await expect(chatNode).toBeVisible();
-    await expect(chatNode).toHaveAttribute("data-canvas-node-x", "680");
+    await expect(chatNode).toHaveAttribute("data-canvas-node-x", "720");
     await expect(chatNode).toHaveAttribute("data-canvas-node-y", "0");
+    await expect(chatNode).toHaveAttribute("data-canvas-node-width", "660");
+    await expect(chatNode).toHaveAttribute("data-canvas-node-height", "480");
     await expect(
       chatNode.getByRole("textbox", { name: "Chat message" }),
     ).toBeVisible();
@@ -528,6 +540,60 @@ test.describe("workspace canvas mode", () => {
       ]);
   });
 
+  test("matches other session sizes from a canvas node context menu", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [session("alpha"), session("beta")]);
+
+    await page.goto("/");
+    await page.getByTestId("workspace-view-status").click();
+    await page.getByRole("option", { name: "Canvas" }).click();
+
+    const canvas = page.getByTestId("workspace-canvas");
+    const alpha = canvas.locator('[data-canvas-session-id="alpha"]');
+    const beta = canvas.locator('[data-canvas-session-id="beta"]');
+    const betaPosition = {
+      x: await beta.getAttribute("data-canvas-node-x"),
+      y: await beta.getAttribute("data-canvas-node-y"),
+    };
+
+    const resizeAlpha = alpha.getByTestId(
+      "workspace-canvas-node-resize-handle",
+    );
+    await resizeAlpha.press("Shift+ArrowRight");
+    await resizeAlpha.press("Shift+ArrowDown");
+    await expect(alpha).toHaveAttribute("data-canvas-node-width", "660");
+    await expect(alpha).toHaveAttribute("data-canvas-node-height", "480");
+
+    await alpha
+      .getByTestId("workspace-canvas-node-drag-handle")
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", {
+        name: "Match other sessions to this size",
+        exact: true,
+      })
+      .click();
+
+    await expect(beta).toHaveAttribute("data-canvas-node-width", "660");
+    await expect(beta).toHaveAttribute("data-canvas-node-height", "480");
+    await expect(beta).toHaveAttribute("data-canvas-node-x", betaPosition.x!);
+    await expect(beta).toHaveAttribute("data-canvas-node-y", betaPosition.y!);
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = localStorage.getItem("acorn-workspaces");
+          if (!raw) return null;
+          const beta = JSON.parse(raw).state.workspaces?.["/tmp/demo"]?.canvas
+            ?.nodes?.beta;
+          return beta ? { width: beta.width, height: beta.height } : null;
+        }),
+      )
+      .toEqual({ width: 660, height: 480 });
+  });
+
   test("moves, resizes, zooms, and restores live terminal nodes", async ({
     page,
     tauri,
@@ -738,7 +804,7 @@ test.describe("workspace canvas mode", () => {
     );
 
     await expect(alpha).toHaveAttribute("data-canvas-node-width", "620");
-    await expect(alpha).toHaveAttribute("data-canvas-node-height", "400");
+    await expect(alpha).toHaveAttribute("data-canvas-node-height", "440");
     await expect(alpha).toHaveCSS("z-index", "3");
     await expect(canvas.getByTestId("workspace-canvas-size-hint"))
       .toHaveAttribute("data-canvas-match-width", "true");
@@ -762,7 +828,7 @@ test.describe("workspace canvas mode", () => {
       wholePixelResizeBox.y + wholePixelResizeBox.height / 2 + 20,
     );
     await expect(alpha).toHaveAttribute("data-canvas-node-width", "640");
-    await expect(alpha).toHaveAttribute("data-canvas-node-height", "420");
+    await expect(alpha).toHaveAttribute("data-canvas-node-height", "460");
     await expect(canvas.getByTestId("workspace-canvas-size-hint")).toHaveCount(0);
     await page.mouse.up();
 


### PR DESCRIPTION
## Summary
Canvas nodes now keep a more useful and consistent size from initial creation through multi-node layout adjustments.

1. **Taller default nodes** — increase the grid-aligned default from `620 × 400px` to `620 × 440px` while preserving dimensions already stored in workspace state.
2. **Active-size inheritance** — create new canvas nodes with the active canvas node dimensions, falling back to the default only when no active node is available.
3. **Bulk size matching** — add a node context-menu action that copies the selected node dimensions to every other canvas node and persists the result immediately.
4. **Localized coverage** — add the new action in English, Korean, Japanese, and Simplified Chinese, with unit, component, and Playwright regression coverage.

## Expected impact

| Canvas behavior | Before | After |
| --- | --- | --- |
| Default new-node size | `620 × 400px` | `620 × 440px` |
| New node with an active node | Always used the default size | Inherits the active node width and height |
| Matching several node sizes | Resize each node manually | One context-menu action updates all other nodes |
| Existing persisted layouts | Restored their saved geometry | Unchanged |

## Design notes

- The existing placement-anchor flow already remembers the previously active session while a newly created session becomes active. Placement now carries the anchor dimensions through nearby candidates and the fallback search so size inheritance holds even when adjacent positions are occupied.
- Bulk matching changes width and height only; node positions and stacking order remain intact. The action is disabled when there is no peer node to update.
- The final default height is `440px`: `460px` caused the resize handle to overlap the minimap at a common app viewport, while `440px` provides a 10% height increase without that regression.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 105 files, 1,227 tests pass
- [x] `PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/canvas.spec.ts` — 17 Canvas tests pass
- [x] `pnpm run build` — production build passes; Vite reports only non-failing bundle advisory warnings
