### PR TITLE
fix(project-settings): complete worktree deletion without modal reload

### DIFF
--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -28,6 +28,9 @@ vi.mock("../lib/api", () => ({
         removeSessions?: boolean,
       ) => Promise<WorktreeRemoval | null>
     >(),
+    discardRemovedWorktree: vi.fn<
+      (removal: WorktreeRemoval) => Promise<void>
+    >(),
     updateProjectSettings: vi.fn<
       (
         repoPath: string,
@@ -104,12 +107,14 @@ describe("ProjectSettingsModal", () => {
     mockApi.listProjects.mockReset();
     mockApi.listSessions.mockReset();
     mockApi.removeWorktree.mockReset();
+    mockApi.discardRemovedWorktree.mockReset();
     mockApi.updateProjectSettings.mockReset();
     mockApi.listProjectWorktrees.mockResolvedValue([]);
     mockApi.listProjectBranches.mockResolvedValue([]);
     mockApi.listProjects.mockResolvedValue([]);
     mockApi.listSessions.mockResolvedValue([]);
     mockApi.removeWorktree.mockResolvedValue(null);
+    mockApi.discardRemovedWorktree.mockResolvedValue();
   });
 
   afterEach(() => {
@@ -217,6 +222,12 @@ describe("ProjectSettingsModal", () => {
   });
 
   it("lists project worktrees and removes one after confirmation", async () => {
+    const removal: WorktreeRemoval = {
+      token: "remove-feature-alpha",
+      repoPath: "/repo/acorn",
+      worktreePath: "/repo/acorn/.acorn/worktrees/feature-alpha",
+      gitCommonDir: "/repo/acorn/.git",
+    };
     mockApi.getProjectSettings.mockResolvedValue({
       key: "github:im-ian/acorn",
       settings: {
@@ -227,26 +238,19 @@ describe("ProjectSettingsModal", () => {
         worktrees: { base_branch: null },
       },
     });
-    mockApi.listProjectWorktrees
-      .mockResolvedValueOnce([
-        {
-          name: "feature-alpha",
-          path: "/repo/acorn/.acorn/worktrees/feature-alpha",
-          modified_ms: Date.UTC(2026, 4, 19, 12, 0, 0),
-        },
-        {
-          name: "feature-beta",
-          path: "/repo/acorn/.acorn/worktrees/feature-beta",
-          modified_ms: null,
-        },
-      ])
-      .mockResolvedValueOnce([
-        {
-          name: "feature-beta",
-          path: "/repo/acorn/.acorn/worktrees/feature-beta",
-          modified_ms: null,
-        },
-      ]);
+    mockApi.listProjectWorktrees.mockResolvedValueOnce([
+      {
+        name: "feature-alpha",
+        path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: Date.UTC(2026, 4, 19, 12, 0, 0),
+      },
+      {
+        name: "feature-beta",
+        path: "/repo/acorn/.acorn/worktrees/feature-beta",
+        modified_ms: null,
+      },
+    ]);
+    mockApi.removeWorktree.mockResolvedValueOnce(removal);
     const onClose = vi.fn();
 
     await act(async () => {
@@ -301,8 +305,45 @@ describe("ProjectSettingsModal", () => {
       "/repo/acorn/.acorn/worktrees/feature-alpha",
       false,
     );
+    expect(mockApi.discardRemovedWorktree).toHaveBeenCalledWith(removal);
+    expect(mockApi.listProjectWorktrees).toHaveBeenCalledTimes(1);
     expect(document.body.textContent).not.toContain("feature-alpha");
     expect(document.body.textContent).toContain("feature-beta");
+  });
+
+  it("does not reload project data for an equivalent project prop", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: { generation_prompt: null },
+        worktrees: { base_branch: null },
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    expect(mockApi.getProjectSettings).toHaveBeenCalledTimes(1);
+    expect(mockApi.listProjectWorktrees).toHaveBeenCalledTimes(1);
+    expect(mockApi.listProjectBranches).toHaveBeenCalledTimes(1);
   });
 
   it("requires confirmation before deleting a worktree used by the active session", async () => {

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -368,10 +368,10 @@ export function ProjectSettingsModal({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [project, projectRootsKey]);
+  }, [project?.repoPath, projectRootsKey]);
 
   useEffect(() => {
-    if (!project || !activeWorktreeRoot) {
+    if (!project?.repoPath || !activeWorktreeRoot) {
       setBranches([]);
       setBranchesLoading(false);
       setBranchError(null);
@@ -399,7 +399,7 @@ export function ProjectSettingsModal({
     return () => {
       cancelled = true;
     };
-  }, [project, activeWorktreeRoot]);
+  }, [project?.repoPath, activeWorktreeRoot]);
 
   const prompt = settings.pull_requests.generation_prompt ?? "";
   const activeRootSettings =
@@ -590,13 +590,22 @@ export function ProjectSettingsModal({
     setRemovingPath(target.path);
     setWorktreeError(null);
     try {
-      await removeProjectWorktree(
+      const removedWorktree = await removeProjectWorktree(
         target.rootPath,
         target.path,
         targetSessions.length > 0,
       );
+      if (removedWorktree) {
+        await api.discardRemovedWorktree(removedWorktree);
+      }
       setConfirmRemove(null);
-      setWorktrees(await listWorktreesForRoots(projectRoots));
+      setWorktrees((current) =>
+        current.filter(
+          (worktree) =>
+            worktree.rootPath !== target.rootPath ||
+            worktree.path !== target.path,
+        ),
+      );
     } catch (e) {
       setWorktreeError({ kind: "remove", message: String(e) });
     } finally {

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -162,10 +162,24 @@ test.describe("project settings", () => {
     await tauri.handle("remove_worktree", (args) => {
       const w = window as unknown as {
         __removeWorktreeCalls?: unknown[];
-        __worktrees?: Array<{ path: string }>;
       };
       w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
       w.__removeWorktreeCalls.push(args);
+      const worktreePath = (args as { worktreePath?: string }).worktreePath;
+      return {
+        token: "remove-feature-alpha",
+        repoPath: "/tmp/acorn",
+        worktreePath,
+        gitCommonDir: "/tmp/acorn/.git",
+      };
+    });
+    await tauri.handle("discard_removed_worktree", (args) => {
+      const w = window as unknown as {
+        __discardWorktreeCalls?: unknown[];
+        __worktrees?: Array<{ path: string }>;
+      };
+      w.__discardWorktreeCalls = w.__discardWorktreeCalls ?? [];
+      w.__discardWorktreeCalls.push(args);
       const worktreePath = (args as { worktreePath?: string }).worktreePath;
       w.__worktrees = (w.__worktrees ?? []).filter(
         (worktree) => worktree.path !== worktreePath,
@@ -216,6 +230,20 @@ test.describe("project settings", () => {
       {
         repoPath: "/tmp/acorn",
         worktreePath: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+      },
+    ]);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __discardWorktreeCalls?: unknown[] })
+            .__discardWorktreeCalls,
+      ),
+    ).toEqual([
+      {
+        token: "remove-feature-alpha",
+        repoPath: "/tmp/acorn",
+        worktreePath: "/tmp/acorn/.acorn/worktrees/feature-alpha",
+        gitCommonDir: "/tmp/acorn/.git",
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Project settings now completes worktree deletion and keeps the modal stable while the operation updates application state.

1. **Finalize worktree deletion** — consume the staged removal token with `discard_removed_worktree`, so the hidden backup and Git worktree registration are actually removed.
2. **Preserve modal state** — key loading effects by project path instead of transient prop identity and remove the deleted row locally, avoiding a full worktree-list reload and scroll reset.
3. **Cover the regression** — model staged-versus-discarded backend behavior in component and Playwright tests, including equivalent-project rerenders.

## Expected impact

| Behavior | Before | After |
| --- | --- | --- |
| Delete from Project Settings | Worktree was only staged, then reappeared from its remaining Git registration | Worktree backup and registration are permanently removed |
| Modal during deletion | Store refresh could restart modal loading and move scroll to the top | Modal state and scroll position remain stable |
| Worktree list refresh | Entire list was fetched again after deletion | Only the confirmed row is removed locally |

## Design notes

- `remove_worktree` intentionally stages a recoverable filesystem move and returns a removal token. Project Settings presents a permanent delete confirmation rather than an undo flow, so this call site immediately finalizes that token with the existing discard command.
- The project object is reconstructed by the sidebar during store updates. Loading effects now depend on the stable repository path and root key, while still reloading when the selected project actually changes.
- Multi-root projects filter by both root path and worktree path so identically named worktrees in separate repositories remain untouched.

## Test plan

- [x] `pnpm test` — 109 files, 1,292 tests passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm exec playwright test tests/e2e/project-settings.spec.ts` — 10 Chromium tests passed
