### PR TITLE
fix(projects): give every source root its own workspace row

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15368,6 +15368,41 @@ mod tests {
     }
 
     #[test]
+    fn splitting_refuses_the_primary_root() {
+        // The primary root *is* the project — splitting it out would leave the
+        // project pointing at a root it no longer owns, so only extra source
+        // folders are separable.
+        let state = crate::state::AppState::default();
+        let owner = PathBuf::from("/tmp/acorn-split-primary-owner");
+        let source = PathBuf::from("/tmp/acorn-split-primary-source");
+        state.projects.ensure(owner.clone(), "owner".to_string());
+        state
+            .projects
+            .set_source_paths(&owner, vec![source.clone()])
+            .expect("project is registered");
+
+        let error = super::split_project_source_inner(
+            &state,
+            owner.display().to_string(),
+            owner.display().to_string(),
+        )
+        .expect_err("split is refused");
+
+        assert!(
+            error.to_string().contains("not a source folder"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(state.projects.list().len(), 1);
+        assert_eq!(
+            state
+                .projects
+                .owner_of_root(&source)
+                .map(|project| project.repo_path),
+            Some(owner),
+        );
+    }
+
+    #[test]
     fn splitting_refuses_a_root_the_project_does_not_span() {
         let state = crate::state::AppState::default();
         let owner = PathBuf::from("/tmp/acorn-split-guard-owner");

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1291,7 +1291,7 @@ export function Sidebar() {
         const folder = folderId
           ? projectFolderById(currentAllWorkspaceGroups, folderId)
           : null;
-        return folder ? isGroupDefaultFolder(folder) : false;
+        return folder && project ? isGroupDefaultFolder(project, folder) : false;
       };
       if (
         activeSession.project_scoped !== false &&
@@ -2190,9 +2190,12 @@ function ProjectGroupView({
     transition,
   };
 
+  // A multi-root project flattens nothing, so this falls through to the
+  // primary root's folder — the project header's own create actions still
+  // start there, and every other root has its own row to start from.
   const defaultFolderGroup =
     project.folders.find((folderGroup) =>
-      isGroupDefaultFolder(folderGroup.folder),
+      isGroupDefaultFolder(project, folderGroup.folder),
     ) ?? project.folders[0] ?? null;
   const projectSessionCreationFolder = defaultFolderGroup?.folder ?? null;
 
@@ -2318,7 +2321,7 @@ function ProjectGroupView({
   }
 
   const namedFolderGroups = project.folders.filter(
-    (folderGroup) => !isGroupDefaultFolder(folderGroup.folder),
+    (folderGroup) => !isGroupDefaultFolder(project, folderGroup.folder),
   );
   const projectFoldersForRows = project.folders.map(
     (folderGroup) => folderGroup.folder,

--- a/src/lib/projectFolders.test.ts
+++ b/src/lib/projectFolders.test.ts
@@ -8,6 +8,7 @@ import {
   isGroupDefaultFolder,
   makeDefaultProjectFolder,
   projectFolderDisplayName,
+  projectGroupSpansMultipleRoots,
   pruneSessionFolderAssignments,
   resolveProjectFolderIdForSession,
   resolveProjectRootPath,
@@ -375,7 +376,7 @@ describe("project source folders", () => {
     ]);
   });
 
-  it("flattens every root's default folder under the project header", () => {
+  it("draws a row for every root, the primary one included", () => {
     const groups = buildProjectFolderGroups(
       [multiRoot],
       [],
@@ -383,12 +384,24 @@ describe("project source folders", () => {
     );
 
     const flattened = groups[0].folders.filter((group) =>
-      isGroupDefaultFolder(group.folder),
+      isGroupDefaultFolder(groups[0], group.folder),
     );
-    expect(flattened.map((group) => group.folder.repoPath)).toEqual([
-      "/repo/app",
-      "/repo/api",
-    ]);
+    expect(flattened).toEqual([]);
+    expect(projectGroupSpansMultipleRoots(groups[0])).toBe(true);
+  });
+
+  it("keeps a single-root project's sessions flat under its header", () => {
+    const single = project("/repo/app");
+    const groups = buildProjectFolderGroups(
+      [single],
+      [session("a", "/repo/app")],
+      ensureProjectFolders([single], [], {}),
+    );
+
+    expect(projectGroupSpansMultipleRoots(groups[0])).toBe(false);
+    expect(isGroupDefaultFolder(groups[0], groups[0].folders[0].folder)).toBe(
+      true,
+    );
   });
 
   it("names a source root's workspace after its folder", () => {

--- a/src/lib/projectFolders.ts
+++ b/src/lib/projectFolders.ts
@@ -63,13 +63,26 @@ export function resolveProjectRootPath(
   return index.get(repoPath) ?? repoPath;
 }
 
+/** Whether the group's folders come from more than one repository root. */
+export function projectGroupSpansMultipleRoots(
+  group: ProjectFolderProjectGroup,
+): boolean {
+  const roots = new Set(group.folders.map((entry) => entry.folder.repoPath));
+  return roots.size > 1;
+}
+
 /**
- * Whether a folder's sessions render flat under the project header. Every
- * root's default folder qualifies: a source folder is a place sessions start,
- * not a workspace of its own, so it gets no row — the agent already sees it as
- * an extra directory.
+ * Whether a folder's sessions render flat under the project header. Only a
+ * single-root project flattens. Once a project spans several roots every root
+ * — the primary one included — draws its own workspace row: the row is where a
+ * session or worktree is started in that repository, and each root keeps its
+ * own view mode (panes/kanban/canvas) instead of borrowing a sibling's.
  */
-export function isGroupDefaultFolder(folder: ProjectFolder): boolean {
+export function isGroupDefaultFolder(
+  group: ProjectFolderProjectGroup,
+  folder: ProjectFolder,
+): boolean {
+  if (projectGroupSpansMultipleRoots(group)) return false;
   return isDefaultProjectFolder(folder);
 }
 

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -1,5 +1,6 @@
 import {
   isGroupDefaultFolder,
+  projectGroupSpansMultipleRoots,
   type ProjectFolderGroup,
   type ProjectFolderProjectGroup,
 } from "./projectFolders";
@@ -27,12 +28,14 @@ export function buildProjectTopLevelItems(
   order: readonly string[],
   prioritizeNeedsInputTabs = false,
 ): ProjectTopLevelItem[] {
-  // Every root's default folder flattens into the same top-level list, so a
-  // session started in a source folder sits beside the primary root's.
+  // A multi-root project draws a row per root instead, so nothing flattens —
+  // falling back to the first folder there would render its sessions twice.
   const defaultFolderGroups = project.folders.filter((folderGroup) =>
-    isGroupDefaultFolder(folderGroup.folder),
+    isGroupDefaultFolder(project, folderGroup.folder),
   );
-  const fallbackFolderGroup = defaultFolderGroups[0] ?? project.folders[0] ?? null;
+  const fallbackFolderGroup = projectGroupSpansMultipleRoots(project)
+    ? null
+    : (defaultFolderGroups[0] ?? project.folders[0] ?? null);
   const directSessions: ProjectTopLevelItem[] = (
     defaultFolderGroups.length > 0
       ? defaultFolderGroups
@@ -48,7 +51,7 @@ export function buildProjectTopLevelItems(
     })),
   );
   const folders: ProjectTopLevelItem[] = project.folders
-    .filter((folderGroup) => !isGroupDefaultFolder(folderGroup.folder))
+    .filter((folderGroup) => !isGroupDefaultFolder(project, folderGroup.folder))
     .map((folderGroup) => ({
       id: sidebarFolderItemId(folderGroup.folder.id),
       type: "folder",
@@ -144,7 +147,7 @@ export function buildDragPriorityIndex(
   for (const group of groups) {
     const topLevelContainerId = `project:${group.repoPath}`;
     for (const folderGroup of group.folders) {
-      const isDefaultFolder = isGroupDefaultFolder(folderGroup.folder);
+      const isDefaultFolder = isGroupDefaultFolder(group, folderGroup.folder);
       // The default folder is flattened into top-level session rows and never
       // drawn as a folder row, so it has no drag id to index.
       if (!isDefaultFolder) {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -737,6 +737,24 @@ describe("openSessionSurface", () => {
     expect(state.terminalPopupSessionId).toBeNull();
   });
 
+  it("gives every source root of a project its own view mode", async () => {
+    await seed(
+      [{ ...project(REPO_A, 0), source_paths: [REPO_B] }],
+      [session("a1", REPO_A), session("b1", REPO_B)],
+    );
+
+    useAppStore.getState().setActiveProject(REPO_A);
+    useAppStore.getState().setWorkspaceViewMode("kanban");
+
+    // Each root draws its own sidebar row, so its view mode is its own: the
+    // source folder's row stays on panes until the user switches it.
+    expect(useAppStore.getState().openSessionSurface("b1")).toBe(true);
+    expect(useAppStore.getState().workspaceViewMode).toBe("panes");
+
+    expect(useAppStore.getState().openSessionSurface("a1")).toBe(true);
+    expect(useAppStore.getState().workspaceViewMode).toBe("kanban");
+  });
+
   it("does not open a surface for an unknown session", async () => {
     await seed([project(REPO_A, 0)], [session("a1", REPO_A)]);
 

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4349,7 +4349,7 @@ test.describe("sidebar: project lifecycle", () => {
       .toBe("manual-order");
   });
 
-  test("a source folder folds into its project instead of getting a row", async ({
+  test("every root of a project draws its own workspace row", async ({
     page,
     tauri,
   }) => {
@@ -4435,18 +4435,22 @@ test.describe("sidebar: project lifecycle", () => {
 
     // One project row, not two, even though the sessions live in two repos.
     await expect(page.getByRole("button", { name: /^Project / })).toHaveCount(1);
-    // A source folder is not a workspace: it gets no row of its own, and the
-    // session started in it sits flat under the project header beside the
-    // primary root's session.
+    // Each root is a workspace of its own — the primary one included — so it
+    // is obvious which repository a session starts in, and each row keeps its
+    // own view mode.
+    await expect(
+      page.locator('aside [data-sidebar-workspace-id="/tmp/demo"]'),
+    ).toBeVisible();
     await expect(
       page.locator('aside [data-sidebar-workspace-id="/tmp/demo-api"]'),
-    ).toHaveCount(0);
-    await expect(
-      page.locator("aside").getByRole("listitem").filter({ hasText: /^primarymain/ }),
     ).toBeVisible();
+    // Each row is labelled after its own repository.
     await expect(
-      page.locator("aside").getByRole("listitem").filter({ hasText: /^apimain/ }),
-    ).toBeVisible();
+      page.locator('aside [data-sidebar-workspace-id="/tmp/demo"]'),
+    ).toContainText("demo");
+    await expect(
+      page.locator('aside [data-sidebar-workspace-id="/tmp/demo-api"]'),
+    ).toContainText("demo-api");
     // Its named workspaces still render, tagged with the root they belong to.
     await expect(
       page.locator(
@@ -4455,7 +4459,7 @@ test.describe("sidebar: project lifecycle", () => {
     ).toContainText("demo-api");
   });
 
-  test("top-level sessions reorder across the project's roots", async ({
+  test("each root's row holds the sessions started in that root", async ({
     page,
     tauri,
   }) => {
@@ -4528,18 +4532,20 @@ test.describe("sidebar: project lifecycle", () => {
     await page.goto("/");
 
     const sidebar = page.locator("aside");
-    const primary = sidebar.getByRole("button", {
-      name: /^primary main · Ready/,
-    });
-    const api = sidebar.getByRole("button", { name: /^api main · Ready/ });
+    const primaryRow = sidebar.locator(
+      'li:has(> [data-sidebar-workspace-id="/tmp/demo"])',
+    );
+    const apiRow = sidebar.locator(
+      'li:has(> [data-sidebar-workspace-id="/tmp/demo-api"])',
+    );
 
-    // Both roots' sessions share the project's top level, so one can be
-    // dragged past the other even though they live in different repos.
-    expect(await sessionPairOrder(primary, api)).toBe("alpha-beta");
-    await dragBetween(page, api, primary);
-    await expect
-      .poll(async () => sessionPairOrder(primary, api))
-      .toBe("beta-alpha");
+    // Each session sits under the row of the root it was started in — a
+    // session records one repository, so the rows are what keeps that visible.
+    await expect(primaryRow.getByText("primary", { exact: true })).toHaveCount(
+      1,
+    );
+    await expect(primaryRow.getByText("api", { exact: true })).toHaveCount(0);
+    await expect(apiRow.getByText("api", { exact: true })).toHaveCount(1);
   });
 
   test("the project hover card lists the source folders", async ({
@@ -4558,10 +4564,15 @@ test.describe("sidebar: project lifecycle", () => {
     await tauri.respond("list_sessions", []);
 
     await page.goto("/");
-    await page.getByText("demo", { exact: true }).hover();
+    // The primary root's own row carries the same basename, so scope the
+    // hover to the project header's label rather than matching either row.
+    await page
+      .getByRole("button", { name: "Project demo" })
+      .getByText("demo", { exact: true })
+      .hover();
 
-    // Source roots draw no rows, so the hover card is where the extra
-    // directories every session hands the agent are visible.
+    // With no sessions yet the rows are empty, so the hover card is still
+    // where the extra directories every session hands the agent are visible.
     const tooltip = page.getByRole("tooltip");
     await expect(tooltip).toContainText("/tmp/demo");
     await expect(tooltip).toContainText("/tmp/demo-api");


### PR DESCRIPTION
Since #741 a project's source roots were flattened: every root's default folder rendered as bare sessions under the project header, and the roots themselves had no rows. That left a multi-root project with no place to act on a root — no way to start a session or a worktree in a source folder — and it made a single view mode look broken, since the sessions of two roots sat side by side while each root's workspace remembered its own panes/kanban/canvas choice.

Rows are back, and now the primary root gets one too: a project that spans several roots draws a workspace row per root, so a session is always started from the repository it will live in, and each row keeps its own view mode instead of borrowing a sibling's. A single-root project is untouched — its sessions still render flat under the project header, with no extra level of nesting.

Splitting a root back out into its own project stays limited to the extra source folders: the primary root is the project, and `split_project_source` already refuses it. A test pins that.

## Verification

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1287 passed
- [x] `npx playwright test tests/e2e/sidebar.spec.ts` — 50 passed, including the rewritten multi-root row expectations
- [x] `npx playwright test tests/e2e/{canvas,kanban,panes,project-settings,right-panel}.spec.ts` — 95 passed
- [x] `cargo test --lib splitting_refuses` — 2 passed, covering the new primary-root guard

https://claude.ai/code/session_016KqTD6A7zkKAsoiXL1Qja2
