### PR TITLE
fix(agent-status): reconcile completed Codex turns after provisional boundaries

### DIFF
--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -1063,6 +1063,27 @@ impl SessionStore {
         );
     }
 
+    /// Fill the provider id for a turn that began before Codex assigned one.
+    /// Existing per-turn activity stays intact because this is the same turn,
+    /// not a new boundary. A conflicting id is rejected so delayed events
+    /// cannot replace the current owner.
+    pub fn bind_hook_turn_id(&self, id: &Uuid, turn_id: &str) -> bool {
+        let turn_id = turn_id.trim();
+        if turn_id.is_empty() {
+            return false;
+        }
+
+        let mut runtime = self.lock_hook_runtime();
+        let state = runtime.entry(*id).or_default();
+        match state.turn_id.as_deref() {
+            None | Some("") => {
+                state.turn_id = Some(turn_id.to_string());
+                true
+            }
+            Some(current) => current == turn_id,
+        }
+    }
+
     pub fn hook_turn_id(&self, id: &Uuid) -> Option<String> {
         self.lock_hook_runtime()
             .get(id)
@@ -1862,6 +1883,30 @@ mod tests {
         store.remove(&session.id).expect("session exists");
         assert_eq!(store.hook_tool_started_at(&session.id), None);
         assert_eq!(store.hook_turn_id(&session.id), None);
+    }
+
+    #[test]
+    fn hook_turn_id_binding_preserves_current_turn_activity() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false));
+        let observed_at =
+            std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(123_456);
+
+        store.begin_hook_turn(&session.id, None);
+        store.mark_hook_tool_started_at(&session.id, observed_at);
+        store.mark_codex_permission_waiting_at(&session.id, observed_at);
+
+        assert!(store.bind_hook_turn_id(&session.id, "turn-1"));
+        assert_eq!(store.hook_turn_id(&session.id).as_deref(), Some("turn-1"));
+        assert_eq!(store.hook_tool_started_at(&session.id), Some(observed_at));
+        assert_eq!(
+            store.codex_permission_waiting_at(&session.id),
+            Some(observed_at)
+        );
+
+        assert!(store.bind_hook_turn_id(&session.id, "turn-1"));
+        assert!(!store.bind_hook_turn_id(&session.id, "turn-2"));
+        assert_eq!(store.hook_turn_id(&session.id).as_deref(), Some("turn-1"));
     }
 
     #[test]

--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -235,10 +235,21 @@ impl AgentHookReducer {
         };
 
         let mut candidate = lane.codex.clone();
+        let active_turn_id_before = candidate.active_turn_id().map(str::to_string);
         let reduction = candidate.reduce(lifecycle_id, signal, &event);
+        let newly_learned_turn_id =
+            match (active_turn_id_before.as_deref(), candidate.active_turn_id()) {
+                (None, Some(turn_id)) => Some(turn_id.to_string()),
+                _ => None,
+            };
         let effects = match reduction {
             CodexReduction::Apply(effects) => effects,
             CodexReduction::IgnoreAndCommit(reason) => {
+                bind_learned_codex_turn_id(
+                    &self.sessions,
+                    event.session_id,
+                    newly_learned_turn_id.as_deref(),
+                )?;
                 lane.codex = candidate;
                 return Ok(AgentHookApplyOutcome::Ignored {
                     status: current_status,
@@ -252,10 +263,34 @@ impl AgentHookReducer {
                 });
             }
         };
+        if !effects.begin_turn {
+            bind_learned_codex_turn_id(
+                &self.sessions,
+                event.session_id,
+                newly_learned_turn_id.as_deref(),
+            )?;
+        }
         let status = apply_validated_agent_hook_event(&self.sessions, event, effects)?;
         lane.codex = candidate;
         Ok(AgentHookApplyOutcome::Applied(status))
     }
