### PR TITLE
chore(release): v1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.30.0",
+  "version": "1.31.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.30.0"
+version = "1.31.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.31.0 from green `main` at `57266ac`, containing all merged changes since v1.30.0.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to 1.31.0.
2. **Release scope** — ships visual graph workflows and automatic graph engineering, multi-root project and worktree improvements, Japanese localization, Grok support, editor and terminal polish, performance work, and the active-agent removal safety fix.
3. **Publication path** — prepares the existing signed Apple Silicon and Intel release workflow plus updater metadata for the v1.31.0 tag.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Graph workflows | Adds visual graph sessions, automatic graph engineering, faster graph loading, and safe cancellation before session or project removal. |
| Projects and worktrees | Improves multi-root handling, worktree creation and removal, branch behavior, and project discovery. |
| Agents and interface | Adds Japanese UI and Grok provider support, with editor, IME, terminal, status, and navigation refinements. |
| Reliability and security | Includes session lifecycle fixes, dependency updates, and security hardening merged since v1.30.0. |
| Updater | Publishes 1.31.0 artifacts and `latest.json` for both supported macOS architectures after the tag workflow succeeds. |

## Design notes

- This is a minor release because it contains substantial user-visible features without a breaking configuration or data migration.
- The release PR is version-only; each product change was reviewed and merged independently before the version bump.
- Included PRs: #729, #730, #731, #732, #733, #734, #735, #736, #737, #738, #740, #741, #742, #743, #744, #746, #747, #748, #749, #750, #751, #752, #753, #754, #755, #756, #757, #758, #759, #763, #764, and #766.
- Release notes are generated bilingually from those merged PRs. The tag is created only after this PR passes CI and lands on `main`.

## Follow-up (not in this PR)

- Push the annotated `v1.31.0` tag after merge.
- Verify the Release workflow, both architecture bundles, updater metadata, and published bilingual notes.

## Test plan

- [x] `pnpm install --frozen-lockfile` — lockfile install succeeded.
- [x] `pnpm run typecheck` — TypeScript checks passed.
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root package resolves as 1.31.0.
- [x] `node scripts/validate-release-version.mjs v1.31.0` — all four version sources match.
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 3 files and 15 tests passed.
- [x] Generated release notes contain Korean and English summaries and include the expected graph-session changes.
- [x] Main CI for the graph-session safety fix passed at `57266ac`: https://github.com/im-ian/acorn/actions/runs/31373275188
- [x] `git diff --check` — no whitespace errors.

## Notes

- The v1.31.0 tag and GitHub Release do not exist yet; they are intentionally created after this PR merges.
- This version-only PR uses `skip-changelog`; its product changes retain their original changelog labels.