### PR TITLE
fix(explorer): scope the file explorer to a project's source folders

### DIFF
--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -262,8 +262,13 @@ impl FsScope {
         let mut roots = Vec::new();
         let mut project_roots = Vec::new();
         for project in state.projects.list() {
-            if let Some(root) = Self::push_root(&mut roots, project.repo_path) {
-                project_roots.push(root);
+            // Every root the project spans, not just the primary one: a source
+            // folder is a real repository root, and its files stay unreadable
+            // without it in scope.
+            for path in project.roots() {
+                if let Some(root) = Self::push_root(&mut roots, path) {
+                    project_roots.push(root);
+                }
             }
         }
         project_roots.sort();
@@ -2052,6 +2057,30 @@ mod tests {
         let roots = scope.roots;
 
         assert!(roots.contains(&repo.path().canonicalize().unwrap()));
+        assert!(roots.contains(&worktree.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn scope_from_state_includes_project_source_roots_and_their_sessions() {
+        let state = AppState::new();
+        let repo = tmpdir();
+        let source = tmpdir();
+        let worktree = tmpdir();
+        state
+            .projects
+            .ensure(repo.path().to_path_buf(), "repo".to_string());
+        state
+            .projects
+            .set_source_paths(repo.path(), vec![source.path().to_path_buf()])
+            .unwrap();
+        state
+            .sessions
+            .insert(test_session(source.path(), worktree.path(), true));
+
+        let scope = FsScope::from_state(&state);
+        let roots = scope.roots;
+
+        assert!(roots.contains(&source.path().canonicalize().unwrap()));
         assert!(roots.contains(&worktree.path().canonicalize().unwrap()));
     }
 


### PR DESCRIPTION
## Problem

Opening the file tree of a project's source folder returned `invalid path: path outside allowed project roots: /Users/...` and the tree stayed empty.

`FsScope::from_state` — the allow-list every `fs_explorer` command authorizes against — was still built from `project.repo_path` alone, so the extra roots a project gained in #738 were never in scope.

## Fix

The scope now walks `Project::roots()`, the same helper `registered_project_roots` in `commands.rs` already uses. That also repairs the two lists derived from it: linked worktrees are enumerated per source root instead of the primary one only, and a session whose `repo_path` is a source folder now matches a registered root, so its worktree is authorized too.

## Test

`scope_from_state_includes_project_source_roots_and_their_sessions` covers a project with one source root and a session under it. Verified it fails on the old scope (`assertion failed: roots.contains(&source...)`) and passes with the fix; `cargo test --lib fs_explorer::` is 64 passed.

Refs #738

Claude-Session: https://claude.ai/code/session_015tBt7Qbzx3xtNKFFNEmiER
