### PR TITLE
feat(sidebar): convert workspaces to projects and back

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -1351,6 +1351,29 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    /// Re-home a session under a different registered project. Used when a
+    /// workspace folder is promoted to a standalone project (and the reverse:
+    /// a project folded back in as a workspace of another project). Only the
+    /// project association moves — the on-disk `worktree_path` is untouched,
+    /// so the live PTY keeps its cwd. `isolated` is cleared when the session's
+    /// worktree becomes the new project root: it is no longer a throwaway
+    /// worktree *inside* a project, and worktree-deletion prompts must not
+    /// offer to delete the project root itself.
+    pub fn update_repo_path(
+        &self,
+        id: &Uuid,
+        repo_path: std::path::PathBuf,
+    ) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.isolated = entry.isolated && entry.worktree_path != repo_path;
+        entry.repo_path = repo_path;
+        entry.updated_at = Utc::now();
+        Ok(entry.clone())
+    }
+
     /// Re-point a session at its main repo and clear `isolated` when the
     /// linked worktree has disappeared from disk (typically: agent exit
     /// pruned the worktree but the session row still references it). Keeps
@@ -1456,6 +1479,46 @@ mod tests {
             progress: SessionGoalProgress::initial(),
             revision,
         }
+    }
+
+    #[test]
+    fn update_repo_path_clears_isolated_only_when_the_worktree_becomes_the_root() {
+        let store = SessionStore::new();
+        let promoted = store.insert(fake_session(
+            "/tmp/acorn-repo",
+            "/tmp/acorn-repo/.acorn/worktrees/wt",
+            true,
+        ));
+        let folded = store.insert(fake_session(
+            "/tmp/acorn-repo/nested",
+            "/tmp/acorn-repo/nested",
+            false,
+        ));
+
+        // Workspace promoted to a project: its worktree is now the repo root.
+        let promoted = store
+            .update_repo_path(
+                &promoted.id,
+                PathBuf::from("/tmp/acorn-repo/.acorn/worktrees/wt"),
+            )
+            .expect("promote");
+        assert_eq!(
+            promoted.repo_path,
+            PathBuf::from("/tmp/acorn-repo/.acorn/worktrees/wt")
+        );
+        assert!(!promoted.isolated);
+
+        // Project folded into a host project: the worktree stays put and the
+        // session must not be mistaken for a throwaway worktree session.
+        let folded = store
+            .update_repo_path(&folded.id, PathBuf::from("/tmp/acorn-repo"))
+            .expect("fold");
+        assert_eq!(folded.repo_path, PathBuf::from("/tmp/acorn-repo"));
+        assert_eq!(
+            folded.worktree_path,
+            PathBuf::from("/tmp/acorn-repo/nested")
+        );
+        assert!(!folded.isolated);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5523,6 +5523,72 @@ pub async fn add_project<R: Runtime>(
     Ok(Some(project))
 }
 
+/// Register a directory that already belongs to a registered project (a linked
+/// worktree, or a nested repository) as a project of its own. Unlike
+/// `add_project` there is no folder picker, so no new trust root is created:
+/// the path must already be reachable from a project Acorn knows about, and it
+/// must be a repository root — a plain subdirectory resolves back to its own
+/// repo and could never hold sessions of its own.
+#[tauri::command]
+pub fn open_project_at_path(state: State<'_, AppState>, path: String) -> AppResult<Project> {
+    let path = canonical_existing_path(Path::new(&path))?;
+    if !registered_project_roots(state.inner())
+        .iter()
+        .any(|root| authorize_project_session_cwd(root, &path).is_ok())
+    {
+        return Err(AppError::InvalidPath(format!(
+            "path is not inside a registered project: {}",
+            path.display()
+        )));
+    }
+    let root = worktree::project_root_for_path(&path)?;
+    if root != path {
+        return Err(AppError::InvalidPath(format!(
+            "not a repository root, it belongs to {}",
+            root.display()
+        )));
+    }
+    let project = state.projects.ensure(root.clone(), project_basename(&root));
+    persist(&state);
+    Ok(project)
+}
+
+/// Re-home sessions under a different registered project. Every session is
+/// validated before any of them moves, so a rejected session leaves the whole
+/// group untouched. The rule is the one `create_session` applies to a new
+/// session's cwd: the session's worktree must live inside the target project's
+/// repo subtree or one of its linked worktrees.
+#[tauri::command]
+pub fn move_sessions_to_project(
+    state: State<'_, AppState>,
+    session_ids: Vec<String>,
+    repo_path: String,
+) -> AppResult<Vec<Session>> {
+    let repo = authorize_registered_project_root(state.inner(), Path::new(&repo_path))?;
+    let mut ids = Vec::with_capacity(session_ids.len());
+    for id in &session_ids {
+        let id = Uuid::parse_str(id).map_err(|e| AppError::Other(e.to_string()))?;
+        let session = state.sessions.get(&id)?;
+        if !session.project_scoped {
+            return Err(AppError::InvalidPath(
+                "local sessions do not belong to a project".into(),
+            ));
+        }
+        let cwd = session
+            .worktree_path
+            .canonicalize()
+            .unwrap_or_else(|_| session.worktree_path.clone());
+        authorize_project_session_cwd(&repo, &cwd)?;
+        ids.push(id);
+    }
+    let mut moved = Vec::with_capacity(ids.len());
+    for id in ids {
+        moved.push(state.sessions.update_repo_path(&id, repo.clone())?);
+    }
+    persist(&state);
+    Ok(moved)
+}
+
 #[tauri::command]
 pub async fn select_project_parent_folder<R: Runtime>(
     app: AppHandle<R>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -714,6 +714,8 @@ pub fn run() {
             commands::cancel_chat_message,
             commands::list_projects,
             commands::add_project,
+            commands::open_project_at_path,
+            commands::move_sessions_to_project,
             commands::select_project_parent_folder,
             commands::get_last_project_parent_folder,
             commands::has_git_identity,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,8 +9,10 @@ import {
   Copy,
   ExternalLink,
   Folder,
+  FolderInput,
   FolderOpen,
   FolderPlus,
+  FolderSymlink,
   GitBranch,
   GitPullRequest,
   Home,
@@ -118,6 +120,7 @@ import {
   findProjectFolderById,
   findWorktreeWorkspaceForPath,
   isDefaultProjectFolder,
+  isPathInsideOrEqual,
   resolveProjectFolderIdForSession,
   type ProjectFolder,
   type ProjectFolderGroup,
@@ -2002,11 +2005,27 @@ function ProjectGroupView({
 }: ProjectGroupViewProps) {
   const t = useTranslation();
   const shortcuts = useSettings((s) => s.settings.shortcuts);
+  const showToast = useToasts((s) => s.show);
+  const projects = useAppStore((s) => s.projects);
+  const foldProjectIntoProject = useAppStore((s) => s.foldProjectIntoProject);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [createMenu, setCreateMenu] = useState<{
     x: number;
     y: number;
   } | null>(null);
+  // Only a project that physically lives inside another one can become its
+  // workspace — sessions have to keep resolving under the host repo.
+  // ponytail: prefix check only; add a git-worktree lookup if someone keeps
+  // worktrees outside the repo tree.
+  const foldTargets = useMemo(
+    () =>
+      projects.filter(
+        (candidate) =>
+          candidate.repo_path !== project.repoPath &&
+          isPathInsideOrEqual(project.repoPath, candidate.repo_path),
+      ),
+    [projects, project.repoPath],
+  );
   const {
     attributes,
     listeners,
@@ -2054,6 +2073,18 @@ function ProjectGroupView({
     },
     [onAddAutonomousGoal, onAddSession, projectSessionCreationFolder],
   );
+
+  async function foldIntoProject(targetRepoPath: string) {
+    const folded = await foldProjectIntoProject(
+      project.repoPath,
+      targetRepoPath,
+    );
+    if (folded) return;
+    const error = useAppStore.getState().consumeError();
+    showToast(
+      `${t("toasts.project.foldIntoProjectFailed")} ${error ?? ""}`.trim(),
+    );
+  }
 
   const createMenuItems = useMemo<ContextMenuItem[]>(
     () => {
@@ -2305,6 +2336,25 @@ function ProjectGroupView({
             onClick: onAddWorktreeFolder,
           },
           contextMenuGroupTitle(t, "project"),
+          ...(foldTargets.length > 0
+            ? [
+                {
+                  type: "submenu" as const,
+                  label: sidebarText(
+                    t,
+                    "sidebar.actions.foldProjectIntoProject",
+                  ),
+                  icon: <FolderInput size={12} />,
+                  children: foldTargets.map((target) => ({
+                    label: target.name,
+                    icon: <Folder size={12} />,
+                    onClick: () => {
+                      void foldIntoProject(target.repo_path);
+                    },
+                  })),
+                },
+              ]
+            : []),
           {
             label: sidebarText(t, "sidebar.actions.projectSettings"),
             icon: <SettingsIcon size={12} />,
@@ -2477,6 +2527,10 @@ function ProjectFolderView({
 }: ProjectFolderViewProps) {
   const t = useTranslation();
   const shortcuts = useSettings((s) => s.settings.shortcuts);
+  const showToast = useToasts((s) => s.show);
+  const promoteProjectFolderToProject = useAppStore(
+    (s) => s.promoteProjectFolderToProject,
+  );
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [createMenu, setCreateMenu] = useState<{
@@ -2577,6 +2631,15 @@ function ProjectFolderView({
   function submitRename(next: string) {
     setEditing(false);
     onRenameFolder(folder.id, next);
+  }
+
+  async function promoteToProject() {
+    const promoted = await promoteProjectFolderToProject(folder.id);
+    if (promoted) return;
+    const error = useAppStore.getState().consumeError();
+    showToast(
+      `${t("toasts.project.promoteWorkspaceFailed")} ${error ?? ""}`.trim(),
+    );
   }
 
   const workspaceLabel = workspacePathLabel(folder);
@@ -2790,6 +2853,20 @@ function ProjectFolderView({
             icon: <Pencil size={12} />,
             onClick: () => setEditing(true),
           },
+          ...(removable && isWorktreeWorkspace(folder)
+            ? [
+                {
+                  label: sidebarText(
+                    t,
+                    "sidebar.actions.promoteProjectFolderToProject",
+                  ),
+                  icon: <FolderSymlink size={12} />,
+                  onClick: () => {
+                    void promoteToProject();
+                  },
+                } satisfies ContextMenuItem,
+              ]
+            : []),
           {
             label: sidebarText(t, "sidebar.actions.revealInFinder"),
             icon: <FolderOpen size={12} />,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -327,6 +327,18 @@ export const api = {
   addProject(title?: string): Promise<Project | null> {
     return invoke<Project | null>("add_project", { title });
   },
+  openProjectAtPath(path: string): Promise<Project> {
+    return invoke<Project>("open_project_at_path", { path });
+  },
+  moveSessionsToProject(
+    sessionIds: string[],
+    repoPath: string,
+  ): Promise<Session[]> {
+    return invoke<Session[]>("move_sessions_to_project", {
+      sessionIds,
+      repoPath,
+    });
+  },
   selectProjectParentFolder(title?: string): Promise<string | null> {
     return invoke<string | null>("select_project_parent_folder", { title });
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,8 @@
       "pauseFailed": "Goal session could not be paused:"
     },
     "project": {
+      "promoteWorkspaceFailed": "Failed to convert workspace to project:",
+      "foldIntoProjectFailed": "Failed to convert project to workspace:",
       "addFailed": "Failed to add project:",
       "createFailed": "Failed to create project:",
       "removeFailed": "Failed to remove project:",
@@ -1233,6 +1235,8 @@
       "newProjectFolder": "New workspace",
       "newProjectFolderWithWorktree": "New worktree workspace",
       "createWorkspaceFromWorktree": "Create Workspace from Worktree",
+      "promoteProjectFolderToProject": "Convert to project",
+      "foldProjectIntoProject": "Convert to workspace of…",
       "renameProjectFolder": "Rename workspace",
       "removeProjectFolder": "Remove workspace",
       "moveToProjectFolder": "Move to",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -28,6 +28,8 @@
       "pauseFailed": "目標セッションを一時停止できませんでした:"
     },
     "project": {
+      "promoteWorkspaceFailed": "ワークスペースをプロジェクトに変換できませんでした:",
+      "foldIntoProjectFailed": "プロジェクトをワークスペースに変換できませんでした:",
       "addFailed": "プロジェクトの追加に失敗しました:",
       "createFailed": "プロジェクトの作成に失敗しました:",
       "removeFailed": "プロジェクトの削除に失敗しました:",
@@ -1233,6 +1235,8 @@
       "newProjectFolder": "新しいワークスペース",
       "newProjectFolderWithWorktree": "新しいワークツリーワークスペース",
       "createWorkspaceFromWorktree": "ワークツリーからワークスペースを作成する",
+      "promoteProjectFolderToProject": "プロジェクトに変換",
+      "foldProjectIntoProject": "ワークスペースに変換",
       "renameProjectFolder": "ワークスペースの名前を変更する",
       "removeProjectFolder": "ワークスペースを削除する",
       "moveToProjectFolder": "に移動します",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -28,6 +28,8 @@
       "pauseFailed": "Goal 세션을 일시정지하지 못했습니다:"
     },
     "project": {
+      "promoteWorkspaceFailed": "작업공간을 프로젝트로 전환하지 못했습니다:",
+      "foldIntoProjectFailed": "프로젝트를 작업공간으로 전환하지 못했습니다:",
       "addFailed": "프로젝트를 추가하지 못했습니다:",
       "createFailed": "프로젝트를 만들지 못했습니다:",
       "removeFailed": "프로젝트를 제거하지 못했습니다:",
@@ -1233,6 +1235,8 @@
       "newProjectFolder": "새 작업공간",
       "newProjectFolderWithWorktree": "새 워크트리 작업공간",
       "createWorkspaceFromWorktree": "이 워크트리로 작업공간 만들기",
+      "promoteProjectFolderToProject": "프로젝트로 전환",
+      "foldProjectIntoProject": "작업공간으로 전환",
       "renameProjectFolder": "작업공간 이름 변경",
       "removeProjectFolder": "작업공간 제거",
       "moveToProjectFolder": "이동",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -28,6 +28,8 @@
       "pauseFailed": "目标会话无法暂停："
     },
     "project": {
+      "promoteWorkspaceFailed": "无法将工作区转换为项目：",
+      "foldIntoProjectFailed": "无法将项目转换为工作区：",
       "addFailed": "无法添加项目：",
       "createFailed": "无法创建项目：",
       "removeFailed": "无法删除项目：",
@@ -1233,6 +1235,8 @@
       "newProjectFolder": "新建工作区",
       "newProjectFolderWithWorktree": "新建工作树工作区",
       "createWorkspaceFromWorktree": "从工作树创建工作区",
+      "promoteProjectFolderToProject": "转换为项目",
+      "foldProjectIntoProject": "转换为工作区",
       "renameProjectFolder": "重命名工作区",
       "removeProjectFolder": "删除工作区",
       "moveToProjectFolder": "移至",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -42,6 +42,8 @@ vi.mock("./lib/api", () => {
       agentTranscriptSummary: vi.fn(async () => null),
       agentTranscriptSummaryAtPath: vi.fn(async () => null),
       addProject: vi.fn(async () => ({}) as Project),
+      openProjectAtPath: vi.fn(async () => ({}) as Project),
+      moveSessionsToProject: vi.fn(async () => [] as Session[]),
       createNewProject: vi.fn(async () => ({}) as Project),
       removeProject: vi.fn(async () => []),
       reorderProjects: vi.fn(async (paths: string[]) =>
@@ -246,6 +248,7 @@ beforeEach(() => {
   mockApi.removeSession.mockResolvedValue(null);
   mockApi.removeWorktree.mockResolvedValue(null);
   mockApi.removeProject.mockResolvedValue([]);
+  mockApi.moveSessionsToProject.mockResolvedValue([]);
   mockApi.loadChatSessionState.mockResolvedValue({
     messages: [],
     turns: [],
@@ -4070,5 +4073,122 @@ describe("auto initial session on first project add", () => {
     await useAppStore.getState().addProject("Select project");
 
     expect(mockApi.createSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("workspace <-> project conversion", () => {
+  const WORKTREE_A = `${REPO_A}/.acorn/worktrees/wt`;
+  const NESTED_A = `${REPO_A}/packages/web`;
+
+  it("promotes a workspace into its own project and moves its sessions there", async () => {
+    const promoted = project(WORKTREE_A, 1);
+    mockApi.openProjectAtPath.mockResolvedValueOnce(promoted);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0), promoted]);
+    mockApi.listSessions.mockResolvedValue([
+      session("s1", WORKTREE_A, { worktree_path: WORKTREE_A }),
+    ]);
+    useAppStore.setState({
+      projects: [project(REPO_A, 0)],
+      sessions: [
+        session("s1", REPO_A, { worktree_path: WORKTREE_A, isolated: true }),
+      ],
+      projectFolders: {
+        [REPO_A]: [
+          {
+            id: REPO_A,
+            repoPath: REPO_A,
+            name: "Default",
+            cwdPath: REPO_A,
+            position: 0,
+          },
+          {
+            id: "wt-folder",
+            repoPath: REPO_A,
+            name: "wt",
+            cwdPath: WORKTREE_A,
+            position: 1,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      useAppStore.getState().promoteProjectFolderToProject("wt-folder"),
+    ).resolves.toBe(true);
+
+    expect(mockApi.openProjectAtPath).toHaveBeenCalledWith(WORKTREE_A);
+    expect(mockApi.moveSessionsToProject).toHaveBeenCalledWith(
+      ["s1"],
+      WORKTREE_A,
+    );
+    const state = useAppStore.getState();
+    expect(state.projectFolders[REPO_A]?.map((folder) => folder.id)).toEqual([
+      REPO_A,
+    ]);
+    expect(state.activeProject).toBe(WORKTREE_A);
+  });
+
+  it("refuses to promote a workspace that shares the project directory", async () => {
+    useAppStore.setState({
+      projects: [project(REPO_A, 0)],
+      projectFolders: {
+        [REPO_A]: [
+          {
+            id: "plain",
+            repoPath: REPO_A,
+            name: "Plain",
+            cwdPath: REPO_A,
+            position: 1,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      useAppStore.getState().promoteProjectFolderToProject("plain"),
+    ).resolves.toBe(false);
+    expect(mockApi.openProjectAtPath).not.toHaveBeenCalled();
+  });
+
+  it("refuses to promote the default workspace", async () => {
+    useAppStore.setState({ projects: [project(REPO_A, 0)] });
+
+    await expect(
+      useAppStore.getState().promoteProjectFolderToProject(REPO_A),
+    ).resolves.toBe(false);
+    expect(mockApi.openProjectAtPath).not.toHaveBeenCalled();
+  });
+
+  it("folds a nested project back in as a workspace of its host", async () => {
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+    mockApi.listSessions.mockResolvedValue([
+      session("s1", REPO_A, { worktree_path: NESTED_A }),
+    ]);
+    useAppStore.setState({
+      projects: [project(REPO_A, 0), project(NESTED_A, 1)],
+      sessions: [session("s1", NESTED_A, { worktree_path: NESTED_A })],
+    });
+
+    await expect(
+      useAppStore.getState().foldProjectIntoProject(NESTED_A, REPO_A),
+    ).resolves.toBe(true);
+
+    expect(mockApi.moveSessionsToProject).toHaveBeenCalledWith(["s1"], REPO_A);
+    expect(mockApi.removeProject).toHaveBeenCalledWith(NESTED_A, false);
+    const state = useAppStore.getState();
+    expect(state.projectFolders[NESTED_A]).toBeUndefined();
+    expect(
+      state.projectFolders[REPO_A]?.map((folder) => folder.cwdPath),
+    ).toEqual([REPO_A, NESTED_A]);
+    expect(state.activeProject).toBe(REPO_A);
+  });
+
+  it("refuses to fold a project into one that is not registered", async () => {
+    useAppStore.setState({ projects: [project(NESTED_A, 0)] });
+
+    await expect(
+      useAppStore.getState().foldProjectIntoProject(NESTED_A, REPO_A),
+    ).resolves.toBe(false);
+    expect(mockApi.removeProject).not.toHaveBeenCalled();
   });
 });

--- a/src/store.ts
+++ b/src/store.ts
@@ -73,6 +73,7 @@ import {
   ensureProjectFolders,
   isDefaultProjectFolder,
   isPathInsideOrEqual,
+  makeDefaultProjectFolder,
   makeProjectFolderId,
   pruneSessionFolderAssignments,
   resolveProjectFolderIdForSession,
@@ -479,6 +480,16 @@ interface AppStateModel {
   ) => ProjectFolder | null;
   renameProjectFolder: (folderId: string, name: string) => void;
   removeProjectFolder: (folderId: string) => void;
+  /** Promote a workspace folder to a standalone project. Only works when the
+   *  folder's directory is a repository root of its own (a linked worktree, a
+   *  nested repo) — the backend rejects plain subdirectories. */
+  promoteProjectFolderToProject: (folderId: string) => Promise<boolean>;
+  /** Fold a project back in as a workspace of `targetRepoPath`. Requires the
+   *  project to live inside the target project's tree. */
+  foldProjectIntoProject: (
+    repoPath: string,
+    targetRepoPath: string,
+  ) => Promise<boolean>;
   moveSessionToProjectFolder: (
     sessionId: string,
     folderId: string | null,
@@ -2510,6 +2521,107 @@ export const useAppStore = create<AppStateModel>()(
         ),
       };
     });
+  },
+
+  async promoteProjectFolderToProject(folderId) {
+    const state = get();
+    const folder = findProjectFolder(state, folderId);
+    if (!folder || isDefaultProjectFolder(folder)) return false;
+    // A workspace that shares the project's directory has nothing to promote:
+    // it would resolve straight back to the project it already lives in.
+    if (folder.cwdPath === folder.repoPath) return false;
+    const folders = state.projectFolders[folder.repoPath] ?? [];
+    const sessionIds = state.sessions
+      .filter(
+        (session) =>
+          session.repo_path === folder.repoPath &&
+          session.project_scoped !== false &&
+          resolveProjectFolderIdForSession(
+            folders,
+            session,
+            state.sessionFolderIds,
+          ) === folder.id,
+      )
+      .map((session) => session.id);
+    try {
+      const project = await api.openProjectAtPath(folder.cwdPath);
+      if (sessionIds.length > 0) {
+        await api.moveSessionsToProject(sessionIds, project.repo_path);
+      }
+      await get().refreshAll();
+      get().removeProjectFolder(folder.id);
+      get().setActiveProject(project.repo_path);
+      set({ error: null });
+      return true;
+    } catch (e) {
+      set({ error: errorMessage(e) });
+      return false;
+    }
+  },
+
+  async foldProjectIntoProject(repoPath, targetRepoPath) {
+    if (repoPath === targetRepoPath) return false;
+    const state = get();
+    const hasTarget = state.projects.some(
+      (project) => project.repo_path === targetRepoPath,
+    );
+    if (!hasTarget) return false;
+    const sourceName =
+      state.projects.find((project) => project.repo_path === repoPath)?.name ??
+      basenamePath(repoPath);
+    const sourceFolders = sortProjectFolders(
+      state.projectFolders[repoPath]?.length
+        ? state.projectFolders[repoPath]
+        : [makeDefaultProjectFolder(repoPath)],
+    );
+    const sessionIds = state.sessions
+      .filter(
+        (session) =>
+          session.repo_path === repoPath && session.project_scoped !== false,
+      )
+      .map((session) => session.id);
+    try {
+      if (sessionIds.length > 0) {
+        await api.moveSessionsToProject(sessionIds, targetRepoPath);
+      }
+      await api.removeProject(repoPath, false);
+      await get().refreshAll();
+    } catch (e) {
+      // The session move may already have landed before the project removal
+      // failed — resync so the sidebar shows what the backend actually holds.
+      await get().refreshAll();
+      set({ error: errorMessage(e) });
+      return false;
+    }
+    // One workspace per distinct directory: the project root itself plus any
+    // worktree workspaces it owned. Extra named workspaces that shared the
+    // root directory collapse into it — sessions are matched back by cwd, and
+    // two workspaces on one directory would be indistinguishable anyway.
+    const seenCwdPaths = new Set<string>();
+    for (const folder of sourceFolders) {
+      if (seenCwdPaths.has(folder.cwdPath)) continue;
+      seenCwdPaths.add(folder.cwdPath);
+      get().createProjectFolder(
+        targetRepoPath,
+        isDefaultProjectFolder(folder) ? sourceName : folder.name,
+        folder.cwdPath,
+      );
+    }
+    set((s) => {
+      const staleFolderIds = new Set(
+        (s.projectFolders[repoPath] ?? []).map((folder) => folder.id),
+      );
+      const { [repoPath]: _dropped, ...projectFolders } = s.projectFolders;
+      const workspaces = Object.fromEntries(
+        Object.entries(s.workspaces).filter(
+          ([workspaceId]) => !staleFolderIds.has(workspaceId),
+        ),
+      );
+      return { projectFolders, workspaces };
+    });
+    get().setActiveProject(targetRepoPath);
+    set({ error: null });
+    return true;
   },
 
   moveSessionToProjectFolder(sessionId, folderId) {


### PR DESCRIPTION
## Summary

Adds two sidebar context-menu conversions between the workspace ("source folder") and project levels, so a directory can move between the two groupings without losing its sessions.

- **Right-click a worktree workspace title → "Convert to project".** The workspace directory is registered as a standalone project and every session in that workspace is re-homed under it.
- **Right-click a project title → "Convert to workspace of …".** The project folds back in as a workspace of a host project that physically contains it; its own worktree workspaces are recreated under the host so nothing is orphaned.

## How it works

A project is a repository root and a workspace is a directory inside one, so the conversions are only offered where the paths actually nest that way:

- Promote is shown only for workspaces whose directory differs from the project root, and the backend additionally rejects anything that is not a repository root of its own — a plain subdirectory resolves back to the repo it already belongs to and could never hold sessions.
- Fold lists only projects that contain the source project's path, which covers Acorn-managed worktrees (`.acorn/worktrees/*`) and monorepo subdirectories.

Two new commands back this:

- `open_project_at_path` registers a directory that already belongs to a registered project. There is no folder picker, so unlike `add_project` it creates no new trust root: the path must already be reachable from a project Acorn knows about.
- `move_sessions_to_project` re-homes sessions, validating every session against the target project before any of them moves, using the same rule `create_session` applies to a new session's cwd.

`SessionStore::update_repo_path` clears `isolated` when the session's worktree becomes the new project root, so worktree-deletion prompts never offer to delete the project root itself. The on-disk `worktree_path` is untouched, so a live PTY keeps its cwd across the conversion.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1232 passed (5 new store tests covering promote, fold, and both refusal guards)
- [x] `pnpm run build:frontend`
- [x] `cargo test --lib` — 659 passed (1 new `update_repo_path` test)
- [ ] Manual run of the desktop app — not executed in this environment

## Notes

Detecting git worktrees kept outside the repo tree is intentionally left out: the fold target list uses a path-prefix check only. Worth adding a real worktree lookup if someone keeps worktrees elsewhere.
