### PR TITLE
chore(release): v1.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.31.1",
+  "version": "1.32.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.31.1"
+version = "1.32.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.31.1"
+version = "1.32.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.32.0 from green `main` at `5fdc2bb`, adding first-class Windows x64 support while preserving the existing macOS release path.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.31.1 to 1.32.0.
2. **Release scope** — ships the native Windows daemon/IPC, ConPTY and process-tree lifecycle, Windows path/shell/shortcut handling, and x64 NSIS installer/updater support from #772.
3. **Publication path** — prepares signed macOS updater bundles plus the updater-signed Windows x64 NSIS pair and three-platform `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Windows | Adds the first supported Acorn x64 installer and native desktop/session behavior. |
| Daemon & IPC | Uses per-user Windows named pipes and process-tree ownership while retaining Unix sockets on macOS. |
| Updater | Adds `windows-x86_64` alongside both macOS architectures in `latest.json`. |
| macOS | Preserves the existing Apple Silicon and Intel build/sign/update path. |

## Design notes

- 1.32.0 is a minor release because #772 adds a new supported desktop platform without an intentional breaking change.
- This PR changes version metadata only; the implementation was independently reviewed, exercised on a clean Windows host, and merged in #772.
- Windows updater integrity uses the existing Tauri signing key. Authenticode is separate and not configured for this release.
- Release notes are generated bilingually from changelog-labelled merged PRs; this version PR is excluded.

## Follow-up (not in this PR)

- Push annotated tag `v1.32.0` after merge.
- Verify the macOS bundles, Windows NSIS pair, `latest.json`, Latest pointer, bilingual release notes, and installed Windows upgrade path.

## Test plan

- [x] `pnpm install --frozen-lockfile` — succeeded.
- [x] `pnpm run typecheck` — passed.
- [x] `cargo metadata --locked --manifest-path src-tauri/Cargo.toml --no-deps --format-version 1` — root Acorn package is 1.32.0.
- [x] `node scripts/validate-release-version.mjs v1.32.0` and `--assert-newer v1.32.0 v1.31.1` — passed.
- [x] `pnpm exec vitest run scripts/build-sidecar.test.mjs scripts/release-artifacts.test.mjs scripts/release-notes.test.mjs scripts/validate-release-version.test.mjs` — 4 files / 30 tests passed.
- [x] Generated notes contain #772 plus Korean and English summary blockquotes.
- [x] `git diff --check` — no whitespace errors.
- [x] GitHub CI and security checks pass on the release branch.

## Notes

- `v1.32.0` and its GitHub Release are intentionally created only after this PR merges.
- This release PR uses `skip-changelog`; #772 remains the user-visible Features entry.
- The Windows installer is updater-signed but not Authenticode-signed, so SmartScreen may warn on first download.