### PR TITLE
fix(projects): treat every project root as the project

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3804,11 +3804,14 @@ pub async fn list_unscoped_agent_history(
     state: State<'_, AppState>,
     limit: Option<usize>,
 ) -> AppResult<Vec<AgentHistoryItem>> {
+    // Unscoped history is everything *outside* the known projects, so the list
+    // has to name every root a project spans. Miss a source folder and its
+    // transcripts show up here as if they belonged to no project at all.
     let project_paths = state
         .projects
         .list()
         .into_iter()
-        .map(|project| PathBuf::from(project.repo_path))
+        .flat_map(|project| project.roots())
         .collect();
     run_blocking("list_unscoped_agent_history", move || {
         agent_history::list_unscoped_agent_history(project_paths, limit)
@@ -6229,11 +6232,17 @@ pub async fn remove_project(
         }
     }
     app_state.projects.remove(roots.first().unwrap_or(&path));
-    let drop_settings = remove_settings.unwrap_or(false)
-        || project_settings::should_remove_on_project_close(&path).unwrap_or(false);
-    if drop_settings {
-        if let Err(err) = project_settings::remove(&path) {
-            tracing::warn!(error = %err, path = %path.display(), "failed to remove project settings");
+    // Settings are keyed per repository, so a multi-root project has one record
+    // per root. Closing it has to clear all of them or the source folders keep
+    // a record nothing points at any more.
+    for root in &roots {
+        let drop_settings = remove_settings.unwrap_or(false)
+            || project_settings::should_remove_on_project_close(root).unwrap_or(false);
+        if !drop_settings {
+            continue;
+        }
+        if let Err(err) = project_settings::remove(root) {
+            tracing::warn!(error = %err, path = %root.display(), "failed to remove project settings");
         }
     }
     persist(&app_state);

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -565,4 +565,57 @@ describe("ProjectSettingsModal", () => {
     );
     expect(mockApi.removeWorktree).not.toHaveBeenCalled();
   });
+
+  it("resolves a source folder path to the project that owns it", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: false,
+        pull_requests: { generation_prompt: null },
+      },
+    });
+    useAppStore.setState({
+      projects: [
+        {
+          repo_path: "/repo/acorn",
+          name: "Acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+          source_paths: ["/repo/backoffice"],
+        },
+      ],
+    });
+
+    // The merge dialog opens the modal with a session's own repo path, which
+    // for a session in a source folder is not the project's primary root.
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "backoffice", repoPath: "/repo/backoffice" }}
+          onClose={vi.fn()}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const sourcesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Source folders");
+    expect(sourcesTab).toBeDefined();
+    await act(async () => {
+      sourcesTab!.click();
+    });
+
+    // Both roots are listed, with the project's own root marked primary —
+    // not the source folder the modal was opened from.
+    expect(document.body.textContent).toContain("/repo/acorn");
+    expect(document.body.textContent).toContain("/repo/backoffice");
+    const removeSource = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-label") === "Remove source folder backoffice",
+    );
+    expect(removeSource).toBeDefined();
+  });
 });

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -155,8 +155,13 @@ export function ProjectSettingsModal({
   const pendingSourceMerge = useAppStore((s) => s.pendingSourceMerge);
   const removeProjectWorktree = useAppStore((s) => s.removeProjectWorktree);
   const projects = useAppStore((s) => s.projects);
+  // The modal is also opened from a session's repo path, which for a session
+  // in a source folder is not any project's primary root. Match on every root
+  // a project spans so it still resolves to the project that owns it.
   const projectEntry = project
-    ? projects.find((entry) => entry.repo_path === project.repoPath)
+    ? projects.find((entry) =>
+        projectRootPaths(entry).includes(project.repoPath),
+      )
     : undefined;
   // Worktrees belong to a repository, so a multi-root project has to list and
   // remove them per root rather than through its primary one.
@@ -319,7 +324,10 @@ export function ProjectSettingsModal({
     try {
       const trimmed = name.trim();
       if (trimmed && trimmed !== projectName) {
-        const renamed = await renameProject(project.repoPath, trimmed);
+        const renamed = await renameProject(
+          projectEntry?.repo_path ?? project.repoPath,
+          trimmed,
+        );
         if (!renamed) {
           const message = useAppStore.getState().consumeError();
           setError(
@@ -602,7 +610,9 @@ function ProjectSourceFolderList({ repoPath }: { repoPath: string }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const project = projects.find((entry) => entry.repo_path === repoPath);
+  const project = projects.find((entry) =>
+    projectRootPaths(entry).includes(repoPath),
+  );
   const roots = project ? projectRootPaths(project) : [repoPath];
 
   async function add() {


### PR DESCRIPTION
Follow-up sweep after #742: three more places that still equated a project with its primary root.

## Backend

- **`list_unscoped_agent_history`** passed only `repo_path` to the scanner. The unscoped scope accepts a transcript whose cwd belongs to *no* project, so agent sessions run inside a source folder appeared in the "other" history list as though they sat outside every project. Now built from `roots()`.
- **`remove_project`** cascaded sessions and worktrees over `roots()` but cleared settings for the requested path alone, so closing a multi-root project left a settings record behind for each source folder. The drop decision now runs per root.

## Frontend

- **Project Settings opened from the merge dialog** gets the session's own repo path, which for a session in a source folder is not any project's primary root. The lookup by `repo_path` found nothing, so the Source folders tab drew that folder as the primary and only root ("This project has no extra source folders yet."), the Worktrees tab listed that root alone, and saving a new name called `rename_project` with a path the store does not key. Both lookups now match on every root a project spans, and the rename targets the resolved project's primary root.

## Test

`resolves a source folder path to the project that owns it` renders the modal with a source root and asserts both roots are listed with the real primary marked. Verified it fails on the old lookup — the assertion output shows the source folder rendered as `Primary` with no extra folders — and passes with the fix.

`pnpm vitest run` 1232 passed, `pnpm tsc --noEmit` clean, `cargo test --lib` 665 passed.

Refs #738

Claude-Session: https://claude.ai/code/session_015tBt7Qbzx3xtNKFFNEmiER
