### PR TITLE
feat(pull-requests): manage draft and closed states from detail modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -17,7 +17,7 @@ use crate::project_settings::{self, ProjectSettings, ProjectSettingsRecord};
 use crate::pull_requests::{
     self, GeneratedCommitMessage, IssueDetailListing, IssueListing, IssueStateFilter, MergeMethod,
     PrStateFilter, PullRequestDetailListing, PullRequestDiffListing, PullRequestListing,
-    WorkflowRunDetailListing, WorkflowRunsListing,
+    PullRequestStateChange, WorkflowRunDetailListing, WorkflowRunsListing,
 };
 use crate::state::{AppState, PendingSessionRemoval};
 use crate::todos::{self, TodoItem};
@@ -10875,6 +10875,15 @@ pub async fn merge_pull_request(
 #[tauri::command]
 pub async fn close_pull_request(repo_path: String, number: u64) -> AppResult<()> {
     pull_requests::close_pull_request(&PathBuf::from(repo_path), number)
+}
+
+#[tauri::command]
+pub async fn change_pull_request_state(
+    repo_path: String,
+    number: u64,
+    change: PullRequestStateChange,
+) -> AppResult<()> {
+    pull_requests::change_pull_request_state(&PathBuf::from(repo_path), number, change)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -824,6 +824,7 @@ pub fn run() {
             commands::resolve_commit_logins,
             commands::merge_pull_request,
             commands::close_pull_request,
+            commands::change_pull_request_state,
             commands::update_pull_request_body,
             commands::generate_pr_commit_message,
             commands::list_workflow_runs,

--- a/src-tauri/src/pull_requests.rs
+++ b/src-tauri/src/pull_requests.rs
@@ -2135,7 +2135,7 @@ struct GhCheck {
 }
 
 // ---------------------------------------------------------------------------
-// PR mutations: merge / close / AI commit message
+// PR mutations: merge / lifecycle state / AI commit message
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -2144,6 +2144,14 @@ pub enum MergeMethod {
     Squash,
     Merge,
     Rebase,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PullRequestStateChange {
+    Ready,
+    Draft,
+    Reopen,
 }
 
 impl MergeMethod {
@@ -2206,6 +2214,27 @@ pub fn close_pull_request(repo_path: &Path, number: u64) -> AppResult<()> {
         AccountOutcome::Ok { value, .. } => Ok(value),
         AccountOutcome::NoAccess { .. } => Err(AppError::Other(
             "No logged-in gh account can close this PR.".to_string(),
+        )),
+    }
+}
+
+pub fn change_pull_request_state(
+    repo_path: &Path,
+    number: u64,
+    change: PullRequestStateChange,
+) -> AppResult<()> {
+    let Some(slug) = github_owner_repo(repo_path)? else {
+        return Err(AppError::Other(
+            "Origin remote is not a GitHub repository.".to_string(),
+        ));
+    };
+
+    match try_with_account(repo_path, &slug, |token| {
+        run_pr_state_change(&slug, number, token, change)
+    })? {
+        AccountOutcome::Ok { value, .. } => Ok(value),
+        AccountOutcome::NoAccess { .. } => Err(AppError::Other(
+            "No logged-in gh account can change this PR's state.".to_string(),
         )),
     }
 }
@@ -2312,6 +2341,47 @@ fn run_pr_close(slug: &str, number: u64, token: &str) -> AppResult<()> {
         cmd.env("GH_TOKEN", token)
             .env("GH_HOST", GH_HOST)
             .args(["pr", "close", &number_s, "--repo", slug]);
+    })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let msg = if stderr.is_empty() {
+            format!("gh exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(AppError::Other(msg));
+    }
+    Ok(())
+}
+
+fn pr_state_change_args(slug: &str, number: u64, change: PullRequestStateChange) -> Vec<String> {
+    let subcommand = match change {
+        PullRequestStateChange::Ready | PullRequestStateChange::Draft => "ready",
+        PullRequestStateChange::Reopen => "reopen",
+    };
+    let mut args = vec![
+        "pr".to_string(),
+        subcommand.to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        slug.to_string(),
+    ];
+    if matches!(change, PullRequestStateChange::Draft) {
+        args.push("--undo".to_string());
+    }
+    args
+}
+
+fn run_pr_state_change(
+    slug: &str,
+    number: u64,
+    token: &str,
+    change: PullRequestStateChange,
+) -> AppResult<()> {
+    let output = cli_resolver::run("gh", |cmd| {
+        cmd.env("GH_TOKEN", token)
+            .env("GH_HOST", GH_HOST)
+            .args(pr_state_change_args(slug, number, change));
     })?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -3050,6 +3120,22 @@ mod tests {
 
         assert_eq!(pr.closed_at.as_deref(), Some("2026-07-10T00:59:00Z"));
         assert_eq!(pr.merged_at.as_deref(), Some("2026-07-10T00:58:00Z"));
+    }
+
+    #[test]
+    fn pr_state_changes_map_to_non_interactive_gh_commands() {
+        assert_eq!(
+            pr_state_change_args("acme/widgets", 42, PullRequestStateChange::Ready),
+            ["pr", "ready", "42", "--repo", "acme/widgets"]
+        );
+        assert_eq!(
+            pr_state_change_args("acme/widgets", 42, PullRequestStateChange::Draft),
+            ["pr", "ready", "42", "--repo", "acme/widgets", "--undo"]
+        );
+        assert_eq!(
+            pr_state_change_args("acme/widgets", 42, PullRequestStateChange::Reopen),
+            ["pr", "reopen", "42", "--repo", "acme/widgets"]
+        );
     }
 
     #[test]

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -13,6 +13,7 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   GitPullRequestDraft,
+  Loader2,
   MessagesSquare,
   Minus,
   PencilLine,
@@ -41,6 +42,7 @@ import type {
   PullRequestDetail,
   PullRequestDetailListing,
   PullRequestReview,
+  PullRequestStateChange,
 } from "../lib/types";
 import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag, buildProfileMenuItems } from "./AuthorTag";
@@ -105,8 +107,8 @@ interface PullRequestDetailModalProps {
   cwd?: string;
   onClose: () => void;
   /**
-   * Notifies the parent that the PR's lifecycle changed (merged/closed) so
-   * the surrounding list can refetch.
+   * Notifies the parent that the PR's lifecycle changed so the surrounding
+   * list can refetch.
    */
   onMutated?: () => void;
 }
@@ -131,6 +133,8 @@ export function PullRequestDetailModal({
   const [refreshing, setRefreshing] = useState(false);
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
   const [closeDialogOpen, setCloseDialogOpen] = useState(false);
+  const [stateChanging, setStateChanging] =
+    useState<PullRequestStateChange | null>(null);
   const [commentDraft, setCommentDraft] = useState("");
   const [discardCommentDialogOpen, setDiscardCommentDialogOpen] =
     useState(false);
@@ -144,6 +148,8 @@ export function PullRequestDetailModal({
   } | null>(null);
   const [bodySaveError, setBodySaveError] = useState<string | null>(null);
   const bodyWriteSeqRef = useRef(0);
+  const stateWriteSeqRef = useRef(0);
+  const detailFetchGenerationRef = useRef(0);
   const detailFetchInFlightRef = useRef<{
     key: string;
     promise: Promise<PullRequestDetailListing>;
@@ -166,12 +172,13 @@ export function PullRequestDetailModal({
   }, []);
 
   const requestClose = useCallback(() => {
+    if (stateChanging !== null) return;
     if (commentDraft.trim().length > 0) {
       setDiscardCommentDialogOpen(true);
       return;
     }
     onClose();
-  }, [commentDraft, onClose]);
+  }, [commentDraft, onClose, stateChanging]);
 
   const discardAndClose = useCallback(() => {
     setCommentDraft("");
@@ -193,6 +200,9 @@ export function PullRequestDetailModal({
 
   // Hard-clear stale data whenever the modal closes or switches PR.
   useEffect(() => {
+    stateWriteSeqRef.current += 1;
+    detailFetchGenerationRef.current += 1;
+    detailFetchInFlightRef.current = null;
     if (!open) {
       setListing(null);
       setError(null);
@@ -201,6 +211,7 @@ export function PullRequestDetailModal({
       setReloadKey(0);
       setMergeDialogOpen(false);
       setCloseDialogOpen(false);
+      setStateChanging(null);
       setCommentDraft("");
       setDiscardCommentDialogOpen(false);
       setDeleteCommentId(null);
@@ -213,6 +224,7 @@ export function PullRequestDetailModal({
     setCommentDraft("");
     setDiscardCommentDialogOpen(false);
     setDeleteCommentId(null);
+    setStateChanging(null);
     setBodyOverride(null);
     setBodySaveError(null);
   }, [open]);
@@ -221,16 +233,27 @@ export function PullRequestDetailModal({
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
+    const generation = detailFetchGenerationRef.current;
     setRefreshing(true);
     fetchDetail(open.repoPath, open.number)
       .then((result) => {
-        if (cancelled) return;
+        if (
+          cancelled ||
+          generation !== detailFetchGenerationRef.current
+        ) {
+          return;
+        }
         setListing(result);
         setError(null);
         setRefreshing(false);
       })
       .catch((e) => {
-        if (cancelled) return;
+        if (
+          cancelled ||
+          generation !== detailFetchGenerationRef.current
+        ) {
+          return;
+        }
         setError(String(e));
         setRefreshing(false);
       });
@@ -248,15 +271,22 @@ export function PullRequestDetailModal({
     if (!open || !hasRunningChecks) return;
     let cancelled = false;
     const handle = window.setInterval(() => {
+      const generation = detailFetchGenerationRef.current;
       void fetchDetail(open.repoPath, open.number)
         .then((result) => {
-          if (!cancelled) {
+          if (
+            !cancelled &&
+            generation === detailFetchGenerationRef.current
+          ) {
             setListing(result);
             setError(null);
           }
         })
         .catch((e) => {
-          if (!cancelled) {
+          if (
+            !cancelled &&
+            generation === detailFetchGenerationRef.current
+          ) {
             console.debug("[PullRequestDetailModal] polling failed", e);
           }
         });
@@ -275,6 +305,59 @@ export function PullRequestDetailModal({
     setReloadKey((k) => k + 1);
     onMutated?.();
   }, [onMutated]);
+
+  const handleStateChange = useCallback(
+    async (change: PullRequestStateChange) => {
+      if (!open || !detail || stateChanging) return;
+      const seq = ++stateWriteSeqRef.current;
+      setStateChanging(change);
+      try {
+        await api.changePullRequestState(open.repoPath, open.number, change);
+        if (seq !== stateWriteSeqRef.current) return;
+
+        detailFetchGenerationRef.current += 1;
+        detailFetchInFlightRef.current = null;
+        const nextIsDraft =
+          change === "draft"
+            ? true
+            : change === "ready"
+              ? false
+              : detail.is_draft;
+        setListing((current) =>
+          current?.kind === "ok"
+            ? {
+                ...current,
+                detail: {
+                  ...current.detail,
+                  state: change === "reopen" ? "OPEN" : current.detail.state,
+                  is_draft: nextIsDraft,
+                },
+              }
+            : current,
+        );
+        emitPullRequestMutation({
+          kind: change === "reopen" ? "reopened" : "draft_changed",
+          repoPath: open.repoPath,
+          number: open.number,
+          headBranch: detail.head_branch,
+          baseBranch: detail.base_branch,
+          title: detail.title,
+          isDraft: nextIsDraft,
+        });
+        handleMutated();
+      } catch (e) {
+        if (seq !== stateWriteSeqRef.current) return;
+        showToast(
+          `${t("toasts.pullRequests.stateChangeFailed")} ${String(e)}`,
+        );
+      } finally {
+        if (seq === stateWriteSeqRef.current) {
+          setStateChanging(null);
+        }
+      }
+    },
+    [detail, handleMutated, open, showToast, stateChanging, t],
+  );
 
   const handleSubmitComment = useCallback(
     async (body: string) => {
@@ -430,6 +513,8 @@ export function PullRequestDetailModal({
             diffReloadKey={reloadKey}
             onOpenMerge={() => setMergeDialogOpen(true)}
             onOpenClose={() => setCloseDialogOpen(true)}
+            stateChanging={stateChanging}
+            onChangeState={handleStateChange}
             onSubmitComment={handleSubmitComment}
             onUpdateComment={handleUpdateComment}
             onRequestDeleteComment={setDeleteCommentId}
@@ -514,6 +599,8 @@ function DetailBody({
   diffReloadKey,
   onOpenMerge,
   onOpenClose,
+  stateChanging,
+  onChangeState,
   onSubmitComment,
   onUpdateComment,
   onRequestDeleteComment,
@@ -536,6 +623,8 @@ function DetailBody({
   diffReloadKey: number;
   onOpenMerge: () => void;
   onOpenClose: () => void;
+  stateChanging: PullRequestStateChange | null;
+  onChangeState: (change: PullRequestStateChange) => void;
   onSubmitComment: (body: string) => Promise<void>;
   onUpdateComment: (commentId: number, body: string) => Promise<void>;
   onRequestDeleteComment: (commentId: number) => void;
@@ -704,17 +793,36 @@ function DetailBody({
         <div className="flex shrink-0 items-center gap-1">
           {detail.state.toUpperCase() === "OPEN" ? (
             <>
+              <PullRequestStateButton
+                change={detail.is_draft ? "ready" : "draft"}
+                busy={stateChanging !== null}
+                loading={stateChanging === (detail.is_draft ? "ready" : "draft")}
+                onClick={onChangeState}
+              />
               <MergeActionButton
                 mergeable={detail.mergeable}
+                isDraft={detail.is_draft}
+                busy={stateChanging !== null}
                 onClick={onOpenMerge}
               />
               <button
                 type="button"
                 onClick={onOpenClose}
-                className="rounded-md bg-rose-500/15 px-2.5 py-1 text-[11px] font-medium text-rose-300 transition hover:bg-rose-500/25"
+                disabled={stateChanging !== null}
+                className="rounded-md bg-rose-500/15 px-2.5 py-1 text-[11px] font-medium text-rose-300 transition hover:bg-rose-500/25 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {dt(t, "dialogs.common.close")}
               </button>
+              <span className="mx-1 h-4 w-px bg-border" aria-hidden />
+            </>
+          ) : detail.state.toUpperCase() === "CLOSED" ? (
+            <>
+              <PullRequestStateButton
+                change="reopen"
+                busy={stateChanging !== null}
+                loading={stateChanging === "reopen"}
+                onClick={onChangeState}
+              />
               <span className="mx-1 h-4 w-px bg-border" aria-hidden />
             </>
           ) : null}
@@ -736,7 +844,8 @@ function DetailBody({
               type="button"
               aria-label={dt(t, "dialogs.common.close")}
               onClick={onClose}
-              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+              disabled={stateChanging !== null}
+              className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             >
               <X size={16} />
             </button>
@@ -921,6 +1030,7 @@ function DetailSkeleton({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          <SkeletonBlock className="h-6 w-20 rounded-md bg-fg-muted/10" />
           <SkeletonBlock className="h-6 w-14 rounded-md bg-fg-muted/10" />
           <SkeletonBlock className="h-6 w-12 rounded-md bg-fg-muted/10" />
           <span className="mx-1 h-4 w-px bg-border" aria-hidden />
@@ -1080,16 +1190,64 @@ function summarizeChecks(checks: PullRequestCheck[]): CheckCounts {
   return { passed, failed, pending };
 }
 
+function PullRequestStateButton({
+  change,
+  busy,
+  loading,
+  onClick,
+}: {
+  change: PullRequestStateChange;
+  busy: boolean;
+  loading: boolean;
+  onClick: (change: PullRequestStateChange) => void;
+}) {
+  const t = useTranslation();
+  const label =
+    change === "ready"
+      ? dt(t, "dialogs.pullRequestDetail.readyForReview")
+      : change === "draft"
+        ? dt(t, "dialogs.pullRequestDetail.convertToDraft")
+        : dt(t, "dialogs.pullRequestDetail.reopen");
+  const icon =
+    change === "draft" ? (
+      <GitPullRequestDraft size={12} />
+    ) : (
+      <GitPullRequest size={12} />
+    );
+
+  return (
+    <button
+      type="button"
+      aria-busy={loading}
+      disabled={busy}
+      onClick={() => onClick(change)}
+      className={cn(
+        "flex items-center gap-1 rounded-md px-2.5 py-1 text-[11px] font-medium transition disabled:cursor-not-allowed disabled:opacity-50",
+        change === "draft"
+          ? "bg-bg-elevated text-fg-muted hover:text-fg"
+          : "bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25",
+      )}
+    >
+      {loading ? <Loader2 size={12} className="animate-spin" /> : icon}
+      {label}
+    </button>
+  );
+}
+
 function MergeActionButton({
   mergeable,
+  isDraft,
+  busy,
   onClick,
 }: {
   mergeable: string | null;
+  isDraft: boolean;
+  busy: boolean;
   onClick: () => void;
 }) {
   const t = useTranslation();
   const upper = mergeable?.toUpperCase() ?? null;
-  const ready = upper === "MERGEABLE";
+  const ready = upper === "MERGEABLE" && !isDraft && !busy;
   const conflicting = upper === "CONFLICTING";
   const button = (
     <button
@@ -1109,9 +1267,11 @@ function MergeActionButton({
   if (ready) {
     return button;
   }
-  const title = conflicting
-    ? dt(t, "dialogs.pullRequestDetail.cannotMergeConflicting")
-    : dt(t, "dialogs.pullRequestDetail.mergeReadinessPending");
+  const title = isDraft
+    ? dt(t, "dialogs.pullRequestDetail.draftMustBeReadyToMerge")
+    : conflicting
+      ? dt(t, "dialogs.pullRequestDetail.cannotMergeConflicting")
+      : dt(t, "dialogs.pullRequestDetail.mergeReadinessPending");
   return (
     <Tooltip label={title} side="bottom">
       {button}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
   PullRequestDetailListing,
   PullRequestDiffListing,
   PullRequestListing,
+  PullRequestStateChange,
   Session,
   SessionAgentDetection,
   SessionAgentProvider,
@@ -662,6 +663,17 @@ export const api = {
   },
   closePullRequest(repoPath: string, number: number): Promise<void> {
     return invoke<void>("close_pull_request", { repoPath, number });
+  },
+  changePullRequestState(
+    repoPath: string,
+    number: number,
+    change: PullRequestStateChange,
+  ): Promise<void> {
+    return invoke<void>("change_pull_request_state", {
+      repoPath,
+      number,
+      change,
+    });
   },
   updatePullRequestBody(
     repoPath: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -750,6 +750,7 @@ export interface TodoItem {
 }
 
 export type PrStateFilter = "open" | "closed" | "merged" | "all";
+export type PullRequestStateChange = "ready" | "draft" | "reopen";
 export type IssueStateFilter = "open" | "closed" | "all";
 
 export interface PullRequestLabel {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,6 +53,7 @@
     "pullRequests": {
       "mergeFailed": "Failed to merge pull request:",
       "closeFailed": "Failed to close pull request:",
+      "stateChangeFailed": "Failed to change pull request state:",
       "bodyUpdateFailed": "Failed to update pull request:"
     }
   },
@@ -2438,6 +2439,10 @@
       "tabChecks": "Checks",
       "tabFiles": "Files",
       "merge": "Merge",
+      "readyForReview": "Ready for review",
+      "convertToDraft": "Convert to draft",
+      "reopen": "Reopen",
+      "draftMustBeReadyToMerge": "Mark as ready for review before merging.",
       "cannotMergeConflicting": "Cannot merge - conflicting branch",
       "mergeReadinessPending": "Merge readiness still being determined...",
       "resizePrBody": "Resize PR body",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -53,6 +53,7 @@
     "pullRequests": {
       "mergeFailed": "プル リクエストのマージに失敗しました:",
       "closeFailed": "プルリクエストをクローズできませんでした:",
+      "stateChangeFailed": "プルリクエストの状態を変更できませんでした:",
       "bodyUpdateFailed": "プル リクエストの更新に失敗しました:"
     }
   },
@@ -2438,6 +2439,10 @@
       "tabChecks": "小切手",
       "tabFiles": "ファイル",
       "merge": "マージ",
+      "readyForReview": "レビューの準備完了",
+      "convertToDraft": "ドラフトに変換",
+      "reopen": "再オープン",
+      "draftMustBeReadyToMerge": "マージする前にレビュー可能な状態にしてください。",
       "cannotMergeConflicting": "マージできません - ブランチが競合しています",
       "mergeReadinessPending": "マージの準備がまだ決定中です...",
       "resizePrBody": "PR 本文のサイズを変更する",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -53,6 +53,7 @@
     "pullRequests": {
       "mergeFailed": "Pull request를 병합하지 못했습니다:",
       "closeFailed": "Pull request를 닫지 못했습니다:",
+      "stateChangeFailed": "Pull request 상태를 변경하지 못했습니다:",
       "bodyUpdateFailed": "Pull request를 업데이트하지 못했습니다:"
     }
   },
@@ -2438,6 +2439,10 @@
       "tabChecks": "검사",
       "tabFiles": "파일",
       "merge": "병합",
+      "readyForReview": "리뷰 준비 완료",
+      "convertToDraft": "초안으로 전환",
+      "reopen": "다시 열기",
+      "draftMustBeReadyToMerge": "병합하려면 먼저 리뷰 준비 완료 상태로 전환하세요.",
       "cannotMergeConflicting": "병합할 수 없음 - 브랜치 충돌",
       "mergeReadinessPending": "병합 가능 여부 확인 중...",
       "resizePrBody": "PR 본문 크기 조절",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -53,6 +53,7 @@
     "pullRequests": {
       "mergeFailed": "无法合并拉取请求：",
       "closeFailed": "无法关闭拉取请求：",
+      "stateChangeFailed": "无法更改拉取请求状态：",
       "bodyUpdateFailed": "无法更新拉取请求："
     }
   },
@@ -2438,6 +2439,10 @@
       "tabChecks": "检查",
       "tabFiles": "文件",
       "merge": "合并",
+      "readyForReview": "可供审阅",
+      "convertToDraft": "转换为草稿",
+      "reopen": "重新打开",
+      "draftMustBeReadyToMerge": "请先标记为可供审阅，再进行合并。",
       "cannotMergeConflicting": "无法合并 - 冲突分支",
       "mergeReadinessPending": "合并准备情况仍在确定中...",
       "resizePrBody": "调整 PR 主体大小",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -485,6 +485,9 @@ export const tauriMockSource = `
     if (cmd === 'add_pull_request_comment') {
       return Promise.resolve(undefined);
     }
+    if (cmd === 'change_pull_request_state') {
+      return Promise.resolve(undefined);
+    }
     if (cmd === 'get_pull_request_diff') {
       return Promise.resolve({ kind: 'ok', account: 'test', diff: { files: [] } });
     }

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -778,6 +778,157 @@ test.describe("right panel: tab switching", () => {
     ).toBeVisible();
   });
 
+  test("changes draft, ready, and closed states from the pull request detail modal", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 92,
+          title: "Manage PR lifecycle",
+          state: "CLOSED",
+          author: "im-ian",
+          head_branch: "feature/lifecycle-actions",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/92",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("get_pull_request_detail", () => {
+      const w = window as unknown as {
+        __prLifecycle?: { state: string; isDraft: boolean };
+        __prDetailCalls?: number;
+        __releaseStalePrDetail?: boolean;
+      };
+      const lifecycle = w.__prLifecycle ?? {
+        state: "CLOSED",
+        isDraft: false,
+      };
+      w.__prLifecycle = lifecycle;
+      w.__prDetailCalls = (w.__prDetailCalls ?? 0) + 1;
+      const result = {
+        kind: "ok",
+        account: "test-account",
+        detail: {
+          number: 92,
+          title: "Manage PR lifecycle",
+          body: "Move this PR through its review states.",
+          state: lifecycle.state,
+          is_draft: lifecycle.isDraft,
+          author: "im-ian",
+          head_branch: "feature/lifecycle-actions",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/92",
+          created_at: "2026-05-18T00:00:00Z",
+          updated_at: "2026-05-19T00:00:00Z",
+          merged_at: null,
+          additions: 12,
+          deletions: 3,
+          changed_files: 2,
+          mergeable: "MERGEABLE",
+          labels: [],
+          comments: [],
+          reviews: [],
+          checks: [],
+          commits: [],
+        },
+      };
+      if (w.__prDetailCalls !== 2) return result;
+      return new Promise((resolve) => {
+        const tick = () => {
+          if (w.__releaseStalePrDetail) {
+            resolve(result);
+            return;
+          }
+          setTimeout(tick, 20);
+        };
+        tick();
+      });
+    });
+    await tauri.handle("change_pull_request_state", (args) => {
+      const w = window as unknown as {
+        __prLifecycle?: { state: string; isDraft: boolean };
+        __prStateChangeArgs?: unknown[];
+      };
+      w.__prLifecycle = w.__prLifecycle ?? {
+        state: "CLOSED",
+        isDraft: false,
+      };
+      w.__prStateChangeArgs = w.__prStateChangeArgs ?? [];
+      w.__prStateChangeArgs.push(args);
+      const change = (args as { change?: string }).change;
+      if (change === "reopen") w.__prLifecycle.state = "OPEN";
+      if (change === "draft") w.__prLifecycle.isDraft = true;
+      if (change === "ready") w.__prLifecycle.isDraft = false;
+      return undefined;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+    const prRow = page
+      .getByText("Manage PR lifecycle")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await dblclickRowRightSide(page, prRow);
+
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Manage PR lifecycle" }),
+    });
+    await dialog.getByRole("button", { name: "Refresh" }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __prDetailCalls?: number })
+              .__prDetailCalls ?? 0,
+        ),
+      )
+      .toBe(2);
+    await dialog.getByRole("button", { name: "Reopen" }).click();
+    await expect(
+      dialog.getByRole("button", { name: "Convert to draft" }),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Merge" })).toBeEnabled();
+    await page.evaluate(() => {
+      (window as unknown as { __releaseStalePrDetail?: boolean })
+        .__releaseStalePrDetail = true;
+    });
+    await expect(
+      dialog.getByRole("button", { name: "Convert to draft" }),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Convert to draft" }).click();
+    await expect(
+      dialog.getByRole("button", { name: "Ready for review" }),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Merge" })).toBeDisabled();
+
+    await dialog.getByRole("button", { name: "Ready for review" }).click();
+    await expect(
+      dialog.getByRole("button", { name: "Convert to draft" }),
+    ).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Merge" })).toBeEnabled();
+
+    const calls = await page.evaluate(
+      () =>
+        (window as unknown as { __prStateChangeArgs?: unknown[] })
+          .__prStateChangeArgs,
+    );
+    expect(calls).toEqual([
+      { repoPath: "/tmp/demo", number: 92, change: "reopen" },
+      { repoPath: "/tmp/demo", number: 92, change: "draft" },
+      { repoPath: "/tmp/demo", number: 92, change: "ready" },
+    ]);
+  });
+
   test("PR files render before a selected image preview finishes loading", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
PR detail now owns the common review-state transitions that previously required leaving Acorn for GitHub.

1. **Lifecycle actions** — add context-aware `Ready for review`, `Convert to draft`, and `Reopen` buttons to the PR detail header while keeping merged PRs immutable.
2. **Safer merge state** — disable Merge for draft pull requests and explain that the PR must be marked ready first.
3. **GitHub command bridge** — route the new actions through the existing multi-account `gh` authentication flow using typed Tauri/API contracts.
4. **Refresh reliability** — optimistically update the detail view, invalidate surrounding PR caches, and prevent stale detail requests from overwriting a completed state change.
5. **Coverage and copy** — exercise the full closed → open → draft → ready flow in Playwright, verify `gh` argument mapping in Rust, and add all four locale strings.

## Expected impact
| Flow | Before | After |
| --- | --- | --- |
| Draft → ready | Open the PR on GitHub | One click in PR detail |
| Ready → draft | Open the PR on GitHub | One click in PR detail |
| Closed → open | Open the PR on GitHub | `Reopen` in PR detail |
| Merge from draft | Merge dialog could be opened before GitHub rejected the state | Merge stays disabled until the PR is ready |
| Concurrent refresh | A late detail response could restore stale state | Pre-mutation requests are ignored after success |

## Design notes
- `PullRequestStateChange` is a narrow shared contract with `ready`, `draft`, and `reopen` variants. The backend maps these to `gh pr ready`, `gh pr ready --undo`, and `gh pr reopen` with explicit `--repo` routing.
- State changes reuse `try_with_account`, so mutations honor the same repository-aware GitHub account selection as PR listing, detail, merge, and close.
- The modal invalidates its current detail-fetch generation after a successful mutation. This keeps a manual refresh or running-check poll that started earlier from overwriting the optimistic state.
- State-change buttons and close affordances stay disabled while a lifecycle mutation is in flight; merged PRs expose no reversible lifecycle action.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 109 files / 1,291 tests pass
- [x] `pnpm run build` — production frontend build passes
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "changes draft, ready, and closed states"` — Chromium flow passes, including stale-refresh coverage
- [x] `cargo test --manifest-path src-tauri/Cargo.toml pull_requests::tests::pr_state_changes_map_to_non_interactive_gh_commands` — Rust command mapping passes

## Notes
- The frontend build still reports the existing ineffective dynamic-import and large-chunk warnings. The targeted Rust test still reports existing dead-code warnings. Neither warning set is introduced by this PR.
