### PR TITLE
feat(sidebar): keep multi-root project headers project-only

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2141,13 +2141,14 @@ function ProjectGroupView({
   const t = useTranslation();
   const shortcuts = useSettings((s) => s.settings.shortcuts);
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
-  // Source roots have no rows of their own, so the project's hover card is
-  // where they show up.
+  // The persisted source list drives both project hover details and whether
+  // creation belongs on the project header or on the individual root rows.
   const sourcePaths = useAppStore(
     (s) =>
       s.projects.find((entry) => entry.repo_path === project.repoPath)
         ?.source_paths,
   );
+  const hasMultipleProjectRoots = (sourcePaths?.length ?? 0) > 0;
   const showToast = useToasts((s) => s.show);
   const projects = useAppStore((s) => s.projects);
   const convertProjectToSourceFolder = useAppStore(
@@ -2190,9 +2191,8 @@ function ProjectGroupView({
     transition,
   };
 
-  // A multi-root project flattens nothing, so this falls through to the
-  // primary root's folder — the project header's own create actions still
-  // start there, and every other root has its own row to start from.
+  // Single-root project headers create in this folder. Multi-root projects
+  // leave creation to their root rows so the target repository is explicit.
   const defaultFolderGroup =
     project.folders.find((folderGroup) =>
       isGroupDefaultFolder(project, folderGroup.folder),
@@ -2320,6 +2320,63 @@ function ProjectGroupView({
     }
   }
 
+  const projectActionMenuItems: ContextMenuItem[] = [
+    ...(sourceFolderHosts.length > 0
+      ? [
+          {
+            type: "submenu" as const,
+            label: sidebarText(
+              t,
+              "sidebar.actions.convertProjectToSourceFolder",
+            ),
+            icon: <FolderInput size={12} />,
+            children: sourceFolderHosts.map((host) => ({
+              label: host.name,
+              icon: <FolderGit2 size={12} />,
+              onClick: () => {
+                void convertToSourceFolder(host.repo_path);
+              },
+            })),
+          },
+        ]
+      : []),
+    {
+      label: sidebarText(t, "sidebar.actions.projectSettings"),
+      icon: <SettingsIcon size={12} />,
+      onClick: onOpenSettings,
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      icon: <FolderOpen size={12} />,
+      onClick: () => {
+        void openInFinder(project.repoPath);
+      },
+    },
+    {
+      label: sidebarText(t, "sidebar.actions.copyPath"),
+      icon: <Copy size={12} />,
+      onClick: () => {
+        void copyText(project.repoPath);
+      },
+    },
+  ];
+  const closeProjectMenuItem: ContextMenuItem = {
+    label: sidebarText(t, "sidebar.actions.closeProject"),
+    icon: <X size={12} />,
+    onClick: onRemoveProject,
+  };
+  const projectManagementMenuItems: ContextMenuItem[] = [
+    contextMenuGroupTitle(t, "project"),
+    {
+      label: sidebarText(t, "sidebar.actions.addProjectSourceFolder"),
+      icon: <FolderGit2 size={12} />,
+      onClick: onAddSourceFolder,
+    },
+    ...projectActionMenuItems,
+    contextMenuGroupTitle(t, "danger"),
+    closeProjectMenuItem,
+  ];
+
   const namedFolderGroups = project.folders.filter(
     (folderGroup) => !isGroupDefaultFolder(project, folderGroup.folder),
   );
@@ -2412,51 +2469,70 @@ function ProjectGroupView({
           )}
         </span>
         <div className="ml-auto hidden shrink-0 items-center gap-1 group-hover:flex">
-          {PROJECT_SESSION_PRIMARY_CREATE_ACTIONS.map((action) => (
-            <Tooltip
-              key={action.id}
-              label={sidebarText(t, action.labelKey)}
-              shortcut={
-                action.hotkeyId
-                  ? formatHotkey(shortcuts[action.hotkeyId])
-                  : undefined
-              }
-              side="bottom"
-            >
-              <button
-                type="button"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setMenu(null);
-                  setCreateMenu(null);
-                  runCreateAction(action);
-                }}
-                className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-                aria-label={sidebarText(t, action.ariaKey)}
-              >
-                {projectSessionCreateIcon(action.id)}
-              </button>
-            </Tooltip>
-          ))}
-          <button
-            type="button"
-            onPointerDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation();
-              const rect = e.currentTarget.getBoundingClientRect();
-              setMenu(null);
-              setCreateMenu((current) =>
-                current === null ? { x: rect.left, y: rect.bottom + 4 } : null,
-              );
-            }}
-            className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-            aria-label={sidebarText(t, "sidebar.aria.newSessionMenuInProject")}
-            aria-haspopup="menu"
-            aria-expanded={createMenu !== null}
+          {!hasMultipleProjectRoots
+            ? PROJECT_SESSION_PRIMARY_CREATE_ACTIONS.map((action) => (
+                <Tooltip
+                  key={action.id}
+                  label={sidebarText(t, action.labelKey)}
+                  shortcut={
+                    action.hotkeyId
+                      ? formatHotkey(shortcuts[action.hotkeyId])
+                      : undefined
+                  }
+                  side="bottom"
+                >
+                  <button
+                    type="button"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMenu(null);
+                      setCreateMenu(null);
+                      runCreateAction(action);
+                    }}
+                    className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+                    aria-label={sidebarText(t, action.ariaKey)}
+                  >
+                    {projectSessionCreateIcon(action.id)}
+                  </button>
+                </Tooltip>
+              ))
+            : null}
+          <Tooltip
+            label={sidebarText(
+              t,
+              hasMultipleProjectRoots
+                ? "sidebar.aria.projectMenu"
+                : "sidebar.aria.newSessionMenuInProject",
+            )}
+            side="bottom"
           >
