### PR TITLE
fix(sessions): stop active agent runs before removal

### DIFF
--- a/src-tauri/src/chat_runs.rs
+++ b/src-tauri/src/chat_runs.rs
@@ -193,6 +193,18 @@ impl ChatRunRegistry {
         Some(cancellation)
     }
 
+    pub fn cancel_active(&self, session_id: &Uuid) -> bool {
+        let active = self.active.lock();
+        let Some(active) = active.get(session_id) else {
+            return false;
+        };
+        match active {
+            ActiveRun::Chat(cancellation) => cancellation.cancel(),
+            ActiveRun::Graph(cancellation) => cancellation.cancel(),
+        }
+        true
+    }
+
     pub fn is_active(&self, session_id: &Uuid) -> bool {
         self.active.lock().contains_key(session_id)
     }
@@ -265,5 +277,20 @@ mod tests {
         assert!(second.is_cancelled());
         registry.finish_graph(&session_id, "run-1");
         assert!(!registry.is_active(&session_id));
+    }
+
+    #[test]
+    fn active_session_cancellation_handles_chat_turns_without_a_turn_id() {
+        let registry = ChatRunRegistry::default();
+        let session_id = Uuid::new_v4();
+        let cancellation = registry
+            .start(session_id, "turn-1".to_string())
+            .expect("start chat run");
+
+        assert!(registry.cancel_active(&session_id));
+        assert!(cancellation.is_cancelled());
+
+        registry.finish(&session_id, cancellation.turn_id());
+        assert!(!registry.cancel_active(&session_id));
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6876,6 +6876,30 @@ pub(crate) fn terminate_session_pty(state: &AppState, id: &Uuid) {
     }
 }
 
