### PR TITLE
fix(agent-status): detect interrupted provider turns without key inference

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -590,6 +590,10 @@ struct HookRuntimeState {
     status_source: Option<AgentStatusSource>,
     tool_started_at: Option<SystemTime>,
     turn_id: Option<String>,
+    /// Receipt time of the current Claude `UserPromptSubmit` hook. Claude's
+    /// interruption transcript marker has no turn id, so the poll uses this
+    /// boundary to reject a marker left by the previous prompt.
+    claude_turn_started_at: Option<SystemTime>,
     permission_waiting_at: Option<SystemTime>,
     /// When an attention request (permission prompt, elicitation dialog) was
     /// raised by a hook that has no resolving counterpart. Claude emits
@@ -628,6 +632,7 @@ impl HookRuntimeState {
         self.status_source = None;
         self.tool_started_at = None;
         self.turn_id = None;
+        self.claude_turn_started_at = None;
         self.permission_waiting_at = None;
         self.attention_at = None;
         self.claude_stop_at = None;
@@ -644,11 +649,12 @@ pub struct SessionStore {
     /// its hook channel is live, the transcript-tail poll stops heuristically
     /// second-guessing turn completion (a long or tool-heavy Claude turn often
     /// leaves no `end_turn` line inside the tail window, so the tail keeps
-    /// reading Working long after the turn ended). The one in-run exception is
-    /// a Codex `task_complete` carrying the exact current hook turn id, which
-    /// can be reconciled under this ledger's lock without admitting a stale
-    /// previous-turn completion. The poll otherwise only keeps ownership of
-    /// the process-liveness edge after no agent remains.
+    /// reading Working long after the turn ended). Bounded in-run exceptions
+    /// are a Codex terminal marker carrying the exact current hook turn id and
+    /// a Claude interruption timestamp newer than the current hook turn. Both
+    /// are reconciled under this ledger's lock without admitting a stale
+    /// previous-turn marker. The poll otherwise only keeps ownership of the
+    /// process-liveness edge after no agent remains.
     ///
     /// Hook activity itself also persists across restarts via the session's
     /// `hook_active` field; this ledger distinguishes "confirmed live this run"
@@ -875,12 +881,12 @@ impl SessionStore {
         Ok(Some(state.advance_lifecycle_revision()))
     }
 
-    /// Reconcile a Codex completion observed in its durable transcript while
-    /// the native hook channel still owns status. The completed turn id is
+    /// Reconcile a Codex turn end observed in its durable transcript while
+    /// the native hook channel still owns status. The terminal turn id is
     /// checked under the same runtime lock as the lifecycle fence so a new
     /// `UserPromptSubmit` cannot race an old `task_complete` into a resting
     /// status.
-    pub fn reconcile_codex_turn_completion_if_current(
+    pub fn reconcile_codex_turn_end_if_current(
         &self,
         id: &Uuid,
         expected_source: Option<AgentStatusSource>,
@@ -912,6 +918,44 @@ impl SessionStore {
         entry.status = SessionStatus::WaitingForInput;
         state.status_source = Some(AgentStatusSource::TranscriptFallback);
         state.permission_waiting_at = None;
+        Ok(Some(state.advance_lifecycle_revision()))
+    }
+
+    /// Reconcile a Claude interruption marker only when it belongs to the
+    /// current native-hook turn. Claude does not include a turn id in
+    /// `interruptedMessageId`, so its provider timestamp is fenced against the
+    /// latest `UserPromptSubmit` receipt under the same lock as status/source.
+    pub fn reconcile_claude_interruption_if_current(
+        &self,
+        id: &Uuid,
+        expected_source: Option<AgentStatusSource>,
+        expected_lifecycle_revision: u64,
+        interrupted_at: SystemTime,
+    ) -> SessionResult<Option<u64>> {
+        let mut runtime = self.lock_hook_runtime();
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        let state = runtime.entry(*id).or_default();
+        if entry.status != SessionStatus::Working
+            || state.status_source != expected_source
+            || state.lifecycle_revision != expected_lifecycle_revision
+            || !state.confirmed
+            || !entry.hook_active
+            || entry.hook_provider != Some(SessionAgentProvider::Claude)
+            || state
+                .claude_turn_started_at
+                .is_none_or(|started_at| interrupted_at <= started_at)
+        {
+            return Ok(None);
+        }
+
+        entry.status = SessionStatus::WaitingForInput;
+        state.status_source = Some(AgentStatusSource::TranscriptFallback);
+        state.claude_turn_started_at = None;
+        state.attention_at = None;
+        state.claude_stop_at = None;
         Ok(Some(state.advance_lifecycle_revision()))
     }
 
@@ -960,6 +1004,9 @@ impl SessionStore {
         state.advance_lifecycle_revision();
         state.confirmed = true;
         state.status_source = Some(AgentStatusSource::Hook);
+        if provider == SessionAgentProvider::Claude && status == SessionStatus::Working {
+            state.claude_turn_started_at = Some(SystemTime::now());
+        }
         entry.status = status;
         entry.hook_active = true;
         entry.hook_provider = Some(provider);
@@ -1021,6 +1068,12 @@ impl SessionStore {
             .get(id)
             .and_then(|state| state.turn_id.clone())
             .filter(|turn_id| !turn_id.is_empty())
+    }
+
+    pub fn claude_turn_started_at(&self, id: &Uuid) -> Option<SystemTime> {
+        self.lock_hook_runtime()
+            .get(id)
+            .and_then(|state| state.claude_turn_started_at)
     }
 
     /// Whether this app run has observed a Codex turn boundary, including a
@@ -1969,12 +2022,7 @@ mod tests {
             .expect("session exists");
 
         assert!(store
-            .reconcile_codex_turn_completion_if_current(
-                &session.id,
-                source,
-                lifecycle_revision,
-                "turn-1",
-            )
+            .reconcile_codex_turn_end_if_current(&session.id, source, lifecycle_revision, "turn-1",)
             .expect("session exists")
             .is_some());
         assert_eq!(
@@ -2011,7 +2059,7 @@ mod tests {
         store.begin_hook_turn(&session.id, Some("turn-2"));
         assert_eq!(
             store
-                .reconcile_codex_turn_completion_if_current(
+                .reconcile_codex_turn_end_if_current(
                     &session.id,
                     source,
                     lifecycle_revision,
@@ -2025,6 +2073,56 @@ mod tests {
             SessionStatus::Working
         );
         assert_eq!(store.hook_turn_id(&session.id).as_deref(), Some("turn-2"));
+    }
+
+    #[test]
+    fn claude_transcript_interruption_must_follow_the_current_hook_turn() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        store
+            .apply_native_status(
+                &session.id,
+                SessionAgentProvider::Claude,
+                SessionStatus::Working,
+            )
+            .expect("session exists");
+        let started_at = store
+            .claude_turn_started_at(&session.id)
+            .expect("Claude start is recorded");
+        let (_, source, _, lifecycle_revision) = store
+            .lifecycle_snapshot(&session.id)
+            .expect("session exists");
+
+        assert_eq!(
+            store
+                .reconcile_claude_interruption_if_current(
+                    &session.id,
+                    source,
+                    lifecycle_revision,
+                    started_at - std::time::Duration::from_secs(1),
+                )
+                .expect("session exists"),
+            None
+        );
+        assert!(store
+            .reconcile_claude_interruption_if_current(
+                &session.id,
+                source,
+                lifecycle_revision,
+                started_at + std::time::Duration::from_secs(1),
+            )
+            .expect("session exists")
+            .is_some());
+        assert_eq!(
+            store.get(&session.id).expect("session exists").status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            store.agent_status_source(&session.id),
+            Some(AgentStatusSource::TranscriptFallback)
+        );
+        assert_eq!(store.claude_turn_started_at(&session.id), None);
+        assert_eq!(store.claude_stop_at(&session.id), None);
     }
 
     #[test]

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -2,6 +2,7 @@
 //! transcript the in-flight agent is writing. Status mapping:
 //!
 //! Claude transcripts:
+//! - user record with `interruptedMessageId` -> WaitingForInput.
 //! - last assistant turn with `stop_reason=end_turn` -> Ready
 //!   (claude finished its turn and accepts an optional follow-up).
 //! - last assistant turn with `stop_reason=tool_use` -> Working (tool pending)
@@ -9,6 +10,7 @@
 //! - no transcript yet -> Ready (session has not produced any conversation)
 //!
 //! Codex transcripts:
+//! - last `payload.type=turn_aborted` -> WaitingForInput.
 //! - last `payload.type=task_complete` / `turn_complete` (also accepted
 //!   `msg`-wrapped or top-level; or `agent_message` with `phase=final_answer`)
 //!   -> Ready (codex finished a turn).
@@ -24,6 +26,8 @@
 //! - last `type=USER_INPUT` or any non-DONE model/tool line -> Working.
 //!
 //! Grok transcripts:
+//! - last `sessionUpdate=turn_completed` with `stop_reason=cancelled` ->
+//!   WaitingForInput as an interrupted turn.
 //! - last `sessionUpdate=turn_completed` -> WaitingForInput while the Grok
 //!   process remains live (the TUI has returned to its prompt).
 //! - user/agent/thought chunks and tool call updates -> Working.
@@ -59,6 +63,7 @@ const TAIL_BYTES: u64 = 262_144;
 #[serde(rename_all = "snake_case")]
 pub enum StatusReason {
     TurnComplete,
+    TurnInterrupted,
     ShellPrompt,
 }
 
@@ -77,10 +82,9 @@ pub struct StatusDetection {
     pub status: SessionStatus,
     pub reason: Option<StatusReason>,
     pub evidence: StatusEvidence,
-    /// Provider turn identity carried by the completion event that produced
-    /// `TurnComplete`. Codex uses `turn_id` and Grok uses `prompt_id`;
-    /// providers or completion formats without a scoped identity leave this
-    /// empty.
+    /// Provider turn identity carried by the terminal turn event. Codex uses
+    /// `turn_id` and Grok uses `prompt_id`; providers or formats without a
+    /// scoped identity leave this empty.
     pub completed_provider_turn_id: Option<String>,
     /// Provider timestamp of the transcript line this detection classified.
     /// Only transcript evidence carries one.
@@ -194,6 +198,18 @@ pub fn detect_with_reason(
         }) => StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
             .with_turn_timestamp(timestamp)
             .with_agent_activity_timestamp(agent_activity_timestamp),
+        Some(TurnObservation {
+            state: TurnState::Interrupted,
+            provider_turn_id,
+            timestamp,
+            ..
+        }) => StatusDetection::new(
+            SessionStatus::WaitingForInput,
+            Some(StatusReason::TurnInterrupted),
+            StatusEvidence::Transcript,
+        )
+        .with_completed_provider_turn_id(provider_turn_id)
+        .with_turn_timestamp(timestamp),
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
         // to Ready. The next poll that lands on a real turn line corrects
@@ -610,6 +626,45 @@ mod tests {
         assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
         assert_eq!(detection.evidence, StatusEvidence::Transcript);
         assert_eq!(detection.completed_provider_turn_id.as_deref(), Some("t1"));
+    }
+
+    #[test]
+    fn detect_reports_waiting_for_an_interrupted_turn() {
+        let path = write_status_transcript(
+            r#"{"timestamp":"t","type":"event_msg","payload":{"type":"turn_aborted","turn_id":"t1"}}"#,
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Codex)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnInterrupted));
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+        assert_eq!(detection.completed_provider_turn_id.as_deref(), Some("t1"));
+        assert_eq!(detection.turn_timestamp.as_deref(), Some("t"));
+    }
+
+    #[test]
+    fn detect_reports_grok_cancel_as_an_interrupted_turn() {
+        let path = write_status_transcript(
+            r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#,
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnInterrupted));
+        assert_eq!(
+            detection.completed_provider_turn_id.as_deref(),
+            Some("prompt-7")
+        );
     }
 
     #[test]

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -26,6 +26,7 @@ impl TranscriptRole {
 pub enum TurnState {
     Ready,
     Working,
+    Interrupted,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -395,7 +396,7 @@ fn parse_grok_value(value: &Value) -> ParsedTranscriptLine {
         TranscriptRole::Other => None,
     };
     let turn_state = match update_type {
-        "turn_completed" => Some(TurnState::Ready),
+        "turn_completed" => Some(grok_completed_turn_state(update)),
         "user_message_chunk"
         | "agent_message_chunk"
         | "agent_thought_chunk"
@@ -418,6 +419,19 @@ fn parse_grok_value(value: &Value) -> ParsedTranscriptLine {
         session_id: string_at(value.get("params"), "sessionId")
             .or_else(|| string_at(value.get("params"), "session_id")),
         ..ParsedTranscriptLine::default()
+    }
+}
+
+fn grok_completed_turn_state(update: &Value) -> TurnState {
+    let stop_reason = update
+        .get("stop_reason")
+        .or_else(|| update.get("stopReason"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    if matches!(stop_reason, "cancelled" | "canceled" | "interrupted") {
+        TurnState::Interrupted
+    } else {
+        TurnState::Ready
     }
 }
 
@@ -445,6 +459,13 @@ fn claude_turn_state(value: &Value) -> Option<TurnState> {
     if line_type != "user" && line_type != "assistant" {
         return None;
     }
+    if value
+        .get("interruptedMessageId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return Some(TurnState::Interrupted);
+    }
     let msg = value.get("message")?;
     if line_type == "user" {
         return Some(TurnState::Working);
@@ -462,6 +483,7 @@ fn codex_turn_state(value: &Value) -> Option<TurnState> {
     let payload_type = event.get("type").and_then(Value::as_str).unwrap_or("");
     match payload_type {
         "task_complete" | "turn_complete" => Some(TurnState::Ready),
+        "turn_aborted" => Some(TurnState::Interrupted),
         "user_message" => Some(TurnState::Working),
         "function_call" | "function_call_output" | "reasoning" => Some(TurnState::Working),
         "agent_message" => {
@@ -475,6 +497,12 @@ fn codex_turn_state(value: &Value) -> Option<TurnState> {
         "message" => {
             if event.get("role").and_then(Value::as_str) == Some("assistant") {
                 Some(TurnState::Working)
+            } else if event.get("role").and_then(Value::as_str) == Some("user")
+                && codex_event_texts(value, event)
+                    .iter()
+                    .any(|text| text.trim_start().starts_with("<turn_aborted>"))
+            {
+                Some(TurnState::Interrupted)
             } else {
                 None
             }
@@ -973,6 +1001,20 @@ mod tests {
     }
 
     #[test]
+    fn claude_interrupted_message_maps_to_interrupted() {
+        let tail = r#"{"timestamp":"2026-08-10T00:00:01Z","type":"user","interruptedMessageId":"message-1","message":{"role":"user","content":[]}}"#;
+        assert_eq!(
+            latest_turn_observation(AgentKind::Claude, tail, true),
+            Some(TurnObservation {
+                state: TurnState::Interrupted,
+                provider_turn_id: None,
+                timestamp: Some("2026-08-10T00:00:01Z".to_string()),
+                agent_activity_timestamp: None,
+            })
+        );
+    }
+
+    #[test]
     fn claude_assistant_end_turn_maps_to_ready_over_trailing_meta() {
         let tail = format!(
             "{}\n{}\n{}\n",
@@ -1097,6 +1139,20 @@ mod tests {
     }
 
     #[test]
+    fn codex_turn_aborted_maps_to_interrupted_with_turn_id() {
+        let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"turn_aborted","turn_id":"t1"}}"#;
+        assert_eq!(
+            latest_turn_observation(AgentKind::Codex, tail, true),
+            Some(TurnObservation {
+                state: TurnState::Interrupted,
+                provider_turn_id: Some("t1".to_string()),
+                timestamp: Some("t".to_string()),
+                agent_activity_timestamp: None,
+            })
+        );
+    }
+
+    #[test]
     fn codex_turn_complete_maps_to_ready() {
         let tail = r#"{"timestamp":"t","type":"event_msg","payload":{"type":"turn_complete","turn_id":"t1","last_agent_message":"done","completed_at":1,"duration_ms":1,"time_to_first_token_ms":1}}"#;
         assert_eq!(
@@ -1192,6 +1248,26 @@ mod tests {
             );
             assert_eq!(parsed.preview_text, None, "message: {message}");
         }
+    }
+
+    #[test]
+    fn codex_hidden_turn_aborted_marker_maps_to_interrupted() {
+        let value = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "<turn_aborted>\nThe user interrupted the turn.\n</turn_aborted>",
+                }],
+            },
+        });
+
+        assert_eq!(
+            parse_transcript_value(AgentKind::Codex, &value).turn_state,
+            Some(TurnState::Interrupted)
+        );
     }
 
     #[test]
@@ -1397,6 +1473,21 @@ mod tests {
             latest_turn_observation(AgentKind::Grok, tail, true),
             Some(TurnObservation {
                 state: TurnState::Ready,
+                provider_turn_id: Some("prompt-7".to_string()),
+                timestamp: None,
+                agent_activity_timestamp: None,
+            })
+        );
+    }
+
+    #[test]
+    fn grok_cancelled_turn_maps_to_interrupted() {
+        let tail = r#"{"method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#;
+
+        assert_eq!(
+            latest_turn_observation(AgentKind::Grok, tail, true),
+            Some(TurnObservation {
+                state: TurnState::Interrupted,
                 provider_turn_id: Some("prompt-7".to_string()),
                 timestamp: None,
                 agent_activity_timestamp: None,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9116,6 +9116,7 @@ fn fallback_agent_status_source(
 enum HookStatusReconciliation {
     Boot,
     CurrentCodexTurn(String),
+    CurrentClaudeInterruption(SystemTime),
     ClaudeAttentionResolved(SystemTime),
     ClaudeBlockedStopResumed(SystemTime),
 }
@@ -9123,7 +9124,9 @@ enum HookStatusReconciliation {
 impl HookStatusReconciliation {
     fn target(&self) -> SessionStatus {
         match self {
-            Self::Boot | Self::CurrentCodexTurn(_) => SessionStatus::WaitingForInput,
+            Self::Boot | Self::CurrentCodexTurn(_) | Self::CurrentClaudeInterruption(_) => {
+                SessionStatus::WaitingForInput
+            }
             Self::ClaudeAttentionResolved(_) | Self::ClaudeBlockedStopResumed(_) => {
                 SessionStatus::Working
             }
@@ -9203,7 +9206,7 @@ fn claude_blocked_stop_resolution(
     ))
 }
 
-/// Recover a hook-owned Working status from a durable turn-complete marker.
+/// Recover a hook-owned Working status from a durable terminal turn marker.
 ///
 /// `hook_active` persists across restarts, so right after boot the poll
 /// already defers to the persisted hook-set status. Durable hook delivery
@@ -9211,12 +9214,13 @@ fn claude_blocked_stop_resolution(
 /// transcript remains the bounded compatibility signal for records that
 /// predate durable delivery or could not be retained. Until the first hook
 /// event of this run confirms the channel, allow exactly one recovery:
-/// Working -> WaitingForInput backed by a real turn-complete marker.
+/// Working -> WaitingForInput backed by a real completion or interruption.
 ///
-/// During the current run, Codex completion recovery is allowed only when the
-/// transcript carries a provider turn id. The store compares that id with the
-/// active native-hook turn under the lifecycle lock before applying it, so a
-/// new prompt cannot be overwritten by the previous turn's completion.
+/// During the current run, Codex recovery requires an exact provider turn id.
+/// Claude's interruption marker has no turn id, so it instead must be newer
+/// than the current `UserPromptSubmit` hook receipt. Both checks are repeated
+/// under the lifecycle lock before applying, so a new prompt cannot be
+/// overwritten by the previous turn's transcript tail.
 fn hook_status_reconciliation(
     stored: SessionStatus,
     hook_confirmed_this_run: bool,
@@ -9224,6 +9228,7 @@ fn hook_status_reconciliation(
     detection: &session_status::StatusDetection,
     attention_at: Option<SystemTime>,
     claude_stop_at: Option<SystemTime>,
+    claude_turn_started_at: Option<SystemTime>,
 ) -> Option<HookStatusReconciliation> {
     if stored == SessionStatus::WaitingForInput {
         return claude_attention_resolution(hook_provider, detection, attention_at)
@@ -9232,22 +9237,41 @@ fn hook_status_reconciliation(
     if stored != SessionStatus::Working {
         return None;
     }
-    if detection.status != SessionStatus::Ready
-        || detection.reason != Some(SessionStatusReason::TurnComplete)
-        || detection.evidence != session_status::StatusEvidence::Transcript
-    {
+    let terminal_turn = matches!(
+        (detection.status, detection.reason),
+        (
+            SessionStatus::Ready,
+            Some(SessionStatusReason::TurnComplete)
+        ) | (
+            SessionStatus::WaitingForInput,
+            Some(SessionStatusReason::TurnInterrupted)
+        )
+    );
+    if !terminal_turn || detection.evidence != session_status::StatusEvidence::Transcript {
         return None;
     }
     if !hook_confirmed_this_run {
         return Some(HookStatusReconciliation::Boot);
     }
-    if hook_provider != Some(AgentKind::Codex) {
-        return None;
+    if hook_provider == Some(AgentKind::Codex) {
+        return detection
+            .completed_provider_turn_id
+            .clone()
+            .map(HookStatusReconciliation::CurrentCodexTurn);
     }
-    detection
-        .completed_provider_turn_id
-        .clone()
-        .map(HookStatusReconciliation::CurrentCodexTurn)
+    if hook_provider == Some(AgentKind::Claude)
+        && detection.reason == Some(SessionStatusReason::TurnInterrupted)
+    {
+        let started_at = claude_turn_started_at?;
+        let interrupted_at: SystemTime =
+            chrono::DateTime::parse_from_rfc3339(detection.turn_timestamp.as_deref()?)
+                .ok()?
+                .into();
+        return (interrupted_at > started_at).then_some(
+            HookStatusReconciliation::CurrentClaudeInterruption(interrupted_at),
+        );
+    }
+    None
 }
 
 fn detect_session_statuses_blocking(
@@ -9446,6 +9470,8 @@ fn detect_session_statuses_blocking(
                 parsed_id.and_then(|uuid| state.sessions.codex_permission_waiting_at(&uuid));
             let attention_at = parsed_id.and_then(|uuid| state.sessions.attention_at(&uuid));
             let claude_stop_at = parsed_id.and_then(|uuid| state.sessions.claude_stop_at(&uuid));
+            let claude_turn_started_at =
+                parsed_id.and_then(|uuid| state.sessions.claude_turn_started_at(&uuid));
             let codex_activity_started_at =
                 match (codex_tool_started_at, codex_permission_waiting_at) {
                     (Some(tool), Some(permission)) => Some(tool.max(permission)),
@@ -9560,9 +9586,10 @@ fn detect_session_statuses_blocking(
                         observed_lifecycle_revision,
                     ));
                 // Boot recovery is allowed before this app instance receives
-                // a native event. In-run recovery is limited to an exact
-                // Codex turn id; the store checks that id together with the
-                // revision/source fence in one conditional write.
+                // a native event. In-run terminal recovery requires either an
+                // exact Codex turn id or a Claude interruption newer than the
+                // current prompt; the store repeats that correlation together
+                // with the revision/source fence in one conditional write.
                 let reconciliation_requested = hook_status_reconciliation(
                     stored,
                     hook_revision > 0,
@@ -9570,6 +9597,7 @@ fn detect_session_statuses_blocking(
                     &detection,
                     attention_at,
                     claude_stop_at,
+                    claude_turn_started_at,
                 );
                 let reconciled = parsed_id.and_then(|uuid| {
                     reconciliation_requested
@@ -9587,13 +9615,21 @@ fn detect_session_statuses_blocking(
                                         Some(AgentStatusSource::TranscriptFallback),
                                     ),
                                 HookStatusReconciliation::CurrentCodexTurn(completed_turn_id) => {
-                                    state.sessions.reconcile_codex_turn_completion_if_current(
+                                    state.sessions.reconcile_codex_turn_end_if_current(
                                         &uuid,
                                         stored_source,
                                         lifecycle_revision,
                                         completed_turn_id,
                                     )
                                 }
+                                HookStatusReconciliation::CurrentClaudeInterruption(
+                                    interrupted_at,
+                                ) => state.sessions.reconcile_claude_interruption_if_current(
+                                    &uuid,
+                                    stored_source,
+                                    lifecycle_revision,
+                                    *interrupted_at,
+                                ),
                                 HookStatusReconciliation::ClaudeAttentionResolved(resumed_at) => {
                                     state.sessions.resolve_attention_if_current(
                                         &uuid,
@@ -11971,9 +12007,13 @@ mod tests {
             .lifecycle_snapshot(&session.id)
             .expect("read lifecycle before terminal input");
         for (label, data) in [
+            ("escape", "Gw=="),
             ("carriage return", "DQ=="),
             ("line feed", "Cg=="),
             ("text followed by carriage return", "YW5zd2VyDQ=="),
+            // Keep Ctrl-C last: the PTY line discipline may terminate `cat`,
+            // but the transport byte still must not mutate session lifecycle.
+            ("control-c", "Aw=="),
         ] {
             super::pty_write(
                 app.state::<AppState>(),
@@ -12016,6 +12056,32 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
+            ),
+            Some(super::HookStatusReconciliation::Boot)
+        );
+    }
+
+    #[test]
+    fn boot_reconciliation_recovers_an_interrupted_turn() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::WaitingForInput,
+            reason: Some(super::SessionStatusReason::TurnInterrupted),
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
+            turn_timestamp: Some("2026-08-10T00:00:00Z".to_string()),
+            agent_activity_timestamp: None,
+        };
+
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                false,
+                Some(super::AgentKind::Claude),
+                &detection,
+                None,
+                None,
+                None,
             ),
             Some(super::HookStatusReconciliation::Boot)
         );
@@ -12043,6 +12109,7 @@ mod tests {
                 Some(AgentKind::Claude),
                 &detection,
                 attention_at,
+                None,
                 None,
             )
         };
@@ -12108,6 +12175,7 @@ mod tests {
                 ),
                 Some(attention_at),
                 None,
+                None,
             ),
             None
         );
@@ -12137,6 +12205,7 @@ mod tests {
                 &detection,
                 None,
                 stop_at,
+                None,
             )
         };
 
@@ -12208,6 +12277,7 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
             ),
             None
         );
@@ -12239,6 +12309,7 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
             ),
             None
         );
@@ -12260,6 +12331,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Codex),
                 &detection,
+                None,
                 None,
                 None,
             ),
@@ -12287,6 +12359,7 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
             ),
             None
         );
@@ -12310,10 +12383,83 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
             ),
             Some(super::HookStatusReconciliation::CurrentCodexTurn(
                 "turn-1".to_string()
             ))
+        );
+    }
+
+    #[test]
+    fn confirmed_codex_hook_accepts_a_scoped_interruption_candidate() {
+        let detection = super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::WaitingForInput,
+            reason: Some(super::SessionStatusReason::TurnInterrupted),
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: Some("turn-1".to_string()),
+            turn_timestamp: Some("2026-08-10T00:00:00Z".to_string()),
+            agent_activity_timestamp: None,
+        };
+
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                true,
+                Some(super::AgentKind::Codex),
+                &detection,
+                None,
+                None,
+                None,
+            ),
+            Some(super::HookStatusReconciliation::CurrentCodexTurn(
+                "turn-1".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn confirmed_claude_hook_accepts_only_a_current_interruption_candidate() {
+        use std::time::Duration;
+
+        let started_at: std::time::SystemTime =
+            chrono::DateTime::parse_from_rfc3339("2026-08-10T00:00:00Z")
+                .expect("valid start timestamp")
+                .into();
+        let detection = |timestamp: &str| super::session_status::StatusDetection {
+            status: acorn_session::SessionStatus::WaitingForInput,
+            reason: Some(super::SessionStatusReason::TurnInterrupted),
+            evidence: super::session_status::StatusEvidence::Transcript,
+            completed_provider_turn_id: None,
+            turn_timestamp: Some(timestamp.to_string()),
+            agent_activity_timestamp: None,
+        };
+
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                true,
+                Some(super::AgentKind::Claude),
+                &detection("2026-08-10T00:00:01Z"),
+                None,
+                None,
+                Some(started_at),
+            ),
+            Some(super::HookStatusReconciliation::CurrentClaudeInterruption(
+                started_at + Duration::from_secs(1)
+            ))
+        );
+        assert_eq!(
+            super::hook_status_reconciliation(
+                acorn_session::SessionStatus::Working,
+                true,
+                Some(super::AgentKind::Claude),
+                &detection("2026-08-09T23:59:59Z"),
+                None,
+                None,
+                Some(started_at),
+            ),
+            None
         );
     }
 
@@ -12333,6 +12479,7 @@ mod tests {
                 true,
                 Some(super::AgentKind::Claude),
                 &detection,
+                None,
                 None,
                 None,
             ),
@@ -12360,6 +12507,7 @@ mod tests {
                 &detection,
                 None,
                 None,
+                None,
             ),
             None
         );
@@ -12383,6 +12531,7 @@ mod tests {
                 false,
                 None,
                 &detection,
+                None,
                 None,
                 None,
             ),

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -283,6 +283,8 @@ function statusReasonLabel(
   switch (reason) {
     case "turn_complete":
       return sidebarText(t, "sidebar.statusReason.turn_complete");
+    case "turn_interrupted":
+      return sidebarText(t, "sidebar.statusReason.turn_interrupted");
     case "shell_prompt":
       return sidebarText(t, "sidebar.statusReason.shell_prompt");
     default:

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -71,6 +71,8 @@ function sessionStatusReasonLabel(
   switch (reason) {
     case "turn_complete":
       return statusBarText(t, "statusBar.sessionStatusReason.turn_complete");
+    case "turn_interrupted":
+      return statusBarText(t, "statusBar.sessionStatusReason.turn_interrupted");
     case "shell_prompt":
       return statusBarText(t, "statusBar.sessionStatusReason.shell_prompt");
     default:

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -3062,6 +3062,8 @@ function statusReasonLabel(
   switch (reason) {
     case "turn_complete":
       return t("sidebar.statusReason.turn_complete");
+    case "turn_interrupted":
+      return t("sidebar.statusReason.turn_interrupted");
     case "shell_prompt":
       return t("sidebar.statusReason.shell_prompt");
     default:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,10 @@ export type SessionStatus =
   | "waiting_for_input"
   | "errored";
 
-export type SessionStatusReason = "turn_complete" | "shell_prompt";
+export type SessionStatusReason =
+  | "turn_complete"
+  | "turn_interrupted"
+  | "shell_prompt";
 
 export type AgentStatusSource =
   | "hook"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -943,6 +943,7 @@
     },
     "sessionStatusReason": {
       "turn_complete": "agent turn complete",
+      "turn_interrupted": "agent turn interrupted",
       "shell_prompt": "shell prompt detected"
     },
     "notifications": {
@@ -1208,6 +1209,7 @@
     },
     "statusReason": {
       "turn_complete": "Agent turn complete",
+      "turn_interrupted": "Agent turn interrupted",
       "shell_prompt": "Shell prompt detected"
     },
     "dialog": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -943,6 +943,7 @@
     },
     "sessionStatusReason": {
       "turn_complete": "エージェントのターンが完了しました",
+      "turn_interrupted": "エージェントのターンが中断されました",
       "shell_prompt": "シェルプロンプトが検出されました"
     },
     "notifications": {
@@ -1208,6 +1209,7 @@
     },
     "statusReason": {
       "turn_complete": "エージェントのターンが完了しました",
+      "turn_interrupted": "エージェントのターンが中断されました",
       "shell_prompt": "シェルプロンプトが検出されました"
     },
     "dialog": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -943,6 +943,7 @@
     },
     "sessionStatusReason": {
       "turn_complete": "에이전트 응답 완료",
+      "turn_interrupted": "에이전트 작업 중단",
       "shell_prompt": "셸 프롬프트 감지"
     },
     "notifications": {
@@ -1208,6 +1209,7 @@
     },
     "statusReason": {
       "turn_complete": "에이전트 응답 완료",
+      "turn_interrupted": "에이전트 작업 중단",
       "shell_prompt": "셸 프롬프트 감지"
     },
     "dialog": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -943,6 +943,7 @@
     },
     "sessionStatusReason": {
       "turn_complete": "智能体轮次完成",
+      "turn_interrupted": "智能体轮次已中断",
       "shell_prompt": "检测到 shell 提示"
     },
     "notifications": {
@@ -1208,6 +1209,7 @@
     },
     "statusReason": {
       "turn_complete": "智能体轮次完成",
+      "turn_interrupted": "智能体轮次已中断",
       "shell_prompt": "检测到 shell 提示"
     },
     "dialog": {


### PR DESCRIPTION
## Summary

Agent sessions now leave `Working` when the provider records an interrupted turn, without interpreting terminal key bytes as lifecycle events.

1. **Provider-owned interruption signals** — classify Claude `interruptedMessageId`, Codex `turn_aborted` (including the legacy hidden marker), and Grok cancelled/interrupted completion reasons.
2. **Race-safe lifecycle reconciliation** — correlate Codex interruptions by exact turn ID and Claude interruptions against the current prompt timestamp while preserving blocked-Stop recovery.
3. **Visible interruption reason** — expose `turn_interrupted` through the session DTO and render localized reasons in the sidebar, status bar, and workspace view.
4. **No key inference** — keep PTY bytes transport-only and expand regression coverage for Escape and Ctrl-C input.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| A provider aborts the current Codex, Claude, or Grok turn | The session can remain `Working` until another lifecycle event arrives | The session moves to `Waiting for input` with an interrupted reason |
| A stale Claude interruption is observed after a newer prompt starts | A naive transcript fallback could overwrite the newer turn | The prompt timestamp fence rejects the stale interruption |
| Escape or Ctrl-C is written to the PTY | Lifecycle behavior was implicit and vulnerable to future key heuristics | Bytes remain transport-only, with explicit regression coverage |

## Design notes

- Transcript interruption is a provider-owned fallback signal, not a terminal-input heuristic.
- Codex reconciliation requires the current turn ID; Claude lacks an equivalent turn ID in the transcript, so reconciliation requires an interruption newer than the authoritative `UserPromptSubmit` boundary.
- Existing native Stop and attention recovery paths remain intact, including the Claude blocked-Stop recovery added in #755.
- Antigravity/Agy continues to use its existing native Stop-hook path when configured. This PR does not mutate global or workspace hook configuration.

## Follow-up (not in this PR)

- Consider opt-in Acorn-managed Antigravity hook registration once there is a safe session-scoped configuration surface.

## Test plan

- [x] `cargo test -p acorn-transcript -p acorn-session` — 105 transcript and 86 session tests passed
- [x] `cargo test -p acorn interruption` — 2 tests passed
- [x] `cargo test -p acorn reconciliation` — 8 tests passed
- [x] `cargo test -p acorn agent_hook` — 83 tests passed
- [x] `cargo test -p acorn pty_write_does_not_infer_lifecycle_from_terminal_bytes` — 1 test passed
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 1,290 tests passed across 109 files
- [x] `jq empty src/locales/{en,ja,ko,zh-CN}.json`
- [x] `git diff --check`

## Notes

- A serial `cargo test --workspace -- --test-threads=1` run reached the unchanged `agent_wrappers::tests::codex_native_hook_version_gate_covers_the_supported_boundary` test, where its spawned wrapper shell did not return; the run was stopped after confirming the process wait. The targeted hook, reconciliation, interruption, PTY, session, and transcript suites above all pass.