+}
+
+fn bind_learned_codex_turn_id(
+    sessions: &SessionStore,
+    session_id: Uuid,
+    turn_id: Option<&str>,
+) -> Result<(), AgentHookApplyError> {
+    let Some(turn_id) = turn_id else {
+        return Ok(());
+    };
+    if sessions.bind_hook_turn_id(&session_id, turn_id) {
+        return Ok(());
+    }
+    Err(AgentHookApplyError::Conflict(format!(
+        "Codex turn id conflict for {session_id}: current {:?}, got {turn_id}",
+        sessions.hook_turn_id(&session_id)
+    )))
 }
 
 fn unsequenced_codex_effects(signal: CodexSignal, event: &AgentHookEvent) -> CodexStoreEffects {
@@ -447,6 +482,15 @@ struct CodexStoreEffects {
 }
 
 impl CodexLane {
+    fn active_turn_id(&self) -> Option<&str> {
+        self.current
+            .as_ref()?
+            .turn
+            .as_ref()?
+            .provider_turn_id
+            .as_deref()
+    }
+
     fn retire_current(&mut self) {
         let Some(current) = self.current.take() else {
             return;
@@ -4624,6 +4668,52 @@ mod tests {
             reducer.apply(unrelated),
             Err(super::AgentHookApplyError::Conflict(_))
         ));
+    }
+
+    #[test]
+    fn reducer_backfills_store_turn_id_after_a_provisional_boundary() {
+        let (sessions, session_id, reducer) = codex_reducer_fixture();
+        let mut fallback = codex_event(session_id, "jsonl_user", None);
+        fallback.native_hooks_enabled = Some(true);
+        assert!(matches!(
+            reducer
+                .apply(fallback)
+                .expect("provisional recorder boundary applies"),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert!(sessions.has_hook_turn_boundary(&session_id));
+        assert_eq!(sessions.hook_turn_id(&session_id), None);
+
+        let mut prompt = codex_event(session_id, "native_prompt", Some("turn-1"));
+        prompt.native_hooks_enabled = Some(true);
+        assert!(matches!(
+            reducer
+                .apply(prompt)
+                .expect("native prompt claims provisional boundary"),
+            AgentHookApplyOutcome::Applied(SessionStatus::Working)
+        ));
+        assert_eq!(
+            sessions.hook_turn_id(&session_id).as_deref(),
+            Some("turn-1")
+        );
+
+        let (_, source, _, lifecycle_revision) =
+            sessions.lifecycle_snapshot(&session_id).expect("snapshot");
+        assert_eq!(
+            sessions
+                .reconcile_codex_turn_end_if_current(
+                    &session_id,
+                    source,
+                    lifecycle_revision,
+                    "turn-1",
+                )
+                .expect("transcript completion reconciles"),
+            Some(lifecycle_revision + 1)
+        );
+        assert_eq!(
+            sessions.get(&session_id).expect("session").status,
+            SessionStatus::WaitingForInput
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Completed Codex turns can recover from a recorder-first lifecycle race instead of remaining stuck in Working.

1. **Bind provisional turn ownership** — when the JSONL recorder opens an ID-less user boundary before native `UserPromptSubmit`, backfill the native Codex `turn_id` into the session runtime.
2. **Preserve current-turn evidence** — keep tool and permission activity timestamps intact while filling the ID, and reject conflicting IDs from delayed events.
3. **Cover transcript recovery** — add regression tests proving a matching durable completion can move the session to WaitingForInput after the late ID arrives.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Recorder user boundary arrives before native prompt and `Stop` is missed | Durable `task_complete` cannot match the ID-less runtime owner, leaving the session in Working | Native prompt binds the active turn ID, so transcript reconciliation can restore WaitingForInput |
| Normal scoped Codex lifecycle | Existing turn tracking | Unchanged; existing IDs remain idempotent and conflicting IDs are rejected |

## Design notes

- The reducer detects only the transition from an ID-less active turn to a scoped turn; normal new-turn effects still use the existing `begin_hook_turn` path.
- `SessionStore::bind_hook_turn_id` fills only an absent or empty sentinel and does not reset per-turn tool or permission evidence.
- The binding happens for both applied and state-only reducer outcomes, covering late native prompts that intentionally do not change the visible status.

## Test plan

- [x] `rustfmt --edition 2021 --check src/agent_hooks.rs crates/acorn-session/src/session.rs`
- [x] `cargo test -p acorn-session -- --test-threads=1` — 87 passed
- [x] `cargo test -p acorn agent_hooks::tests -- --test-threads=1` — 80 passed
- [x] `cargo test -p acorn agent_wrappers::tests::codex_wrapper -- --test-threads=1` — 8 passed
- [x] GitHub Actions CI is green — Frontend and both E2E shards passed

## Notes

- A parallel full-app test observation produced three Codex wrapper fixture failures with empty notifications; all eight wrapper tests, including those three, pass together with `--test-threads=1`, consistent with shared-fixture interference rather than a lifecycle regression.
