### PR TITLE
fix(sessions): keep auto-rename bound to the active Codex transcript

### DIFF
--- a/src-tauri/src/agent_resume_persister.rs
+++ b/src-tauri/src/agent_resume_persister.rs
@@ -29,7 +29,7 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock, PoisonError};
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use acorn_agent::AgentKind;
 use acorn_session::Session;
@@ -170,10 +170,9 @@ fn tick(state: &AppState) -> io::Result<()> {
 /// binders (the status poll's codex fallback) share one write policy
 /// instead of growing a second, subtly different marker writer.
 ///
-/// Writer hierarchy: the background tick stays authoritative — its
-/// PTY-tree scan disambiguates multi-process cwds the fallback abstains
-/// from — and a fallback write it disagrees with is corrected on the next
-/// tick (forward moves pass, the dormant-echo gate blocks bad rollbacks).
+/// Inferred writers share a settling window and dormant-rollback guard.
+/// Provider-declared hook writes bypass incoming guards, while competing
+/// inferred scans wait for the abandoned transcript to become dormant.
 pub fn bind_session_marker(session_id: uuid::Uuid, kind: AgentKind, uuid: &str) -> io::Result<()> {
     let state_dir = agent_resume::ensure_session_state_dir(session_id)?;
     bind_marker_in_state_dir(&state_dir, kind, uuid)
@@ -193,11 +192,51 @@ pub fn bind_provider_session_marker(
 
 /// Serializes marker writes across the background tick and the status
 /// poll's fallback. The read-check-write below is not atomic on its own;
-/// two threads interleaving could skip the dormant-echo arbitration and
-/// flap the marker.
+/// two threads interleaving could skip marker arbitration and flap the
+/// marker.
 fn marker_bind_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct ProviderMarkerLease {
+    uuid: String,
+    bound_at: Instant,
+}
+
+fn provider_marker_leases() -> &'static Mutex<HashMap<(PathBuf, AgentKind), ProviderMarkerLease>> {
+    static LEASES: OnceLock<Mutex<HashMap<(PathBuf, AgentKind), ProviderMarkerLease>>> =
+        OnceLock::new();
+    LEASES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn remember_provider_marker_lease(state_dir: &Path, kind: AgentKind, uuid: &str) {
+    let now = Instant::now();
+    let mut leases = provider_marker_leases()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    leases.retain(|_, lease| {
+        lease.bound_at.elapsed() <= Duration::from_secs(acorn_transcript::DORMANT_TRANSCRIPT_SECS)
+    });
+    leases.insert(
+        (state_dir.to_path_buf(), kind),
+        ProviderMarkerLease {
+            uuid: uuid.to_string(),
+            bound_at: now,
+        },
+    );
+}
+
+fn provider_marker_lease_is_active(state_dir: &Path, kind: AgentKind, uuid: &str) -> bool {
+    let mut leases = provider_marker_leases()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    leases.retain(|_, lease| {
+        lease.bound_at.elapsed() <= Duration::from_secs(acorn_transcript::DORMANT_TRANSCRIPT_SECS)
+    });
+    leases
+        .get(&(state_dir.to_path_buf(), kind))
+        .is_some_and(|lease| lease.uuid == uuid)
 }
 
 fn bind_marker_in_state_dir(state_dir: &Path, kind: AgentKind, uuid: &str) -> io::Result<()> {
@@ -230,35 +269,49 @@ fn bind_marker_in_state_dir_with_policy(
         .lock()
         .unwrap_or_else(PoisonError::into_inner);
     let id_file = state_dir.join(id_filename(kind));
-    let previous = agent_resume::read_provider_marker(&id_file)?.map(|marker| marker.text);
-    if previous.as_deref() == Some(uuid.as_str()) {
+    let previous = agent_resume::read_provider_marker(&id_file)?;
+    if previous.as_ref().map(|marker| marker.text.as_str()) == Some(uuid.as_str()) {
+        if policy == MarkerBindPolicy::ProviderDeclared {
+            remember_provider_marker_lease(state_dir, kind, &uuid);
+        }
         return Ok(());
     }
-    // A backwards move (to an earlier-born transcript) is legitimate
-    // when the user `--resume`d an old conversation — that transcript
-    // is hot again. But right after an in-session `/new` rotation the
-    // scan can echo the abandoned original once the new transcript
-    // goes idle; writing that echo would oscillate the marker. Skip
-    // only the dormant-echo case so the marker never flaps.
-    if marker_update_is_blocked(policy, previous.as_deref(), &uuid, |prev, next| {
-        marker_rollback_is_dormant_echo(kind, prev, next)
-    }) {
+    let provider_binding_is_settling = previous
+        .as_ref()
+        .is_some_and(|marker| provider_marker_lease_is_active(state_dir, kind, &marker.text));
+    // A provider hook can move the marker while the previous transcript is
+    // still hot enough for an inferred scan to select it. Hold that declared
+    // binding through the ambiguity window, then reject dormant backwards
+    // echoes while still allowing an actively written explicit resume.
+    if marker_update_is_blocked(
+        policy,
+        previous.as_ref().map(|marker| marker.text.as_str()),
+        &uuid,
+        provider_binding_is_settling,
+        |prev, next| marker_rollback_is_dormant_echo(kind, prev, next),
+    ) {
         return Ok(());
     }
-    agent_resume::replace_provider_marker(&id_file, &uuid).map(drop)
+    agent_resume::replace_provider_marker(&id_file, &uuid)?;
+    if policy == MarkerBindPolicy::ProviderDeclared {
+        remember_provider_marker_lease(state_dir, kind, &uuid);
+    }
+    Ok(())
 }
 
 fn marker_update_is_blocked<F>(
     policy: MarkerBindPolicy,
     previous: Option<&str>,
     next: &str,
+    provider_binding_is_settling: bool,
     dormant_echo: F,
 ) -> bool
 where
     F: FnOnce(&str, &str) -> bool,
 {
     policy == MarkerBindPolicy::Inferred
-        && previous.is_some_and(|previous| dormant_echo(previous, next))
+        && previous
+            .is_some_and(|previous| provider_binding_is_settling || dormant_echo(previous, next))
 }
 
 fn id_filename(kind: AgentKind) -> &'static str {
@@ -618,33 +671,37 @@ mod tests {
     }
 
     #[test]
-    fn provider_declared_bind_replaces_the_existing_marker() {
+    fn provider_declared_bind_replaces_existing_claude_and_codex_markers() {
         let dir = std::env::temp_dir().join(format!(
             "acorn-provider-bind-{}",
             uuid::Uuid::new_v4().simple()
         ));
         fs::create_dir_all(&dir).unwrap();
-        let marker = dir.join("claude.id");
         let previous = "019f2001-bbbb-76b0-8410-2e073b38a2c2";
         let resumed = "019e2001-aaaa-76b0-8410-2e073b38a2c1";
-        fs::write(&marker, format!("{previous}\n")).unwrap();
 
         assert!(marker_update_is_blocked(
             MarkerBindPolicy::Inferred,
             Some(previous),
             resumed,
+            false,
             |_, _| true,
         ));
         assert!(!marker_update_is_blocked(
             MarkerBindPolicy::ProviderDeclared,
             Some(previous),
             resumed,
+            true,
             |_, _| true,
         ));
 
-        bind_provider_marker_in_state_dir(&dir, AgentKind::Claude, resumed).unwrap();
-
-        assert_eq!(read_marker(&marker).as_deref(), Some(resumed));
+        for kind in [AgentKind::Claude, AgentKind::Codex] {
+            let marker = dir.join(id_filename(kind));
+            fs::write(&marker, format!("{previous}\n")).unwrap();
+            bind_provider_marker_in_state_dir(&dir, kind, resumed).unwrap();
+            bind_marker_in_state_dir(&dir, kind, previous).unwrap();
+            assert_eq!(read_marker(&marker).as_deref(), Some(resumed));
+        }
         fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7355,11 +7355,16 @@ fn generate_session_title_inner(
         Some(&session.worktree_path),
     )?;
     let latest = state.sessions.get(&id)?;
-    let can_store = if force {
-        crate::session_titles::can_force_generate_title(&latest)
-    } else {
-        crate::session_titles::can_generate_title(&latest, Some(&title_input.transcript_id))
-    };
+    let current_title_input = resolve_title_input_for_session(&latest, id);
+    let current_transcript_id = current_title_input
+        .as_ref()
+        .map(|input| input.transcript_id.as_str());
+    let can_store = can_store_generated_session_title(
+        &latest,
+        &title_input.transcript_id,
+        current_transcript_id,
+        force,
+    );
     if !can_store {
         return Ok(GenerateSessionTitleResult {
             status: GenerateSessionTitleStatus::Skipped,
@@ -7382,6 +7387,22 @@ fn generate_session_title_inner(
         status: GenerateSessionTitleStatus::Generated,
         session: enrich_session(updated),
     })
+}
+
+fn can_store_generated_session_title(
+    session: &Session,
+    expected_transcript_id: &str,
+    current_transcript_id: Option<&str>,
+    force: bool,
+) -> bool {
+    if current_transcript_id != Some(expected_transcript_id) {
+        return false;
+    }
+    if force {
+        crate::session_titles::can_force_generate_title(session)
+    } else {
+        crate::session_titles::can_generate_title(session, current_transcript_id)
+    }
 }
 
 fn resolve_title_input_for_session(
@@ -11005,9 +11026,9 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        auto_title_enabled_for_new_session, collect_memory_usage_from_roots,
-        configured_git_identity, create_unique_worktree, daemon_spawn_name_for_session,
-        detach_requested_by_stale_renderer, font_name_from_path,
+        auto_title_enabled_for_new_session, can_store_generated_session_title,
+        collect_memory_usage_from_roots, configured_git_identity, create_unique_worktree,
+        daemon_spawn_name_for_session, detach_requested_by_stale_renderer, font_name_from_path,
         infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
         normalize_session_goal, normalize_session_graph, poll_defers_to_hook,
         remove_linked_worktree_at_path, restore_pending_session_removal, seed_initial_commit,
@@ -11022,7 +11043,7 @@ mod tests {
         Session, SessionAgentProvider, SessionGoal, SessionGoalModelConfig, SessionGoalPolicies,
         SessionGoalPreset, SessionGoalProgress, SessionGoalStagePolicy, SessionGraph,
         SessionGraphAgent, SessionGraphCanvas, SessionGraphNodePosition, SessionKind, SessionMode,
-        WorkGraphGroupDirection,
+        SessionTitleSource, WorkGraphGroupDirection,
     };
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
@@ -14897,6 +14918,47 @@ mod tests {
             SessionKind::Control,
             SessionMode::Chat,
             Some(SessionAgentProvider::Codex),
+        ));
+    }
+
+    #[test]
+    fn generated_title_store_is_fenced_to_the_resolved_transcript() {
+        let mut session = Session::new(
+            "new session".to_string(),
+            PathBuf::from("/tmp/repo"),
+            PathBuf::from("/tmp/repo"),
+            "main".to_string(),
+            false,
+            SessionKind::Regular,
+        );
+        session.auto_title_enabled = Some(true);
+
+        assert!(can_store_generated_session_title(
+            &session,
+            "codex-current",
+            Some("codex-current"),
+            false,
+        ));
+        assert!(!can_store_generated_session_title(
+            &session,
+            "codex-stale",
+            Some("codex-current"),
+            false,
+        ));
+        assert!(!can_store_generated_session_title(
+            &session,
+            "codex-stale",
+            None,
+            true,
+        ));
+
+        session.title_source = SessionTitleSource::Generated;
+        session.generated_title_transcript_id = Some("codex-previous".to_string());
+        assert!(can_store_generated_session_title(
+            &session,
+            "codex-current",
+            Some("codex-current"),
+            false,
         ));
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -165,6 +165,25 @@ fn reveal_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
     }
 }
 
+fn authoritative_hook_transcript(
+    provider: acorn_session::SessionAgentProvider,
+    ownership: agent_hooks::AgentHookOwnership,
+    provider_session_id: Option<&str>,
+) -> Option<(acorn_agent::AgentKind, &str)> {
+    if ownership != agent_hooks::AgentHookOwnership::Owner
+        || !matches!(
+            provider,
+            acorn_session::SessionAgentProvider::Claude
+                | acorn_session::SessionAgentProvider::Codex
+        )
+    {
+        return None;
+    }
+    let provider_session_id = provider_session_id?;
+    uuid::Uuid::parse_str(provider_session_id).ok()?;
+    Some((provider, provider_session_id))
+}
+
 #[cfg(test)]
 mod project_path_tests {
     use super::*;
@@ -220,6 +239,58 @@ mod project_path_tests {
         assert_eq!(normalized.repo_path, root.canonicalize().unwrap());
         assert_eq!(normalized.worktree_path, subdir);
         std::fs::remove_dir_all(&root).ok();
+    }
+}
+
+#[cfg(test)]
+mod hook_transcript_tests {
+    use super::*;
+
+    const PROVIDER_SESSION_ID: &str = "019fd0e8-57a5-77a0-b317-bebfbd855c7d";
+
+    #[test]
+    fn owner_hooks_bind_claude_and_codex_conversations() {
+        for provider in [
+            acorn_session::SessionAgentProvider::Claude,
+            acorn_session::SessionAgentProvider::Codex,
+        ] {
+            assert_eq!(
+                authoritative_hook_transcript(
+                    provider,
+                    agent_hooks::AgentHookOwnership::Owner,
+                    Some(PROVIDER_SESSION_ID),
+                ),
+                Some((provider, PROVIDER_SESSION_ID)),
+            );
+        }
+    }
+
+    #[test]
+    fn hook_transcript_binding_rejects_children_and_unverified_ids() {
+        assert_eq!(
+            authoritative_hook_transcript(
+                acorn_session::SessionAgentProvider::Codex,
+                agent_hooks::AgentHookOwnership::Child,
+                Some(PROVIDER_SESSION_ID),
+            ),
+            None,
+        );
+        assert_eq!(
+            authoritative_hook_transcript(
+                acorn_session::SessionAgentProvider::Antigravity,
+                agent_hooks::AgentHookOwnership::Owner,
+                Some(PROVIDER_SESSION_ID),
+            ),
+            None,
+        );
+        assert_eq!(
+            authoritative_hook_transcript(
+                acorn_session::SessionAgentProvider::Codex,
+                agent_hooks::AgentHookOwnership::Owner,
+                Some("not-a-uuid"),
+            ),
+            None,
+        );
     }
 }
 
@@ -498,27 +569,26 @@ pub fn run() {
                         return agent_hooks::AgentHookHandlerOutcome::Conflict;
                     }
                 };
-                // Claude names the active conversation directly. Bind that
-                // provider-owned identifier without applying transcript mtime
-                // heuristics; the PTY-tree scan remains the fallback and
-                // multi-process arbiter when hooks are unavailable.
-                if provider == acorn_session::SessionAgentProvider::Claude {
-                    if let Some(claude_uuid) = provider_session_id
-                        .as_deref()
-                        .filter(|id| uuid::Uuid::parse_str(id).is_ok())
-                    {
-                        if let Err(err) = agent_resume_persister::bind_provider_session_marker(
-                            session_id,
-                            acorn_agent::AgentKind::Claude,
-                            claude_uuid,
-                        ) {
-                            tracing::warn!(
-                                %session_id,
-                                claude_uuid,
-                                error = %err,
-                                "claude hook transcript bind failed",
-                            );
-                        }
+                // Owner hooks name the active Claude or Codex conversation
+                // directly, so they take precedence over cwd and mtime
+                // inference when both are available.
+                if let Some((provider, provider_uuid)) = authoritative_hook_transcript(
+                    provider,
+                    ownership,
+                    provider_session_id.as_deref(),
+                ) {
+                    if let Err(err) = agent_resume_persister::bind_provider_session_marker(
+                        session_id,
+                        provider,
+                        provider_uuid,
+                    ) {
+                        tracing::warn!(
+                            %session_id,
+                            ?provider,
+                            provider_uuid,
+                            error = %err,
+                            "agent hook transcript bind failed",
+                        );
                     }
                 }
                 if let Err(err) = persistence::save_sessions(&hook_sessions) {


### PR DESCRIPTION
## Summary

Keep generated Acorn session names attached to the Codex conversation that supplied their transcript, including CLI restarts and `/new` rotations.

1. **Authoritative hook binding** — Persist accepted owner hook UUIDs for Claude and Codex as the active provider marker. Child and malformed identifiers remain rejected.
2. **Scanner arbitration** — Protect a provider-declared marker for the existing transcript dormancy window so cwd/mtime inference cannot immediately restore the abandoned conversation.
3. **Stale generation fence** — Re-resolve title input after the AI call and store the generated name only when the transcript ID still matches.
4. **Regression coverage** — Cover provider ownership filtering, Claude/Codex marker replacement, inference rollback, and stale title results.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Restart Codex in the same Acorn session | A previous transcript could win the cwd/mtime scan and supply the title | The accepted owner hook binds the new Codex transcript directly |
| Run `/new` inside Codex | The abandoned transcript could overwrite the new marker during the handoff | The new provider marker stays authoritative through the ambiguity window |
| Transcript rotates during title generation | An in-flight title could be stored for the no-longer-current transcript | The stale result is skipped after transcript revalidation |

## Design notes

- Marker writes happen only after the hook reducer accepts an event, and only owner-scoped Claude or Codex events with UUID provider session IDs qualify.
- The provider marker lease uses the same 10-second dormancy interval as transcript arbitration. Provider hooks can still replace it immediately, while inferred writers resume normal arbitration afterward.
- Title generation records the resolved transcript ID, repeats resolution after the potentially slow AI call, and updates the session only when both IDs match.

## Test plan

- [x] `cargo test -p acorn --lib -- --test-threads=1` — 719 passed, 1 ignored
- [x] `pnpm exec vitest run src/lib/sessionTitle.test.ts src/store.test.ts` — 2 files, 185 tests passed
- [x] `pnpm run typecheck` passes
- [x] `rustfmt --edition 2021 --config skip_children=true --check src/lib.rs src/commands.rs src/agent_resume_persister.rs` passes
- [x] `cargo clippy -p acorn --lib --tests` exits successfully
- [x] `git diff --check origin/main...HEAD` passes

## Notes

- Rust 1.95 Clippy still reports existing warnings in unrelated code; this PR introduces no new Clippy warning.