### PR TITLE
fix(sidebar): restore project-title ellipsis beside hover actions

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2479,7 +2479,12 @@ function ProjectGroupView({
         </button>
         <span className="flex min-w-0 flex-1 items-center gap-1.5 leading-none">
           {hoverDetails ? (
-            <Tooltip label={hoverDetails} side="right" multiline>
+            <Tooltip
+              label={hoverDetails}
+              side="right"
+              multiline
+              className="min-w-0 max-w-full"
+            >
               <span className="truncate text-sm font-medium leading-5 text-fg">
                 {project.name}
               </span>

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2613,7 +2613,7 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
-  test("hidden project header actions do not reserve title width", async ({
+  test("project header uses full title width until hover actions need ellipsis", async ({
     page,
     tauri,
   }) => {
@@ -2664,6 +2664,19 @@ test.describe("sidebar: project lifecycle", () => {
         newSessionButton.evaluate((el) => (el as HTMLElement).offsetWidth),
       )
       .toBeGreaterThan(0);
+
+    const hoveredTitleMetrics = await title.evaluate((el) => {
+      const titleEl = el as HTMLElement;
+      return {
+        clientWidth: titleEl.clientWidth,
+        scrollWidth: titleEl.scrollWidth,
+        textOverflow: getComputedStyle(titleEl).textOverflow,
+      };
+    });
+    expect(hoveredTitleMetrics.textOverflow).toBe("ellipsis");
+    expect(hoveredTitleMetrics.scrollWidth).toBeGreaterThan(
+      hoveredTitleMetrics.clientWidth + 1,
+    );
   });
 
   test("project header exposes regular and worktree session buttons outside the menu", async ({


### PR DESCRIPTION
## Summary

Long project names once again end with an ellipsis when project actions appear on hover.

1. **Restore hover truncation** — let the project-name tooltip trigger shrink within the header so the inner `truncate` label has a constrained width before the action buttons.
2. **Lock the regression** — extend the sidebar E2E coverage to verify hidden actions reserve no space before hover and that the title has real overflow with CSS ellipsis after hover.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Long project name before hover | Uses the available header width | Unchanged |
| Long project name with hover actions visible | Text is clipped abruptly behind the action area | Text ends with an ellipsis before the action buttons |
| Short project name | Renders normally | Unchanged |

## Design notes

- The sizing class is scoped to the project-title `Tooltip` call site. Changing the shared tooltip wrapper would risk altering button, status-bar, and other inline tooltip layouts.
- The existing hidden-actions layout remains intact, so action buttons still consume zero width until hover.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "project header uses full title width until hover actions need ellipsis"` — 1 passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 54 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run test` — 109 files, 1,292 tests passed
- [x] `pnpm run build` — production frontend build passed
- [x] Playwright visual capture — confirmed `codex-ap…` truncation with all hover actions visible and no overlap

## Notes

- The production build continues to report the existing dynamic-import and large-chunk warnings in unrelated modules; this PR does not change those modules or the bundle configuration.