-            <MoreHorizontal size={13} />
-          </button>
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                const rect = e.currentTarget.getBoundingClientRect();
+                setMenu(null);
+                setCreateMenu((current) =>
+                  current === null
+                    ? { x: rect.left, y: rect.bottom + 4 }
+                    : null,
+                );
+              }}
+              className="flex size-5 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              aria-label={sidebarText(
+                t,
+                hasMultipleProjectRoots
+                  ? "sidebar.aria.projectMenu"
+                  : "sidebar.aria.newSessionMenuInProject",
+              )}
+              aria-haspopup="menu"
+              aria-expanded={createMenu !== null}
+            >
+              <MoreHorizontal size={13} />
+            </button>
+          </Tooltip>
           <Tooltip
             label={sidebarText(t, "sidebar.actions.closeProject")}
             side="bottom"
@@ -2481,81 +2557,51 @@ function ProjectGroupView({
         x={createMenu?.x ?? 0}
         y={createMenu?.y ?? 0}
         onClose={() => setCreateMenu(null)}
-        items={overflowCreateMenuItems}
+        items={
+          hasMultipleProjectRoots
+            ? projectManagementMenuItems
+            : overflowCreateMenuItems
+        }
       />
       <ContextMenu
         open={menu !== null}
         x={menu?.x ?? 0}
         y={menu?.y ?? 0}
         onClose={() => setMenu(null)}
-        items={[
-          contextMenuGroupTitle(t, "session"),
-          ...createMenuItems,
-          contextMenuGroupTitle(t, "workspace"),
-          {
-            label: sidebarText(t, "sidebar.actions.newProjectFolder"),
-            icon: <FolderPlus size={12} />,
-            onClick: onAddFolder,
-          },
-          {
-            label: sidebarText(
-              t,
-              "sidebar.actions.newProjectFolderWithWorktree",
-            ),
-            icon: <GitBranch size={12} />,
-            onClick: onAddWorktreeFolder,
-          },
-          {
-            label: sidebarText(t, "sidebar.actions.addProjectSourceFolder"),
-            icon: <FolderGit2 size={12} />,
-            onClick: onAddSourceFolder,
-          },
-          contextMenuGroupTitle(t, "project"),
-          ...(sourceFolderHosts.length > 0
-            ? [
+        items={
+          hasMultipleProjectRoots
+            ? projectManagementMenuItems
+            : [
+                contextMenuGroupTitle(t, "session"),
+                ...createMenuItems,
+                contextMenuGroupTitle(t, "workspace"),
                 {
-                  type: "submenu" as const,
+                  label: sidebarText(t, "sidebar.actions.newProjectFolder"),
+                  icon: <FolderPlus size={12} />,
+                  onClick: onAddFolder,
+                },
+                {
                   label: sidebarText(
                     t,
-                    "sidebar.actions.convertProjectToSourceFolder",
+                    "sidebar.actions.newProjectFolderWithWorktree",
                   ),
-                  icon: <FolderInput size={12} />,
-                  children: sourceFolderHosts.map((host) => ({
-                    label: host.name,
-                    icon: <FolderGit2 size={12} />,
-                    onClick: () => {
-                      void convertToSourceFolder(host.repo_path);
-                    },
-                  })),
+                  icon: <GitBranch size={12} />,
+                  onClick: onAddWorktreeFolder,
                 },
+                {
+                  label: sidebarText(
+                    t,
+                    "sidebar.actions.addProjectSourceFolder",
+                  ),
+                  icon: <FolderGit2 size={12} />,
+                  onClick: onAddSourceFolder,
+                },
+                contextMenuGroupTitle(t, "project"),
+                ...projectActionMenuItems,
+                contextMenuGroupTitle(t, "danger"),
+                closeProjectMenuItem,
               ]
-            : []),
-          {
-            label: sidebarText(t, "sidebar.actions.projectSettings"),
-            icon: <SettingsIcon size={12} />,
-            onClick: onOpenSettings,
-          },
-          {
-            label: sidebarText(t, "sidebar.actions.revealInFinder"),
-            icon: <FolderOpen size={12} />,
-            onClick: () => {
-              void openInFinder(project.repoPath);
-            },
-          },
-          {
-            label: sidebarText(t, "sidebar.actions.copyPath"),
-            icon: <Copy size={12} />,
-            onClick: () => {
-              void copyText(project.repoPath);
-            },
-          },
-          contextMenuGroupTitle(t, "danger"),
-          {
-            label: sidebarText(t, "sidebar.actions.closeProject"),
-            icon: <X size={12} />,
-            onClick: onRemoveProject,
-          },
-        ]}
+        }
       />
       {!collapsed ? (
         <ul
@@ -5141,8 +5187,8 @@ function buildSessionHoverDetails(
 /**
  * What a project is, in the terms that matter to the agent: the folder its
  * sessions start in, and the extra roots every session hands over as
- * `--add-dir`. Those roots have no sidebar rows of their own, so this is where
- * the user sees them.
+ * `--add-dir`. The hover summary keeps the complete paths available while the
+ * sidebar rows use compact root names.
  */
 function buildProjectHoverDetails(
   t: Translator,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1289,6 +1289,7 @@
     },
     "aria": {
       "project": "Project",
+      "projectMenu": "Project menu",
       "dragToReorderProject": "Drag to reorder project",
       "newSessionMenuInProject": "Create session in this project",
       "newSessionMenuInProjectFolder": "Create session in this workspace",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1289,6 +1289,7 @@
     },
     "aria": {
       "project": "プロジェクト",
+      "projectMenu": "プロジェクトメニュー",
       "dragToReorderProject": "ドラッグしてプロジェクトを並べ替えます",
       "newSessionMenuInProject": "このプロジェクトにセッションを作成する",
       "newSessionMenuInProjectFolder": "このワークスペースにセッションを作成する",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1289,6 +1289,7 @@
     },
     "aria": {
       "project": "프로젝트",
+      "projectMenu": "프로젝트 메뉴",
       "dragToReorderProject": "프로젝트 순서를 바꾸려면 드래그",
       "newSessionMenuInProject": "이 프로젝트에 세션 만들기",
       "newSessionMenuInProjectFolder": "이 작업공간에 세션 만들기",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1289,6 +1289,7 @@
     },
     "aria": {
       "project": "项目",
+      "projectMenu": "项目菜单",
       "dragToReorderProject": "拖动以重新排序项目",
       "newSessionMenuInProject": "在此项目中创建会话",
       "newSessionMenuInProjectFolder": "在此工作区中创建会话",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4459,6 +4459,54 @@ test.describe("sidebar: project lifecycle", () => {
     ).toContainText("demo-api");
   });
 
+  test("a multi-root project header keeps only project management actions", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+        source_paths: ["/tmp/demo-api"],
+      },
+    ]);
+    await tauri.respond("list_sessions", []);
+
+    await page.goto("/");
+
+    const projectRow = page.getByRole("button", { name: "Project demo" });
+    await projectRow.hover();
+    await expect(
+      projectRow.getByRole("button", { name: "New session in this project" }),
+    ).toHaveCount(0);
+    await expect(
+      projectRow.getByRole("button", {
+        name: "New worktree session in this project",
+      }),
+    ).toHaveCount(0);
+
+    const projectMenuButton = projectRow.getByRole("button", {
+      name: "Project menu",
+    });
+    await expect(projectMenuButton).toBeVisible();
+    await projectMenuButton.click();
+
+    const expectedProjectActions = [
+      "Add source folder",
+      "Project Settings",
+      "Reveal in Finder",
+      "Copy path",
+      "Close project",
+    ];
+    await expect(page.getByRole("menuitem")).toHaveText(expectedProjectActions);
+
+    await page.keyboard.press("Escape");
+    await projectRow.click({ button: "right" });
+    await expect(page.getByRole("menuitem")).toHaveText(expectedProjectActions);
+  });
+
   test("a source folder header creates a worktree session in that source repository", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Multi-root project headers now delegate root-scoped creation to the individual root rows and keep only project-level actions at the group level.

1. **Header scoping** — hide direct regular and worktree session buttons whenever a project has an extra source root.
2. **Project-only menus** — make both the ellipsis and right-click menus expose source-folder management, project settings, Finder/path actions, and project close only.
3. **Accessible localization** — give the multi-root ellipsis a dedicated project-menu label in all supported languages.
4. **Regression coverage** — verify multi-root headers contain no creation actions while single-root headers keep their existing shortcuts.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Multi-root project header | Creation buttons and mixed workspace/session menu target the primary root implicitly | No root-scoped creation; project management actions only |
| Source-root rows | Per-root session and workspace creation | Unchanged and remains the explicit creation surface |
| Single-root project header | Direct session buttons and creation menu | Unchanged |

## Design notes

- A project is treated as multi-root when `source_paths` contains at least one extra root, meaning the primary root plus one or more source roots.
- The ellipsis and right-click menu share the same project-management item list in multi-root mode so alternate interaction paths cannot expose different scopes.
- Session creation plumbing is unchanged; this only removes ambiguous entry points from the group header.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "multi-root project header|project header exposes regular and worktree session buttons"` — 2 tests pass
- [x] `pnpm run test` — 109 files and 1,287 tests pass
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 52 tests pass
- [x] `git diff --check` — passes