### PR TITLE
feat(projects): open a session when an existing project is added

### DIFF
--- a/src/components/AddExistingProjectDialog.tsx
+++ b/src/components/AddExistingProjectDialog.tsx
@@ -24,15 +24,15 @@ interface AddExistingProjectDialogProps {
 /**
  * Assembles a project before anything is registered: the roots it spans and
  * the name it carries are collected here, and cancelling leaves the app
- * exactly as it was. Nothing opens on save either — the project appears in the
- * sidebar and the user decides when to start a session in it.
+ * exactly as it was. Saving registers the project and opens one session in it,
+ * matching what creating a brand new project does.
  */
 export function AddExistingProjectDialog({
   open,
   onClose,
 }: AddExistingProjectDialogProps) {
   const t = useTranslation();
-  const refreshProjects = useAppStore((s) => s.refreshProjects);
+  const addProjectAt = useAppStore((s) => s.addProjectAt);
   const [roots, setRoots] = useState<string[]>([]);
   const [name, setName] = useState("");
   const [nameTouched, setNameTouched] = useState(false);
@@ -81,8 +81,7 @@ export function AddExistingProjectDialog({
     setBusy(true);
     setError(null);
     try {
-      await api.addProjectAt(name.trim() || basenamePath(roots[0]), roots);
-      await refreshProjects();
+      await addProjectAt(name.trim() || basenamePath(roots[0]), roots);
       onClose();
     } catch (e) {
       setError(String(e));

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -41,6 +41,7 @@ vi.mock("./lib/api", () => {
       }) as unknown as ChatSessionState),
       agentTranscriptSummary: vi.fn(async () => null),
       agentTranscriptSummaryAtPath: vi.fn(async () => null),
+      addProjectAt: vi.fn(async () => ({}) as Project),
       addProjectSource: vi.fn(async () => ({ project: null, merge: null })),
       mergeProjectSource: vi.fn(async () => ({}) as Project),
       createNewProject: vi.fn(async () => ({}) as Project),
@@ -4075,6 +4076,19 @@ describe("project add and create", () => {
       "regular",
       null,
     );
+  });
+
+  it("spawns one regular session when an existing project is added", async () => {
+    mockApi.addProjectAt.mockResolvedValueOnce(project(REPO_B, 1));
+    mockApi.listProjects.mockResolvedValue([project(REPO_B, 1)]);
+    mockApi.createSession.mockResolvedValueOnce(session("s-added", REPO_B));
+    mockApi.listSessions.mockResolvedValue([session("s-added", REPO_B)]);
+
+    await useAppStore.getState().addProjectAt("repo-b", [REPO_B]);
+
+    expect(mockApi.addProjectAt).toHaveBeenCalledWith("repo-b", [REPO_B]);
+    expect(mockApi.createSession).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().activeProject).toBe(REPO_B);
   });
 
   it("holds a source folder another project owns until the merge is confirmed", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -550,6 +550,8 @@ interface AppStateModel {
     removeWorktrees?: boolean,
     removeSettings?: boolean,
   ) => Promise<WorktreeRemoval[]>;
+  /** Register an existing project spanning `roots` and open its first session. */
+  addProjectAt: (name: string, roots: string[]) => Promise<Project>;
   renameProject: (repoPath: string, name: string) => Promise<boolean>;
   addProjectSource: (repoPath: string, title?: string) => Promise<boolean>;
   /** Apply the pending merge: move the folder into the project that asked. */
@@ -3308,6 +3310,20 @@ export const useAppStore = create<AppStateModel>()(
 
   clearPendingRemove() {
     set({ pendingRemoveId: null });
+  },
+
+  async addProjectAt(name, roots) {
+    try {
+      const project = await api.addProjectAt(name, roots);
+      await get().refreshProjects();
+      get().setActiveProject(project.repo_path);
+      await createInitialProjectSession(get, project.repo_path);
+      set({ error: null });
+      return project;
+    } catch (e) {
+      set({ error: errorMessage(e) });
+      throw e;
+    }
   },
 
   async renameProject(repoPath, name) {


### PR DESCRIPTION
## Summary

Adding an existing project registered it and stopped there — the workspace opened on the empty-state prompt with no terminal, while creating a brand new project spawns a first regular session. This makes both paths land the same way.

`AddExistingProjectDialog` now saves through a new `addProjectAt` store action instead of calling the Tauri command directly. The action registers the project, refreshes, activates it, and reuses `createInitialProjectSession`, which is already guarded on the project having zero sessions, so re-adding a known repo never piles on duplicates. The session is a plain regular, non-isolated one rooted at the primary source folder.

## Test plan

- [x] `bunx vitest run` — 109 files, 1257 tests pass (new store test: `spawns one regular session when an existing project is added`)
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: add an existing project from the sidebar, confirm one terminal session opens in it

https://claude.ai/code/session_0116oh4Ns9LXpDBubtQEDSpt
