### PR TITLE
chore(release): v1.31.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.31.0",
+  "version": "1.31.1",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.31.0"
+version = "1.31.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,7 +61,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.31.0"
+version = "1.31.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.31.1 from green `main` at `fda0052`, containing all merged changes since v1.31.0, including the project-title ellipsis fix from #773.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` to 1.31.1.
2. **Release scope** — ships pull-request lifecycle actions, sidebar and project-settings fixes, completed Codex-turn reconciliation, dependency maintenance, and the final project-title ellipsis regression fix.
3. **Publication path** — prepares the existing signed Apple Silicon and Intel release workflow plus updater metadata for the v1.31.1 tag.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Pull requests | Adds ready, draft, and reopen lifecycle actions to the PR detail modal. |
| Sidebar and projects | Restores manual source-root sorting, completes worktree deletion without a modal reload, and preserves project-title ellipsis beside hover actions. |
| Agent status | Reconciles completed Codex turns after provisional transcript boundaries. |
| Reliability | Includes the merged frontend, Rust, and GitHub Actions dependency updates since v1.31.0. |
| Updater | Publishes 1.31.1 artifacts and `latest.json` for both supported macOS architectures after the tag workflow succeeds. |

## Design notes

- The requested version is 1.31.1. This is an explicit semver exception because #770 adds user-visible PR lifecycle actions that would ordinarily make the next version 1.32.0.
- The release PR is version-only; each product change was reviewed and merged independently before the version bump.
- Included PRs: #760, #761, #765, #768, #769, #770, #771, and #773.
- Release notes are generated bilingually from those merged PRs. The tag is created only after this PR passes CI and lands on `main`.

## Follow-up (not in this PR)

- Push the annotated `v1.31.1` tag after merge.
- Verify the Release workflow, both architecture bundles, updater metadata, and published bilingual notes.

## Test plan

- [x] `pnpm install --frozen-lockfile` — lockfile install succeeded.
- [x] `pnpm run typecheck` — TypeScript checks passed.
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root package resolves as 1.31.1.
- [x] `node scripts/validate-release-version.mjs v1.31.1` — all four version sources match.
- [x] `pnpm exec vitest run scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs scripts/release-artifacts.test.mjs` — 3 files and 15 tests passed.
- [x] Generated release notes contain Korean and English summaries and include #773 in the v1.31.1 fixes.
- [x] Main CI for #773 passed: https://github.com/im-ian/acorn/actions/runs/31474961958
- [x] `git diff --check` — no whitespace errors.

## Notes

- The `v1.31.1` tag and GitHub Release do not exist yet; they are intentionally created after this PR merges.
- This version-only PR uses `skip-changelog`; its product changes retain their original changelog labels.
