### PR TITLE
fix(sidebar): keep source root rows manually sortable

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1303,9 +1303,8 @@ export function Sidebar() {
               (group) => group.repoPath === activeProjectRootPath,
             ) ?? null)
           : null;
-      // Every root's default folder renders flat under the project header, so
-      // "is this row at the top level" is a question about the folder, not
-      // about which root the session happens to live in.
+      // Only a single-root project's default folder renders flat under the
+      // project header. Multi-root sessions stay inside their repository row.
       const isTopLevelFolderId = (folderId: string | null): boolean => {
         const folder = folderId
           ? projectFolderById(currentAllWorkspaceGroups, folderId)

--- a/src/lib/projectFolders.ts
+++ b/src/lib/projectFolders.ts
@@ -441,8 +441,8 @@ function folderGroupsForRepo(
 
 /**
  * Flatten a project's roots into one workspace list: the primary root's
- * folders first (its default one is what renders flat under the header), then
- * each source folder's own workspaces in the order the roots were added.
+ * folders first, then each source root's workspaces in the order the roots
+ * were added. Rendering decides whether the single-root default is flattened.
  */
 function folderGroupsForRoots(
   roots: readonly string[],

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -81,6 +81,33 @@ function project(): ProjectFolderProjectGroup {
   };
 }
 
+function multiRootProject(): ProjectFolderProjectGroup {
+  const primaryFolder = makeDefaultProjectFolder("/repo/app");
+  const apiFolder = makeDefaultProjectFolder("/repo/api");
+  const webFolder = makeDefaultProjectFolder("/repo/web");
+  const primaryIdle = session("primary-idle", "ready");
+  const apiNeeds = {
+    ...session("api-needs", "waiting_for_input"),
+    repo_path: "/repo/api",
+    worktree_path: "/repo/api",
+  };
+  const webIdle = {
+    ...session("web-idle", "ready"),
+    repo_path: "/repo/web",
+    worktree_path: "/repo/web",
+  };
+  return {
+    repoPath: "/repo/app",
+    name: "app",
+    sessions: [primaryIdle, apiNeeds, webIdle],
+    folders: [
+      { folder: primaryFolder, sessions: [primaryIdle] },
+      { folder: apiFolder, sessions: [apiNeeds] },
+      { folder: webFolder, sessions: [webIdle] },
+    ],
+  };
+}
+
 describe("sidebar project items", () => {
   it("preserves manual project item order by default", () => {
     const items = buildProjectTopLevelItems(project(), [
@@ -165,6 +192,34 @@ describe("sidebar project items", () => {
         (item) => item.id,
       ),
     ).toEqual(["source-needs", "source-ready"]);
+  });
+
+  it("keeps single-session source roots manually sortable", () => {
+    const group = multiRootProject();
+    const manualOrder = [
+      "folder:/repo/web",
+      "folder:/repo/api",
+      "folder:/repo/app",
+    ];
+
+    expect(
+      buildProjectTopLevelItems(group, manualOrder, true).map(
+        (item) => item.id,
+      ),
+    ).toEqual(manualOrder);
+
+    const index = buildDragPriorityIndex([group]);
+    expect(index.get("folder:/repo/api")).toEqual({
+      containerId: "project:/repo/app",
+      isPrioritized: false,
+    });
+    expect(
+      isPriorityDropAllowed(
+        index,
+        "folder:/repo/web",
+        "folder:/repo/api",
+      ),
+    ).toBe(true);
   });
 
   it("orders urgent items without rewriting the saved order", () => {

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -1,4 +1,5 @@
 import {
+  isDefaultProjectFolder,
   isGroupDefaultFolder,
   projectGroupSpansMultipleRoots,
   type ProjectFolderGroup,
@@ -147,16 +148,19 @@ export function buildDragPriorityIndex(
   for (const group of groups) {
     const topLevelContainerId = `project:${group.repoPath}`;
     for (const folderGroup of group.folders) {
-      const isDefaultFolder = isGroupDefaultFolder(group, folderGroup.folder);
-      // The default folder is flattened into top-level session rows and never
-      // drawn as a folder row, so it has no drag id to index.
-      if (!isDefaultFolder) {
+      const isFlattenedFolder = isGroupDefaultFolder(
+        group,
+        folderGroup.folder,
+      );
+      // A flattened folder becomes top-level session rows and has no folder
+      // drag id of its own.
+      if (!isFlattenedFolder) {
         index.set(sidebarFolderItemId(folderGroup.folder.id), {
           containerId: topLevelContainerId,
           isPrioritized: folderGroupHasProjectPriorityStatus(folderGroup),
         });
       }
-      const sessionContainerId = isDefaultFolder
+      const sessionContainerId = isFlattenedFolder
         ? topLevelContainerId
         : `folder:${folderGroup.folder.id}`;
       for (const session of folderGroup.sessions) {
@@ -238,11 +242,12 @@ function itemHasPriorityStatus(item: ProjectTopLevelItem): boolean {
   return folderGroupHasProjectPriorityStatus(item.folderGroup);
 }
 
-/** A single-tab workspace has no useful internal slot to promote into. */
+/** A named single-tab workspace has no useful internal slot to promote into. */
 function folderGroupHasProjectPriorityStatus(
   folderGroup: ProjectFolderGroup,
 ): boolean {
   return (
+    !isDefaultProjectFolder(folderGroup.folder) &&
     folderGroup.sessions.length <= 1 &&
     folderGroup.sessions.some(hasPriorityStatus)
   );

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4347,7 +4347,7 @@ test.describe("sidebar: project lifecycle", () => {
       .toBe("manual-order");
   });
 
-  test("priority sorting respects source workspace tab count", async ({
+  test("priority sorting stays within source root rows", async ({
     page,
     tauri,
   }) => {
@@ -4452,7 +4452,7 @@ test.describe("sidebar: project lifecycle", () => {
     const sourceWorkspace = sidebar.locator(
       '[data-sidebar-workspace-id="/tmp/demo-api"]',
     );
-    const singleTabWorkspace = sidebar.locator(
+    const singleSessionSource = sidebar.locator(
       '[data-sidebar-workspace-id="/tmp/demo-docs"]',
     );
     const sourceReady = sidebar.getByRole("button", {
@@ -4466,20 +4466,20 @@ test.describe("sidebar: project lifecycle", () => {
       .poll(async () => {
         const primaryBox = await primaryWorkspace.boundingBox();
         const sourceBox = await sourceWorkspace.boundingBox();
-        const singleTabBox = await singleTabWorkspace.boundingBox();
+        const singleSessionBox = await singleSessionSource.boundingBox();
         const readyBox = await sourceReady.boundingBox();
         const needsBox = await sourceNeeds.boundingBox();
         if (
           !primaryBox ||
           !sourceBox ||
-          !singleTabBox ||
+          !singleSessionBox ||
           !readyBox ||
           !needsBox
         ) {
           return "missing";
         }
-        return singleTabBox.y < primaryBox.y &&
-          primaryBox.y < sourceBox.y &&
+        return primaryBox.y < sourceBox.y &&
+          sourceBox.y < singleSessionBox.y &&
           needsBox.y < readyBox.y
           ? "scoped-priority-order"
           : "different";
@@ -4834,6 +4834,126 @@ test.describe("sidebar: project lifecycle", () => {
     );
     await expect(primaryRow.getByText("api", { exact: true })).toHaveCount(0);
     await expect(apiRow.getByText("api", { exact: true })).toHaveCount(1);
+  });
+
+  test("source root rows stay manually sortable with priority enabled", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({
+          interface: { prioritizeNeedsInputTabs: true },
+        }),
+      );
+    });
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+        source_paths: ["/tmp/demo-api", "/tmp/demo-web"],
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "primary-session",
+        name: "primary",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "api-session",
+        name: "api session",
+        repo_path: "/tmp/demo-api",
+        worktree_path: "/tmp/demo-api",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "waiting_for_input",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+      {
+        id: "web-session",
+        name: "web session",
+        repo_path: "/tmp/demo-web",
+        worktree_path: "/tmp/demo-web",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:02Z",
+        updated_at: "2026-01-01T00:00:02Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+      },
+    ]);
+
+    await page.goto("/");
+
+    const apiRow = page.locator(
+      'aside [data-sidebar-workspace-id="/tmp/demo-api"]',
+    );
+    const webRow = page.locator(
+      'aside [data-sidebar-workspace-id="/tmp/demo-web"]',
+    );
+    await expect(apiRow).toBeVisible();
+    await expect(webRow).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: /^api session main · Waiting for input/,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^web session main · Ready/ }),
+    ).toBeVisible();
+
+    await dragBetween(page, webRow, apiRow);
+
+    await expect
+      .poll(async () => {
+        const apiBox = await apiRow.boundingBox();
+        const webBox = await webRow.boundingBox();
+        if (!apiBox || !webBox) return "missing";
+        return webBox.y < apiBox.y ? "web-api" : "api-web";
+      })
+      .toBe("web-api");
+
+    await page.reload();
+
+    await expect
+      .poll(async () => {
+        const apiBox = await apiRow.boundingBox();
+        const webBox = await webRow.boundingBox();
+        if (!apiBox || !webBox) return "missing";
+        return webBox.y < apiBox.y ? "web-api" : "api-web";
+      })
+      .toBe("web-api");
   });
 
   test("the project hover card lists the source folders", async ({


### PR DESCRIPTION
## Summary
Source-root workspace rows now keep the user's manual order even when attention-priority sorting is enabled.

1. **Stable source-root order** — exclude default repository-root workspaces from transient waiting/error priority groups so root rows can be dragged across one another.
2. **Preserved scoped priority** — continue prioritizing waiting/error sessions inside each source root and named single-tab workspaces at the project level.
3. **Regression coverage** — cover priority classification in Vitest and verify drag persistence across reloads in Playwright.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Source-root drag with priority enabled | A waiting/error child could split root rows into different priority groups and block the drop | Root rows remain manually sortable and retain the saved order |
| Sessions inside a source root | Waiting/error sessions move above ready sessions | Unchanged |
| Named single-tab workspaces | A waiting/error workspace moves above ready project items | Unchanged |

## Design notes
- Repository-root rows are structural navigation, so their top-level order remains tied to the persisted manual project-item order rather than transient child status.
- `isDefaultProjectFolder` distinguishes repository roots from named workspaces; the existing single-tab rule remains in place for named workspaces.
- No backend command, source-path ordering API, or persistence schema changes are required.

## Test plan
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec vitest run src/lib/sidebarProjectItems.test.ts src/lib/projectFolders.test.ts src/store.test.ts` — 209 passed
- [x] `pnpm run test` — 109 files, 1,291 tests passed
- [x] `pnpm run build` — passed
- [x] Targeted sidebar Playwright regression tests — 2 passed
- [x] `pnpm run test:e2e` — 319 passed

## Notes
- The production build retains the existing large-chunk and ineffective-dynamic-import warnings; this PR does not touch bundling.
