### PR TITLE
fix(ui): keep dialog actions reachable in compact-height windows

### DIFF
--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -333,6 +333,7 @@ export function ProjectSettingsModal({
       variant="dialog"
       size="2xl"
       ariaLabelledBy="project-settings-title"
+      className="flex flex-col overflow-hidden"
     >
       {project ? (
         <>
@@ -349,7 +350,7 @@ export function ProjectSettingsModal({
             variant="dialog"
             onClose={onClose}
           />
-          <div className="flex h-[28rem]">
+          <div className="flex h-[28rem] min-h-0">
             <SegmentedControl
               activeId={tab}
               items={PROJECT_SETTINGS_TABS.map((tabMeta) => ({

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -4109,7 +4109,7 @@ function WorkflowRunDetailModal({
       onClose={onClose}
       variant="dialog"
       size="2xl"
-      className="flex h-[36rem] flex-col"
+      className="flex h-[36rem] flex-col overflow-hidden"
     >
       {showSkeleton ? (
         <WorkflowRunDetailSkeleton onClose={onClose} />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -470,6 +470,7 @@ export function SettingsModal() {
       variant="dialog"
       size="2xl"
       ariaLabelledBy="acorn-settings-title"
+      className="flex flex-col overflow-hidden"
     >
       <ModalHeader
         title={t("settings.title")}
@@ -478,8 +479,10 @@ export function SettingsModal() {
         variant="dialog"
         onClose={() => setOpen(false)}
       />
-      <div className="flex h-[28rem]">
-        <nav className="flex w-40 shrink-0 flex-col gap-0.5 border-r border-border bg-bg-sidebar/40 px-1.5 py-2">
+      {/* h-[28rem] keeps the body a stable height across tabs (#31); min-h-0
+          lets it shrink instead when the window is too short for 28 rem. */}
+      <div className="flex h-[28rem] min-h-0">
+        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border bg-bg-sidebar/40 px-1.5 py-2">
           {TABS.map((tabMeta) => (
             <button
               key={tabMeta.id}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -31,11 +31,18 @@ const SIZE_CLASS: Record<ModalSize, string> = {
   "5xl": "max-w-5xl",
 };
 
-const BACKDROP_DIALOG = "flex items-start justify-center px-4 pt-24";
+// Dialogs hang from a 96 px top offset on roomy windows. A short webview
+// (~600 px tall) has no room for that plus a fixed-height shell, so below
+// 720 px the offset collapses. `max-h-full` then bounds every dialog to the
+// visible viewport — call sites that lay themselves out as a flex column keep
+// their header/footer fixed and scroll only their body, and the rest fall back
+// to scrolling the shell instead of hanging off the bottom of the webview.
+const BACKDROP_DIALOG =
+  "flex items-start justify-center px-4 pb-6 pt-24 [@media(max-height:720px)]:pt-6";
 const BACKDROP_PANEL = "flex flex-col px-4 py-6";
 
 const CONTENT_DIALOG =
-  "w-full overflow-hidden rounded-2xl border border-border bg-bg-elevated shadow-2xl";
+  "max-h-full w-full overflow-auto rounded-2xl border border-border bg-bg-elevated shadow-2xl";
 const CONTENT_PANEL =
   "mx-auto flex h-full w-full flex-col overflow-hidden rounded-lg border border-border bg-bg shadow-2xl";
 

--- a/src/components/ui/ModalFooter.tsx
+++ b/src/components/ui/ModalFooter.tsx
@@ -29,7 +29,7 @@ export function modalFooterClassName({
   className,
 }: ModalFooterClassNameOptions = {}): string {
   return cn(
-    "flex items-center gap-2 px-4 py-3",
+    "flex shrink-0 items-center gap-2 px-4 py-3",
     MODAL_FOOTER_VARIANT_CLASS[variant],
     MODAL_FOOTER_ALIGN_CLASS[align],
     className,

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect } from "./support";
+import {
+  test,
+  expect,
+  COMPACT_VIEWPORTS,
+  expectFullyInViewport,
+  modalShell,
+} from "./support";
 
 test.describe("project settings", () => {
   test("manages project worktrees from the Worktrees settings tab", async ({
@@ -324,4 +330,41 @@ test.describe("project settings", () => {
     )) as unknown[];
     expect(calls).toEqual([]);
   });
+});
+
+test.describe("project settings: compact height", () => {
+  for (const viewport of COMPACT_VIEWPORTS) {
+    test(`keeps the shell and the footer actions on screen at ${viewport.width}x${viewport.height}`, async ({
+      page,
+      tauri,
+    }) => {
+      await page.setViewportSize({ ...viewport });
+      await tauri.respond("list_projects", [
+        {
+          repo_path: "/tmp/acorn",
+          name: "acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ]);
+
+      await page.goto("/");
+      await page
+        .getByRole("button", { name: "Project acorn" })
+        .click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Project Settings" }).click();
+
+      const modal = page.getByRole("dialog", { name: "Project Settings" });
+      await expect(modal).toBeVisible();
+      await expectFullyInViewport(page, modalShell(modal));
+      await expectFullyInViewport(
+        page,
+        modal.getByRole("button", { name: "Save" }),
+      );
+      await expectFullyInViewport(
+        page,
+        modal.getByRole("button", { name: "Cancel" }),
+      );
+    });
+  }
 });

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  COMPACT_VIEWPORTS,
+  expectFullyInViewport,
+  modalShell,
+} from "./support";
 import type { Locator, Page } from "@playwright/test";
 
 // Right panel needs an active project + session for the tabs to actually
@@ -2569,4 +2576,83 @@ test.describe("right panel: groups", () => {
       )
       .toBe("/tmp/codex-copy-path.jsonl");
   });
+});
+
+test.describe("right panel: workflow run details at compact height", () => {
+  for (const viewport of COMPACT_VIEWPORTS) {
+    test(`keeps the last job reachable at ${viewport.width}x${viewport.height}`, async ({
+      page,
+      tauri,
+    }) => {
+      await page.setViewportSize({ ...viewport });
+      await seedActiveSession(tauri);
+      await tauri.handle("list_workflow_runs", () => ({
+        kind: "ok",
+        account: "test-account",
+        items: [
+          {
+            id: 42,
+            display_title: "Compact dialog run",
+            workflow_name: "CI",
+            status: "completed",
+            conclusion: "success",
+            event: "push",
+            head_branch: "main",
+            head_sha: "abc1234def5678",
+            url: "https://github.com/demo/demo/actions/runs/42",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:05:00Z",
+            started_at: "2026-01-01T00:00:10Z",
+            attempt: 1,
+          },
+        ],
+      }));
+      // 14 jobs overflow the detail body, so the last row is only reachable
+      // when the shell itself fits inside the webview.
+      await tauri.handle("get_workflow_run_detail", () => ({
+        kind: "ok",
+        account: "test-account",
+        detail: {
+          id: 42,
+          display_title: "Compact dialog run",
+          workflow_name: "CI",
+          status: "completed",
+          conclusion: "success",
+          event: "push",
+          head_branch: "main",
+          head_sha: "abc1234def5678",
+          url: "https://github.com/demo/demo/actions/runs/42",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:05:00Z",
+          started_at: "2026-01-01T00:00:10Z",
+          attempt: 1,
+          jobs: Array.from({ length: 14 }, (_, i) => ({
+            id: i + 1,
+            name: `job-${i + 1}`,
+            status: "completed",
+            conclusion: "success",
+            started_at: "2026-01-01T00:00:10Z",
+            completed_at: "2026-01-01T00:01:00Z",
+            url: "",
+            steps: [],
+          })),
+        },
+      }));
+
+      await page.goto("/");
+      await page.getByRole("button", { name: "GitHub" }).click();
+      await page.getByRole("button", { name: "Actions" }).click();
+      await page
+        .getByRole("button", { name: /Compact dialog run/ })
+        .dblclick();
+
+      const modal = page.getByRole("dialog");
+      await expect(modal.getByText("Jobs (14)")).toBeVisible();
+      await expectFullyInViewport(page, modalShell(modal));
+
+      const lastJob = modal.getByRole("button", { name: /job-14/ });
+      await lastJob.scrollIntoViewIfNeeded();
+      await expectFullyInViewport(page, lastJob);
+    });
+  }
 });

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, pressHotkey } from "./support";
+import {
+  test,
+  expect,
+  pressHotkey,
+  COMPACT_VIEWPORTS,
+  expectFullyInViewport,
+  modalShell,
+} from "./support";
 
 const SETTINGS_DIALOG_NAME = /^(Settings|설정)$/;
 
@@ -781,4 +788,36 @@ test.describe("settings modal", () => {
       )
       .toBe(1);
   });
+});
+
+test.describe("settings modal: compact height", () => {
+  for (const viewport of COMPACT_VIEWPORTS) {
+    test(`keeps the shell and the reset action on screen at ${viewport.width}x${viewport.height}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ ...viewport });
+      await page.goto("/");
+      await pressHotkey(page, { mod: true, key: "," });
+
+      const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+      await expect(modal).toBeVisible();
+      await expectFullyInViewport(page, modalShell(modal));
+      await expectFullyInViewport(
+        page,
+        modal.getByRole("button", {
+          name: /^(Reset to defaults|기본값으로 재설정)$/,
+        }),
+      );
+
+      // #31: the body must not resize as tabs change, even once compact-height
+      // bounding is in play.
+      const shellHeight = async () =>
+        (await modalShell(modal).boundingBox())?.height ?? 0;
+      const before = await shellHeight();
+      await modal
+        .getByRole("button", { name: /^(Terminal|터미널)$/ })
+        .click();
+      expect(await shellHeight()).toBe(before);
+    });
+  }
 });

--- a/tests/e2e/support.ts
+++ b/tests/e2e/support.ts
@@ -1,4 +1,9 @@
-import { test as base, expect, type Page } from "@playwright/test";
+import {
+  test as base,
+  expect,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 import { tauriMockSource } from "./fixtures/tauriMock";
 
 type InvokeHandler = (args: unknown) => unknown | Promise<unknown>;
@@ -236,5 +241,38 @@ export async function seedSettingsLanguage(
   );
 }
 
+/** Viewports short enough to expose dialog shells that ignore the window height. */
+export const COMPACT_VIEWPORTS = [
+  { width: 1024, height: 600 },
+  { width: 800, height: 600 },
+] as const;
+
+/**
+ * The `role="dialog"` node is the full-viewport backdrop, so measuring it says
+ * nothing about the dialog itself. This returns the shell inside it.
+ */
+export function modalShell(dialog: Locator): Locator {
+  return dialog.locator("> div").first();
+}
+
+/**
+ * Assert an element is fully painted inside the webview. Compact-height
+ * windows used to push dialog shells (and their footers) below the bottom
+ * edge, where nothing could scroll them back into reach.
+ */
+export async function expectFullyInViewport(
+  page: Page,
+  locator: Locator,
+): Promise<void> {
+  const viewport = page.viewportSize();
+  if (!viewport) throw new Error("Test needs an explicit viewport size");
+  const box = await locator.boundingBox();
+  if (!box) throw new Error("Element must be visible to be measured");
+  expect(box.y).toBeGreaterThanOrEqual(0);
+  expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+}
+
 export { expect };
-export type { Page };
+export type { Locator, Page };


### PR DESCRIPTION
## Summary

At a 600 px-tall Acorn window, several `variant="dialog"` overlays extended past the bottom of the webview. Their bodies scrolled, but the shell itself sat below the visible area, so Settings' **Reset to defaults**, Project Settings' Cancel/Save footer, and the last rows of a Workflow run's job list could not be reached at all.

The root cause was in the shared `Modal`: dialog backdrops always used a 96 px top offset and the shell had no viewport-derived height bound, so `overflow-hidden` clipped whatever fell below the window. This fixes the contract once in `Modal` rather than patching each screen.

## Changes

- `Modal` collapses the dialog top offset from 96 px to 24 px below 720 px of window height, and caps every dialog shell with `max-h-full` so it can never exceed the visible webview.
- Dialog shells fall back to `overflow-auto`, so call sites that are not flex-column aware scroll themselves instead of clipping content that hangs off the bottom edge.
- Settings, Project Settings, and Workflow run details opt into the flex-column treatment (`min-h-0` bodies), keeping their headers and footers fixed while only the body scrolls.
- `ModalFooter` gained `shrink-0` so footer actions keep their height when the shell is squeezed.
- Settings' tab navigation scrolls independently, keeping the reset action reachable on very short windows.

Settings still holds its stable 28 rem body height on taller windows (the intent of #31); it shrinks only when the window genuinely cannot fit it.

## Test plan

- [x] New Playwright coverage at `{ width: 1024, height: 600 }` and `{ width: 800, height: 600 }` for Settings, Project Settings, and Workflow run details, asserting the shell and the critical actions are fully inside the viewport.
- [x] The Workflow run test seeds 14 jobs, scrolls the body to its end, and asserts the final job row is fully visible.
- [x] Verified the six new specs fail on `main`'s layout and pass with this change.
- [x] `pnpm test` — 1227 passed.
- [x] `npx playwright test` — 299 passed, including the existing Graph/canvas compact-height specs and the negative controls (New Project, Merge PR, What's New, Loop session).
- [x] `pnpm build`.

Closes #739
