### PR TITLE
fix(sidebar): restore worktree action for primary project roots

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3050,7 +3050,7 @@ function ProjectFolderView({
                 <Plus size={12} />
               </button>
             </Tooltip>
-            {inSourceRoot && isDefaultProjectFolder(folder) ? (
+            {isDefaultProjectFolder(folder) ? (
               <Tooltip
                 label={sidebarText(
                   t,

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4645,7 +4645,7 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(page.getByRole("menuitem")).toHaveText(expectedProjectActions);
   });
 
-  test("a source folder header creates a worktree session in that source repository", async ({
+  test("primary and source root headers create worktree sessions in their repositories", async ({
     page,
     tauri,
   }) => {
@@ -4677,7 +4677,7 @@ test.describe("sidebar: project lifecycle", () => {
       };
       w.__createCalls = [...(w.__createCalls ?? []), args];
       const created = {
-        id: "created-worktree-session",
+        id: `created-worktree-session-${w.__createCalls.length}`,
         name: input.name,
         repo_path: input.repoPath,
         worktree_path: `${input.repoPath}/.acorn/worktrees/${input.name}`,
@@ -4700,15 +4700,27 @@ test.describe("sidebar: project lifecycle", () => {
 
     await page.goto("/");
 
+    const primaryFolderHeader = page.locator(
+      'aside [data-sidebar-workspace-id="/tmp/demo"]',
+    );
     const sourceFolderHeader = page.locator(
       'aside [data-sidebar-workspace-id="/tmp/acorn"]',
     );
+    await primaryFolderHeader.hover();
+    const createPrimaryWorktreeSessionButton =
+      primaryFolderHeader.getByRole("button", {
+        name: "New worktree session in this workspace",
+      });
+    await expect(createPrimaryWorktreeSessionButton).toBeVisible();
+    await createPrimaryWorktreeSessionButton.click();
+
     await sourceFolderHeader.hover();
-    const createWorktreeSessionButton = sourceFolderHeader.getByRole("button", {
-      name: "New worktree session in this workspace",
-    });
-    await expect(createWorktreeSessionButton).toBeVisible();
-    await createWorktreeSessionButton.click();
+    const createSourceWorktreeSessionButton =
+      sourceFolderHeader.getByRole("button", {
+        name: "New worktree session in this workspace",
+      });
+    await expect(createSourceWorktreeSessionButton).toBeVisible();
+    await createSourceWorktreeSessionButton.click();
 
     await expect
       .poll(async () =>
@@ -4722,6 +4734,11 @@ test.describe("sidebar: project lifecycle", () => {
         ),
       )
       .toEqual([
+        expect.objectContaining({
+          repoPath: "/tmp/demo",
+          isolated: true,
+          kind: "regular",
+        }),
         expect.objectContaining({
           repoPath: "/tmp/acorn",
           isolated: true,


### PR DESCRIPTION
## Summary

Multi-root project sidebars now expose the missing worktree-session shortcut on the primary repository row.

1. **Primary-root action** — show the worktree-session button for every default root workspace row instead of limiting it to source roots.
2. **Regression coverage** — verify that primary and source root buttons each create an isolated regular session against their own repository path.

## Expected impact

| Sidebar flow | Before | After |
| --- | --- | --- |
| Multi-root primary repository row | No direct worktree-session action | Worktree-session button is available on hover |
| Source repository row | Worktree-session button available | Unchanged |
| Single-root project header | Worktree-session button available | Unchanged |

## Design notes

- Multi-root project headers remain limited to project-management actions so the repository target stays explicit at each root row.
- `isDefaultProjectFolder` identifies both primary and source root rows; named workspaces and worktree workspaces remain excluded from the shortcut.
- Session creation continues through the existing workspace-scoped flow, preserving the selected root `repoPath`, isolated flag, and regular session kind.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 109 files, 1,290 tests passed
- [x] `pnpm run build:frontend`
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 53 tests passed