### PR TITLE
fix(deps): pin patched js-yaml and nanoid releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
       "esbuild"
     ],
     "overrides": {
-      "brace-expansion": ">=5.0.8"
+      "brace-expansion": ">=5.0.8",
+      "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
+      "nanoid@<3.3.17": "3.3.17"
     }
   },
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.8'
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
+  nanoid@<3.3.17: 3.3.17
 
 importers:
 
@@ -2354,8 +2356,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -2641,8 +2643,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5224,7 +5226,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -5697,7 +5699,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   node-releases@2.0.51: {}
 
@@ -5821,7 +5823,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5843,7 +5845,7 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.8)
       classnames: 2.5.1
       diff: 9.0.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       memoize-one: 6.0.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
## Summary

The frontend dependency graph now resolves the patched releases for two newly reported high-severity transitive vulnerabilities.

1. **JS-YAML availability fix** — override vulnerable 4.x releases to `js-yaml 4.3.1` without crossing the parent dependency's major-version line.
2. **Nano ID availability fix** — override vulnerable 3.x releases to `nanoid 3.3.17` without crossing the PostCSS dependency's major-version line.
3. **Reproducible resolution** — record both constraints and the resulting package integrity updates in `pnpm-lock.yaml`.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Dependency audit | Two high-severity advisories fail `pnpm audit --audit-level=moderate` | No known vulnerabilities reported |
| Compatibility | Vulnerable `js-yaml 4.3.0` and `nanoid 3.3.16` | Patch-only `js-yaml 4.3.1` and `nanoid 3.3.17` |
| CI | Frontend required check stops before type checking | Audit, type checking, and unit tests can run |

## Design notes

- The packages are transitive dependencies, so the fix uses pnpm overrides instead of adding them as direct application dependencies.
- Overrides are pinned to the first patched release in each existing major line; the update does not introduce `js-yaml 5.x` or `nanoid 6.x` compatibility changes.

## Follow-up (not in this PR)

- Remove the overrides once the direct parent dependencies resolve patched versions on their own.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm audit --audit-level=moderate` — no known vulnerabilities
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 1,290 tests passed across 109 files
- [x] `pnpm why js-yaml` — resolves `4.3.1`
- [x] `pnpm why nanoid` — resolves `3.3.17`
- [x] `git diff --check`

## Notes

- This PR contains only `package.json` and `pnpm-lock.yaml` changes needed for the audit fix.