+fn terminate_session_runtime(state: &AppState, id: &Uuid) -> AppResult<()> {
+    let run_was_active = state.chat_runs.cancel_active(id);
+    terminate_session_pty(state, id);
+    if !run_was_active {
+        return Ok(());
+    }
+    for _ in 0..200 {
+        if !state.chat_runs.is_active(id) {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    Err(AppError::Other(
+        "the session run is still stopping; try removing it again shortly".to_string(),
+    ))
+}
+
+async fn terminate_session_runtime_blocking(state: AppState, id: Uuid) -> AppResult<()> {
+    run_blocking("terminate session runtime", move || {
+        terminate_session_runtime(&state, &id)
+    })
+    .await
+}
+
 pub(crate) fn session_removal_cascade(state: &AppState, session: &Session) -> Vec<Session> {
     let mut sessions = vec![session.clone()];
     let mut seen = HashSet::from([session.id]);
@@ -6979,14 +7003,16 @@ pub async fn remove_project(
         .map(|project| project.roots())
         .unwrap_or_else(|| vec![path.clone()]);
     if cascade {
-        let session_ids: Vec<_> = app_state
+        let sessions_to_remove: Vec<_> = app_state
             .sessions
             .list()
             .into_iter()
             .filter(|s| roots.iter().any(|root| &s.repo_path == root))
             .collect();
-        for session in session_ids {
-            terminate_session_pty(&app_state, &session.id);
+        for session in &sessions_to_remove {
+            terminate_session_runtime_blocking(app_state.clone(), session.id).await?;
+        }
+        for session in sessions_to_remove {
             if drop_worktrees && staged_worktree_paths.insert(session.worktree_path.clone()) {
                 if worktree_path_used_outside_project(&app_state, &path, &session.worktree_path) {
                     tracing::warn!(
@@ -7058,7 +7084,7 @@ pub async fn remove_session(
         )?;
     }
     for session in &sessions_to_remove {
-        terminate_session_pty(&app_state, &session.id);
+        terminate_session_runtime_blocking(app_state.clone(), session.id).await?;
     }
     let removed_worktree = if remove_worktree.unwrap_or(false) {
         match stage_remove_linked_worktree_blocking(
@@ -10958,15 +10984,16 @@ fn stage_remove_linked_worktree_at_path_and_sessions(
 ) -> AppResult<Option<worktree::RemovedWorktree>> {
     let sessions = sessions_using_linked_worktree(state, repo_path, worktree_path);
 
+    for session in &sessions {
+        terminate_session_runtime(state, &session.id)?;
+    }
+
     let removed = stage_remove_linked_worktree_at_path(repo_path, worktree_path)?;
 
     if let Ok(dir) = persistence::data_dir() {
         for session in &sessions {
             scrollback::delete(&dir, &session.id.to_string()).ok();
         }
-    }
-    for session in &sessions {
-        terminate_session_pty(state, &session.id);
     }
     for session in sessions {
         state.sessions.remove(&session.id).ok();
@@ -11177,8 +11204,8 @@ mod tests {
         infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
         normalize_session_goal, normalize_session_graph, poll_defers_to_hook,
         remove_linked_worktree_at_path, restore_pending_session_removal, seed_initial_commit,
-        should_remove_local_project_mirror, validate_editor_command, validate_new_project_name,
-        ChatProviderAdapter, ProcessMemorySnapshot,
+        should_remove_local_project_mirror, terminate_session_runtime, validate_editor_command,
+        validate_new_project_name, ChatProviderAdapter, ProcessMemorySnapshot,
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingSessionRemoval};
@@ -11223,6 +11250,29 @@ mod tests {
         );
         session.in_worktree = true;
         session
+    }
+
+    #[test]
+    fn session_runtime_stop_cancels_an_active_graph_before_removal() {
+        let state = AppState::new();
+        let session_id = Uuid::new_v4();
+        let run_id = "run-1".to_string();
+        let cancellation = state
+            .chat_runs
+            .start_graph(session_id, run_id.clone())
+            .expect("start graph run");
+        let registry = state.chat_runs.clone();
+        let worker = std::thread::spawn(move || {
+            while !cancellation.is_cancelled() {
+                std::thread::yield_now();
+            }
+            registry.finish_graph(&session_id, &run_id);
+        });
+
+        terminate_session_runtime(&state, &session_id).expect("stop session runtime");
+        worker.join().expect("graph worker exits");
+
+        assert!(!state.chat_runs.is_active(&session_id));
     }
 
     fn goal_spec(provider: SessionAgentProvider) -> SessionGoal {


### PR DESCRIPTION
## Summary

Session and worktree removal now shuts down active Graph or Chat provider work before deleting the state and filesystem context that work still depends on.

1. **Session-wide cancellation** — add a run-registry cancellation path that handles either a Chat turn or a Graph run without requiring a stale renderer-side turn/run identifier.
2. **Fail-closed removal ordering** — cancel PTY/provider work and wait for the run registry to drain before project, session, or linked-worktree removal mutates state or stages the worktree.
3. **Regression coverage** — verify generic Chat cancellation and the active Graph shutdown barrier used by removal.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Remove a Graph session while an AI node is running | The provider child can keep running after its session or worktree is removed, then fail its final state publication | The provider child is cancelled and the run fully exits before removal continues |
| Remove a project or linked worktree containing an active Chat/Graph session | Destructive removal can race active agent work | Every affected session runtime is stopped before state or filesystem mutation |
| Provider shutdown does not complete promptly | Removal can proceed into a partially torn-down state | Removal fails closed after a bounded wait and can be retried |

## Design notes

- Deletion owns the entire Acorn session, so the registry-level cancellation deliberately targets the active session claim rather than depending on a renderer-supplied turn or Graph run ID.
- The five-second bounded wait runs through the existing blocking-task boundary, keeping the async command runtime responsive.
- The same shutdown contract is applied to direct session removal, project cascade removal, and linked-worktree removal with sessions.
- No persisted schema, Graph definition, or release protocol changes are required.

## Test plan

- [x] `rustfmt --edition 2021 --check src-tauri/src/chat_runs.rs src-tauri/src/commands.rs`
- [x] `cargo test --workspace --manifest-path src-tauri/Cargo.toml -- --test-threads=1`
- [x] Focused Graph and removal regression tests
- [x] `pnpm run typecheck`
- [x] `pnpm test -- --run` — 109 files / 1,290 tests
- [x] `pnpm run build`
- [x] `git diff --check`

## Notes

- Existing Rust dead-code warnings and Vite chunk/dynamic-import warnings remain unchanged; all commands completed successfully.
