### PR TITLE
perf(graph): lazy-load optional editor UI and styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,4 @@
 @import "tailwindcss";
-@import "@xyflow/react/dist/style.css";
 
 @theme {
   --color-bg: #1f2326;

--- a/src/components/GraphCanvasEditor.tsx
+++ b/src/components/GraphCanvasEditor.tsx
@@ -15,6 +15,7 @@ import {
   type ReactFlowInstance,
   type Viewport,
 } from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
 import {
   Boxes,
   Check,

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -26,6 +26,8 @@ import {
   X,
 } from "lucide-react";
 import {
+  Suspense,
+  lazy,
   useCallback,
   useMemo,
   useRef,
@@ -39,7 +41,6 @@ import { FileViewer } from "./FileViewer";
 import { mediaKindFromPath } from "../lib/mediaFiles";
 import { writeClipboardText } from "../lib/clipboardText";
 import { ChatPane } from "./ChatPane";
-import { GraphSessionView } from "./GraphSessionView";
 import { WorkSummaryView } from "./WorkSummaryView";
 import { api } from "../lib/api";
 import {
@@ -122,6 +123,11 @@ import {
   useWorkspaceTabDragSession,
   type WorkspaceTabDragSession,
 } from "../lib/workspaceTabDrag";
+
+const GraphSessionView = lazy(async () => {
+  const module = await import("./GraphSessionView");
+  return { default: module.GraphSessionView };
+});
 
 const SESSION_STATUS_TONE: Record<SessionStatus, StatusTone> = {
   ready: "neutral",
@@ -606,7 +612,9 @@ export function Pane({ paneId }: PaneProps) {
           a frontend-owned file tab instead of a PTY session.
         */}
         {activeSession?.graph ? (
-          <GraphSessionView session={activeSession} isActive={isFocused} />
+          <Suspense fallback={null}>
+            <GraphSessionView session={activeSession} isActive={isFocused} />
+          </Suspense>
         ) : activeSession?.mode === "chat" ? (
           <ChatPane
             sessionId={activeSession.id}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,8 @@ import {
 import { homeDir } from "@tauri-apps/api/path";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
+  Suspense,
+  lazy,
   useCallback,
   useEffect,
   useMemo,
@@ -179,7 +181,6 @@ import type {
   SessionStatusReason,
 } from "../lib/types";
 import { AutonomousGoalDialog } from "./AutonomousGoalDialog";
-import { GraphSessionDialog } from "./GraphSessionDialog";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { AddExistingProjectDialog } from "./AddExistingProjectDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -220,6 +221,11 @@ const ACTIVITY_DEFAULT_HEIGHT = 192;
 const ACTIVITY_MIN_HEIGHT = 96;
 const ACTIVITY_MAX_HEIGHT = 420;
 const ACTIVITY_KEYBOARD_STEP = 16;
+
+const GraphSessionDialog = lazy(async () => {
+  const module = await import("./GraphSessionDialog");
+  return { default: module.GraphSessionDialog };
+});
 
 const PROJECT_DRAG_PREFIX = "project:";
 const FOLDER_DRAG_PREFIX = "folder:";
@@ -1584,14 +1590,18 @@ export function Sidebar() {
         open={addProjectOpen}
         onClose={() => setAddProjectOpen(false)}
       />
-      <GraphSessionDialog
-        open={graphSessionOpen}
-        scope={graphSessionScope}
-        onClose={() => {
-          setGraphSessionOpen(false);
-          setGraphSessionScope(null);
-        }}
-      />
+      {graphSessionOpen ? (
+        <Suspense fallback={null}>
+          <GraphSessionDialog
+            open
+            scope={graphSessionScope}
+            onClose={() => {
+              setGraphSessionOpen(false);
+              setGraphSessionScope(null);
+            }}
+          />
+        </Suspense>
+      ) : null}
       <NewProjectDialog
         open={newProjectOpen}
         onClose={() => setNewProjectOpen(false)}


### PR DESCRIPTION
## Summary

This keeps the optional Graph editor out of the initial application payload while preserving its existing creation and session workflows.

1. **Lazy Graph entry points** — Load the Graph creation dialog only when requested and the Graph session view only when a Graph session is active.
2. **Shared async editor chunk** — Let Vite extract the React Flow editor and preset toolbar used by both Graph entry points.
3. **Deferred Graph styles** — Move the React Flow stylesheet from the global application CSS into the lazy Graph editor dependency.
4. **Runtime coverage** — Exercise Graph creation, editing, execution, saved-session rendering, and ordinary Chat behavior after the split.

## Expected impact

| Asset | Before | After | Change |
| --- | ---: | ---: | ---: |
| Initial JavaScript | 2,981,678 B | 2,731,645 B | -250,033 B (-8.4%) |
| Initial JavaScript, local gzip | 842,124 B | 766,776 B | -75,348 B (-8.9%) |
| Graph shared JavaScript | Included initially | 237,220 B async chunk | Deferred until Graph use |
| React Flow CSS | Included initially | 15,413 B async CSS | Deferred until Graph use |

## Design notes

- The Sidebar dialog and Pane session view are separate lazy boundaries because they are independent Graph entry points.
- Both boundaries resolve named exports without changing the public component modules.
- Suspense fallbacks are intentionally empty: Tauri serves packaged assets locally, and existing layout remains stable during the short first load.
- Graph dialogs now mount only while open; their existing open effect already resets draft and capability state for every invocation.

## Test plan

- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 1,290 tests passed
- [x] `pnpm exec playwright test tests/e2e/graph-editor.spec.ts` — 6 tests passed
- [x] `pnpm run test:e2e` — 318 tests passed
- [x] `pnpm run build` — passed and emitted separate Graph JS/CSS chunks
- [x] `git diff --check` — passed

## Notes

- The build still reports the pre-existing main-chunk size warning and ineffective dynamic-import warnings for `api.ts` and `store.ts`; this PR materially reduces the main chunk but does not address those separate boundaries.