### PR TITLE
fix(macos): restore IPC path limits + POSIX filename semantics

### DIFF
--- a/src-tauri/crates/acorn-local-ipc/src/lib.rs
+++ b/src-tauri/crates/acorn-local-ipc/src/lib.rs
@@ -84,7 +84,7 @@ fn bind_platform(endpoint: &Path) -> io::Result<Listener> {
     // Keep the staging name deterministic and shorter than the canonical
     // socket. The listener's reclaim guard is disabled because the bound
     // pathname is renamed before the listener is dropped.
-    let staging = endpoint.with_extension("ipc-staging");
+    let staging = endpoint.with_extension("tmp");
     if staging.exists() {
         let _ = std::fs::remove_file(&staging);
     }
@@ -308,6 +308,51 @@ mod tests {
         client.join().unwrap();
 
         drop((server, listener));
+        cleanup(&endpoint);
+        assert!(!endpoint.exists());
+        let _ = std::fs::remove_dir_all(scratch);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn private_endpoint_binds_near_sun_path_limit() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        // Darwin's sun_path holds 104 bytes. Keep the canonical endpoint
+        // valid near that boundary so any staging name longer than the
+        // canonical socket breaks this test.
+        const DATA_DIR_BYTES: usize = 79;
+        let unique = format!(
+            "acorn-ipc-limit-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let padding = DATA_DIR_BYTES
+            .checked_sub("/tmp/".len() + unique.len())
+            .expect("unique test directory should fit below the target length");
+        let scratch =
+            std::path::PathBuf::from("/tmp").join(format!("{unique}{}", "x".repeat(padding)));
+        std::fs::create_dir_all(&scratch).unwrap();
+
+        let endpoint = scratch.join("daemon-stream.sock");
+        assert_eq!(endpoint.as_os_str().as_bytes().len(), 98);
+        assert_eq!(
+            endpoint.with_extension("tmp").as_os_str().as_bytes().len(),
+            97
+        );
+
+        let listener = bind(&endpoint).expect("bind near macOS sun_path limit");
+        assert_eq!(
+            std::fs::metadata(&endpoint).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(!endpoint.with_extension("tmp").exists());
+
+        drop(listener);
         cleanup(&endpoint);
         assert!(!endpoint.exists());
         let _ = std::fs::remove_dir_all(scratch);

--- a/src/components/FileExplorer.listener.test.tsx
+++ b/src/components/FileExplorer.listener.test.tsx
@@ -6,6 +6,7 @@ const apiMocks = vi.hoisted(() => ({
   fsGitStatus: vi.fn(),
   fsGitDiffStats: vi.fn(),
   fsListDir: vi.fn(),
+  fsRename: vi.fn(),
   fsShellEditor: vi.fn(),
   fsOpenDefault: vi.fn(),
   ptyWrite: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock("../lib/api", () => ({
     fsGitStatus: apiMocks.fsGitStatus,
     fsGitDiffStats: apiMocks.fsGitDiffStats,
     fsListDir: apiMocks.fsListDir,
+    fsRename: apiMocks.fsRename,
     fsShellEditor: apiMocks.fsShellEditor,
     fsOpenDefault: apiMocks.fsOpenDefault,
     ptyWrite: apiMocks.ptyWrite,
@@ -90,6 +92,7 @@ describe("FileExplorer filesystem listener", () => {
     storeMocks.activeSessionId = null;
 
     apiMocks.fsShellEditor.mockResolvedValue("");
+    apiMocks.fsRename.mockResolvedValue(undefined);
     apiMocks.fsOpenDefault.mockResolvedValue(undefined);
     apiMocks.ptyWrite.mockResolvedValue(undefined);
     apiMocks.detectSessionAgent.mockResolvedValue({
@@ -256,6 +259,76 @@ describe("FileExplorer filesystem listener", () => {
     expect(editorMocks.openFileInEditor).toHaveBeenCalledWith(filePath);
     expect(apiMocks.fsShellEditor).not.toHaveBeenCalled();
     expect(apiMocks.ptyWrite).not.toHaveBeenCalled();
+  });
+
+  it("preserves literal backslashes when renaming a POSIX file", async () => {
+    const filePath = "/tmp/acorn/old\\name.md";
+    apiMocks.fsListDir.mockResolvedValue({
+      entries: [
+        {
+          name: "old\\name.md",
+          path: filePath,
+          is_dir: false,
+          is_symlink: false,
+          size: 1,
+          modified_ms: 1,
+          gitignored: false,
+        },
+      ],
+      repo_root: "/tmp/acorn",
+    });
+
+    await act(async () => {
+      root?.render(<FileExplorer rootPath="/tmp/acorn" />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const fileButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("old\\name.md"),
+    );
+    expect(fileButton).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => {
+      fileButton?.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 20,
+          clientY: 20,
+        }),
+      );
+    });
+    const renameButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find((button) => button.textContent?.includes("fileExplorer.menu.rename"));
+    expect(renameButton).toBeInstanceOf(HTMLButtonElement);
+
+    act(() => renameButton?.click());
+    const input = document.querySelector<HTMLInputElement>(
+      'input[aria-label="fileExplorer.tree.renameInput"]',
+    );
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    expect(valueSetter).toBeTypeOf("function");
+    act(() => {
+      valueSetter?.call(input, "new\\name.md");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.fsRename).toHaveBeenCalledWith(
+      filePath,
+      "/tmp/acorn/new\\name.md",
+    );
   });
 
   it("queues one follow-up diff-stat refresh instead of overlapping a slow request", async () => {

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -38,6 +38,7 @@ import {
 import { cn } from "../lib/cn";
 import { writeClipboardText } from "../lib/clipboardText";
 import { openFileInEditor } from "../lib/editor";
+import { revealInFileManagerText } from "../lib/fileManager";
 import { retainRecentGitStatPaths } from "../lib/fileExplorerGitStats";
 import { matchesHotkeyEvent } from "../lib/hotkeys";
 import {
@@ -1281,7 +1282,7 @@ export function FileExplorer({
     }
     if (entry) {
       items.push({
-        label: fileExplorerText(t, "fileExplorer.menu.revealInFileManager"),
+        label: revealInFileManagerText(t),
         icon: <ExternalLink size={13} />,
         onClick: () => {
           void api.fsReveal(entry.path).catch((e) => {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -56,6 +56,7 @@ import {
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { requestNewGraphSession } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
+import { revealInFileManagerText } from "../lib/fileManager";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   hasConfiguredEditor,
@@ -1357,7 +1358,7 @@ function TabItem({
       },
     },
     {
-      label: paneT(t, "pane.menu.revealInFinder"),
+      label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void api.fsReveal(tabPath).catch((err: unknown) => {
@@ -1884,7 +1885,7 @@ function buildPaneMenuItems({
           },
         },
         {
-          label: paneT(t, "pane.menu.revealInFinder"),
+          label: revealInFileManagerText(t),
           icon: <FolderOpen size={12} />,
           onClick: () => {
             void api.fsReveal(activeSession.worktree_path).catch(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -88,6 +88,7 @@ import {
   type NewGraphSessionEventDetail,
 } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
+import { revealInFileManagerText } from "../lib/fileManager";
 import { openInConfiguredEditor } from "../lib/editor";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -2368,7 +2369,7 @@ function ProjectGroupView({
       onClick: onOpenSettings,
     },
     {
-      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void openInFinder(project.repoPath);
@@ -3176,7 +3177,7 @@ function ProjectFolderView({
             onClick: () => setEditing(true),
           },
           {
-            label: sidebarText(t, "sidebar.actions.revealInFinder"),
+            label: revealInFileManagerText(t),
             icon: <FolderOpen size={12} />,
             onClick: () => {
               void api.fsReveal(folder.cwdPath);
@@ -3567,7 +3568,7 @@ function SessionRow({
       },
     },
     {
-      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void api.fsReveal(session.worktree_path).catch((err: unknown) => {
@@ -4611,7 +4612,7 @@ function LocalWorkspaceView({
       onClick: () => setEditing(true),
     },
     {
-      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void api.fsReveal(folder.cwdPath);
@@ -4946,7 +4947,7 @@ function LocalSessionRow({
       : []),
     { type: "separator" },
     {
-      label: sidebarText(t, "sidebar.actions.revealInFinder"),
+      label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
         void api.fsReveal(session.worktree_path).catch((err: unknown) => {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -53,6 +53,7 @@ import { writeClipboardText } from "../lib/clipboardText";
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { requestNewGraphSession } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
+import { revealInFileManagerText } from "../lib/fileManager";
 import { openInConfiguredEditor } from "../lib/editor";
 import { isInAcornFloatingLayer } from "../lib/floatingLayer";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
@@ -1449,7 +1450,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         },
       },
       {
-        label: sidebarText(t, "sidebar.actions.revealInFinder"),
+        label: revealInFileManagerText(t),
         icon: <FolderOpen size={12} />,
         onClick: () => {
           void api.fsReveal(session.worktree_path).catch((err: unknown) => {
@@ -2084,7 +2085,7 @@ function KanbanTerminalPopover({
         },
       },
       {
-        label: sidebarText(t, "sidebar.actions.revealInFinder"),
+        label: revealInFileManagerText(t),
         icon: <FolderOpen size={12} />,
         onClick: () => {
           void api.fsReveal(session.worktree_path).catch((err: unknown) => {

--- a/src/lib/fileManager.test.ts
+++ b/src/lib/fileManager.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { revealInFileManagerText } from "./fileManager";
+import { createTranslator } from "./i18n";
+
+describe("revealInFileManagerText", () => {
+  const t = createTranslator("en");
+
+  it("uses Finder terminology on macOS", () => {
+    expect(revealInFileManagerText(t, "MacIntel")).toBe("Reveal in Finder");
+  });
+
+  it("uses platform-neutral terminology outside macOS", () => {
+    expect(revealInFileManagerText(t, "Win32")).toBe(
+      "Reveal in File Manager",
+    );
+    expect(revealInFileManagerText(t, "Linux x86_64")).toBe(
+      "Reveal in File Manager",
+    );
+  });
+});

--- a/src/lib/fileManager.ts
+++ b/src/lib/fileManager.ts
@@ -1,0 +1,10 @@
+import type { Translator } from "./i18n";
+
+export function revealInFileManagerText(
+  t: Translator,
+  platform = typeof navigator === "undefined" ? "" : navigator.platform,
+): string {
+  return platform.startsWith("Mac")
+    ? t("ui.revealInFinder")
+    : t("ui.revealInFileManager");
+}

--- a/src/lib/fileMention.test.ts
+++ b/src/lib/fileMention.test.ts
@@ -79,4 +79,13 @@ describe("formatTerminalFileMention", () => {
       ),
     ).toBe("docs/guide.md ");
   });
+
+  it("escapes rather than rewrites literal backslashes in POSIX filenames", () => {
+    expect(
+      formatTerminalFileMention(
+        "/Users/me/repo/docs/back\\slash.md",
+        "/Users/me/repo",
+      ),
+    ).toBe("docs/back\\\\slash.md ");
+  });
 });

--- a/src/lib/fileMention.ts
+++ b/src/lib/fileMention.ts
@@ -1,10 +1,15 @@
 import { getAgentMentionPrefix } from "./agentProviderRegistry";
-import { normalizePath, pathsEqual, relativePath } from "./pathUtils";
+import {
+  inferPathFlavor,
+  normalizePath,
+  pathsEqual,
+  relativePath,
+} from "./pathUtils";
 import type { SessionAgentProvider } from "./types";
 
 export function pathRelativeToCwd(filePath: string, cwd: string): string {
   if (pathsEqual(filePath, cwd)) return ".";
-  return normalizePath(relativePath(cwd, filePath));
+  return normalizePath(relativePath(cwd, filePath), inferPathFlavor(cwd));
 }
 
 function escapeMentionPath(path: string): string {

--- a/src/lib/pathUtils.test.ts
+++ b/src/lib/pathUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   basename,
+  inferPathFlavor,
   isAbsolutePath,
   isPathInsideOrEqual,
   joinPath,
@@ -21,6 +22,21 @@ describe("path utils", () => {
     expect(normalizePath("\\\\server\\share\\repo\\")).toBe(
       "//server/share/repo",
     );
+    expect(normalizePath("src\\components\\App.tsx")).toBe(
+      "src/components/App.tsx",
+    );
+  });
+
+  it("uses an absolute POSIX root to preserve literal backslashes", () => {
+    expect(inferPathFlavor("/repo/docs/back\\slash.md")).toBe("posix");
+    expect(normalizePath("/repo/docs/back\\slash.md/")).toBe(
+      "/repo/docs/back\\slash.md",
+    );
+    expect(basename("/repo/docs/back\\slash.md")).toBe("back\\slash.md");
+    expect(parentPath("/repo/docs/back\\slash.md")).toBe("/repo/docs");
+    expect(pathsEqual("/repo/docs/back\\slash.md", "/repo/docs/back/slash.md")).toBe(
+      false,
+    );
   });
 
   it("extracts a basename from POSIX and Windows paths", () => {
@@ -36,6 +52,9 @@ describe("path utils", () => {
     );
     expect(relativePath("C:\\Repo", "C:\\Repo-other\\App.tsx")).toBe(
       "C:\\Repo-other\\App.tsx",
+    );
+    expect(relativePath("/repo", "/repo/docs/back\\slash.md")).toBe(
+      "docs/back\\slash.md",
     );
   });
 
@@ -72,11 +91,20 @@ describe("path utils", () => {
     expect(parentPath("C:\\repo\\src")).toBe("C:\\repo");
     expect(parentPath("C:\\repo")).toBe("C:\\");
     expect(parentPath("\\\\server\\share")).toBe("\\\\server\\share");
-    expect(joinPath("/repo", "src\\App.tsx")).toBe("/repo/src/App.tsx");
+    expect(joinPath("/repo", "src\\App.tsx")).toBe(
+      "/repo/src\\App.tsx",
+    );
     expect(joinPath("C:\\repo", "src/App.tsx")).toBe(
       "C:\\repo\\src\\App.tsx",
     );
     expect(joinPath("C:\\", "src")).toBe("C:\\src");
+  });
+
+  it("keeps a POSIX backslash filename intact through the rename path flow", () => {
+    const path = "/repo/docs/old\\name.md";
+    expect(joinPath(parentPath(path), "new\\name.md")).toBe(
+      "/repo/docs/new\\name.md",
+    );
   });
 
   it("recognizes POSIX, drive, and UNC absolute paths", () => {

--- a/src/lib/pathUtils.ts
+++ b/src/lib/pathUtils.ts
@@ -1,10 +1,37 @@
-function usesWindowsCaseSemantics(path: string): boolean {
-  return /^[a-zA-Z]:/u.test(path) || path.startsWith("//");
+export type PathFlavor = "posix" | "windows";
+
+function explicitPathFlavor(path: string): PathFlavor | null {
+  if (
+    /^[a-zA-Z]:/u.test(path) ||
+    path.startsWith("\\\\") ||
+    path.startsWith("//")
+  ) {
+    return "windows";
+  }
+  if (path.startsWith("/")) return "posix";
+  return null;
 }
 
-function comparisonPath(path: string): string {
-  const normalized = normalizePath(path);
-  return usesWindowsCaseSemantics(normalized)
+/**
+ * Infer how separators in a path should be interpreted. Absolute roots are
+ * authoritative; an unanchored relative path containing a backslash keeps the
+ * Windows-compatible behavior used by terminal output and Git paths.
+ */
+export function inferPathFlavor(path: string): PathFlavor {
+  return explicitPathFlavor(path) ?? (path.includes("\\") ? "windows" : "posix");
+}
+
+function anchoredPathFlavor(anchor: string, other?: string): PathFlavor {
+  return (
+    explicitPathFlavor(anchor) ??
+    (other === undefined ? null : explicitPathFlavor(other)) ??
+    (anchor.includes("\\") || other?.includes("\\") ? "windows" : "posix")
+  );
+}
+
+function comparisonPath(path: string, flavor: PathFlavor): string {
+  const normalized = normalizePath(path, flavor);
+  return flavor === "windows"
     ? normalized.toLocaleLowerCase("en-US")
     : normalized;
 }
@@ -13,13 +40,15 @@ function isDriveRoot(path: string): boolean {
   return /^[a-zA-Z]:[\\/]+$/u.test(path);
 }
 
-function isUncShareRoot(path: string): boolean {
-  const normalized = normalizePath(path);
+function isUncShareRoot(path: string, flavor: PathFlavor): boolean {
+  if (flavor !== "windows") return false;
+  const normalized = normalizePath(path, flavor);
   if (!normalized.startsWith("//")) return false;
   return normalized.slice(2).split("/").filter(Boolean).length <= 2;
 }
 
-function preferredSeparator(path: string): "/" | "\\" {
+function preferredSeparator(path: string, flavor: PathFlavor): "/" | "\\" {
+  if (flavor === "posix") return "/";
   if (/^[a-zA-Z]:\\/u.test(path) || path.startsWith("\\\\")) {
     return "\\";
   }
@@ -27,8 +56,17 @@ function preferredSeparator(path: string): "/" | "\\" {
   return "/";
 }
 
-export function normalizePath(path: string): string {
+export function normalizePath(
+  path: string,
+  flavor: PathFlavor = inferPathFlavor(path),
+): string {
   if (path.length === 0) return path;
+
+  if (flavor === "posix") {
+    const normalized = path.replace(/\/+/gu, "/");
+    if (/^\/+$/u.test(normalized)) return "/";
+    return normalized.replace(/\/+$/u, "");
+  }
 
   const unc = /^[\\/]{2}[^\\/]/u.test(path);
   let normalized = path.replace(/[\\/]+/gu, "/");
@@ -46,74 +84,100 @@ export function normalizePath(path: string): string {
  * style. Filesystem roots remain usable rather than collapsing to an empty
  * string or a drive-relative path.
  */
-export function trimTrailingPathSeparators(path: string): string {
-  if (path.length === 0 || /^[\\/]+$/u.test(path) || isDriveRoot(path)) {
-    return path;
+export function trimTrailingPathSeparators(
+  path: string,
+  flavor: PathFlavor = inferPathFlavor(path),
+): string {
+  if (path.length === 0) return path;
+  if (flavor === "posix") {
+    return /^\/+$/u.test(path) ? path : path.replace(/\/+$/u, "");
   }
+  if (/^[\\/]+$/u.test(path) || isDriveRoot(path)) return path;
   return path.replace(/[\\/]+$/u, "");
 }
 
-export function basename(path: string): string {
-  const trimmed = trimTrailingPathSeparators(path);
-  const parts = trimmed.split(/[\\/]/u).filter(Boolean);
+export function basename(
+  path: string,
+  flavor: PathFlavor = inferPathFlavor(path),
+): string {
+  const trimmed = trimTrailingPathSeparators(path, flavor);
+  const parts = trimmed
+    .split(flavor === "windows" ? /[\\/]/u : /\//u)
+    .filter(Boolean);
   return parts[parts.length - 1] ?? trimmed;
 }
 
-export function parentPath(path: string): string {
-  const trimmed = trimTrailingPathSeparators(path);
+export function parentPath(
+  path: string,
+  flavor: PathFlavor = inferPathFlavor(path),
+): string {
+  const trimmed = trimTrailingPathSeparators(path, flavor);
+  const isRoot =
+    flavor === "windows" ? /^[\\/]+$/u.test(trimmed) : /^\/+$/u.test(trimmed);
   if (
     trimmed.length === 0 ||
-    /^[\\/]+$/u.test(trimmed) ||
-    isDriveRoot(trimmed) ||
-    isUncShareRoot(trimmed)
+    isRoot ||
+    (flavor === "windows" && isDriveRoot(trimmed)) ||
+    isUncShareRoot(trimmed, flavor)
   ) {
     return trimmed;
   }
 
   const slash = trimmed.lastIndexOf("/");
-  const backslash = trimmed.lastIndexOf("\\");
+  const backslash = flavor === "windows" ? trimmed.lastIndexOf("\\") : -1;
   const index = Math.max(slash, backslash);
   if (index < 0) return ".";
 
   const separator = trimmed[index];
   const parent = trimmed.slice(0, index);
   if (parent.length === 0) return separator;
-  if (/^[a-zA-Z]:$/u.test(parent)) return `${parent}${separator}`;
+  if (flavor === "windows" && /^[a-zA-Z]:$/u.test(parent)) {
+    return `${parent}${separator}`;
+  }
   return parent;
 }
 
 export function joinPath(base: string, child: string): string {
-  const separator = preferredSeparator(base);
-  const relative = child
-    .replace(/^[\\/]+/u, "")
-    .replace(/[\\/]+/gu, separator);
-  const trimmedBase = trimTrailingPathSeparators(base);
-  if (trimmedBase.endsWith("/") || trimmedBase.endsWith("\\")) {
-    return `${trimmedBase}${relative}`;
-  }
+  const flavor = inferPathFlavor(base);
+  const separator = preferredSeparator(base, flavor);
+  const relative =
+    flavor === "windows"
+      ? child.replace(/^[\\/]+/u, "").replace(/[\\/]+/gu, separator)
+      : child.replace(/^\/+/u, "").replace(/\/+/gu, separator);
+  const trimmedBase = trimTrailingPathSeparators(base, flavor);
+  const endsWithSeparator =
+    flavor === "windows"
+      ? trimmedBase.endsWith("/") || trimmedBase.endsWith("\\")
+      : trimmedBase.endsWith("/");
+  if (endsWithSeparator) return `${trimmedBase}${relative}`;
   return `${trimmedBase}${separator}${relative}`;
 }
 
 export function pathsEqual(a: string, b: string): boolean {
-  return comparisonPath(a) === comparisonPath(b);
+  const flavor = anchoredPathFlavor(a, b);
+  return comparisonPath(a, flavor) === comparisonPath(b, flavor);
 }
 
 export function isPathInsideOrEqual(path: string, rootPath: string): boolean {
-  const pathKey = comparisonPath(path);
-  const rootKey = comparisonPath(rootPath);
+  const flavor = anchoredPathFlavor(rootPath, path);
+  const pathKey = comparisonPath(path, flavor);
+  const rootKey = comparisonPath(rootPath, flavor);
   if (pathKey === rootKey) return true;
   const prefix = rootKey.endsWith("/") ? rootKey : `${rootKey}/`;
   return pathKey.startsWith(prefix);
 }
 
 export function relativePath(rootPath: string, path: string): string {
-  const root = normalizePath(rootPath);
-  const normalized = normalizePath(path);
-  if (pathsEqual(normalized, root)) return basename(path);
+  const flavor = anchoredPathFlavor(rootPath, path);
+  const root = normalizePath(rootPath, flavor);
+  const normalized = normalizePath(path, flavor);
+  if (comparisonPath(normalized, flavor) === comparisonPath(root, flavor)) {
+    return basename(path, flavor);
+  }
   const prefix = root.endsWith("/") ? root : `${root}/`;
-  const rootKey = comparisonPath(root);
+  const rootKey = comparisonPath(root, flavor);
   const prefixKey = rootKey.endsWith("/") ? rootKey : `${rootKey}/`;
-  return comparisonPath(normalized).startsWith(prefixKey)
+  return comparisonPath(normalized, flavor).startsWith(prefixKey)
     ? normalized.slice(prefix.length)
     : path;
 }

--- a/src/lib/terminalFileLinks.test.ts
+++ b/src/lib/terminalFileLinks.test.ts
@@ -306,6 +306,18 @@ describe("terminal file links", () => {
     );
   });
 
+  it("preserves literal backslashes while resolving POSIX file paths", () => {
+    expect(resolveTerminalFilePath("/repo/app", "src\\App.tsx")).toBe(
+      "/repo/app/src\\App.tsx",
+    );
+    expect(resolveTerminalFilePath("/repo/app/src", "../back\\slash.md")).toBe(
+      "/repo/app/back\\slash.md",
+    );
+    expect(resolveTerminalFilePath("/repo/app", "/tmp/back\\slash.ts")).toBe(
+      "/tmp/back\\slash.ts",
+    );
+  });
+
   it("resolves Windows drive paths without treating the drive colon as a line", () => {
     expect(resolveTerminalFilePath("C:\\repo\\app", "src\\App.tsx")).toBe(
       "C:/repo/app/src/App.tsx",

--- a/src/lib/terminalFileLinks.ts
+++ b/src/lib/terminalFileLinks.ts
@@ -4,7 +4,13 @@ import type {
   ILinkProvider,
   Terminal as XTerm,
 } from "@xterm/xterm";
-import { isAbsolutePath, normalizePath, pathsEqual } from "./pathUtils";
+import {
+  inferPathFlavor,
+  isAbsolutePath,
+  normalizePath,
+  pathsEqual,
+  type PathFlavor,
+} from "./pathUtils";
 
 export interface TerminalFileReference {
   path: string;
@@ -262,23 +268,32 @@ export function resolveTerminalFilePathCandidates(
   options: { home?: string | null; basePaths?: string[] } = {},
 ): string[] {
   if (isAbsolutePath(referencePath)) {
-    return [normalizeTerminalPath(referencePath)];
+    return [
+      normalizeTerminalPath(referencePath, inferPathFlavor(referencePath)),
+    ];
   }
   if (/^~[\\/]/u.test(referencePath)) {
     const { home } = options;
     if (!home) return [referencePath];
+    const flavor = inferPathFlavor(home);
     return [
       normalizeTerminalPath(
-        `${normalizePath(home)}/${normalizePath(referencePath.slice(2))}`,
+        `${normalizePath(home, flavor)}/${normalizePath(referencePath.slice(2), flavor)}`,
+        flavor,
       ),
     ];
   }
-  const normalizedReference = normalizePath(referencePath);
   const candidates = [cwd, ...(options.basePaths ?? [])].flatMap((base) => {
-    const basePath = normalizeTerminalPath(base);
+    const flavor = inferPathFlavor(base);
+    const normalizedReference = normalizePath(referencePath, flavor);
+    const basePath = normalizeTerminalPath(base, flavor);
     return [
-      normalizeTerminalPath(`${basePath}/${normalizedReference}`),
-      ...resolveAncestorPrefixedPathCandidates(basePath, normalizedReference),
+      normalizeTerminalPath(`${basePath}/${normalizedReference}`, flavor),
+      ...resolveAncestorPrefixedPathCandidates(
+        basePath,
+        normalizedReference,
+        flavor,
+      ),
     ];
   });
   return candidates.filter(
@@ -290,13 +305,19 @@ export function resolveTerminalFilePathCandidates(
 function resolveAncestorPrefixedPathCandidates(
   base: string,
   referencePath: string,
+  flavor: PathFlavor,
 ): string[] {
-  if (/^\.{1,2}[\\/]/u.test(referencePath)) {
+  const explicitRelativePrefix =
+    flavor === "windows" ? /^\.{1,2}[\\/]/u : /^\.{1,2}\//u;
+  if (explicitRelativePrefix.test(referencePath)) {
     return [];
   }
-  const parsedBase = parseTerminalPath(normalizeTerminalPath(base));
+  const parsedBase = parseTerminalPath(
+    normalizeTerminalPath(base, flavor),
+    flavor,
+  );
   const baseParts = parsedBase.parts;
-  const referenceParts = parseTerminalPath(referencePath).parts;
+  const referenceParts = parseTerminalPath(referencePath, flavor).parts;
   const maxMatchLength = Math.min(baseParts.length, referenceParts.length - 1);
   const candidates: string[] = [];
   for (let matchLength = maxMatchLength; matchLength >= 1; matchLength -= 1) {
@@ -344,9 +365,13 @@ interface ParsedTerminalPath {
   caseInsensitive: boolean;
 }
 
-function parseTerminalPath(path: string): ParsedTerminalPath {
-  const normalized = path.replace(/\\/gu, "/");
-  const drive = /^([a-zA-Z]:)\/(.*)$/u.exec(normalized);
+function parseTerminalPath(
+  path: string,
+  flavor: PathFlavor,
+): ParsedTerminalPath {
+  const normalized = flavor === "windows" ? path.replace(/\\/gu, "/") : path;
+  const drive =
+    flavor === "windows" ? /^([a-zA-Z]:)\/(.*)$/u.exec(normalized) : null;
   if (drive) {
     return {
       root: `${drive[1]}/`,
@@ -354,7 +379,7 @@ function parseTerminalPath(path: string): ParsedTerminalPath {
       caseInsensitive: true,
     };
   }
-  if (normalized.startsWith("//")) {
+  if (flavor === "windows" && normalized.startsWith("//")) {
     const parts = normalized.slice(2).split("/").filter(Boolean);
     const shareParts = parts.slice(0, 2);
     return {
@@ -373,7 +398,7 @@ function parseTerminalPath(path: string): ParsedTerminalPath {
   return {
     root: "",
     parts: normalized.split("/").filter(Boolean),
-    caseInsensitive: false,
+    caseInsensitive: flavor === "windows",
   };
 }
 
@@ -384,8 +409,11 @@ function formatTerminalPath(path: ParsedTerminalPath): string {
   return suffix ? `${path.root}/${suffix}` : path.root;
 }
 
-function normalizeTerminalPath(path: string): string {
-  const parsed = parseTerminalPath(path);
+function normalizeTerminalPath(
+  path: string,
+  flavor: PathFlavor = inferPathFlavor(path),
+): string {
+  const parsed = parseTerminalPath(path, flavor);
   const parts: string[] = [];
   for (const part of parsed.parts) {
     if (part === "" || part === ".") continue;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1193,6 +1193,8 @@
   },
   "ui": {
     "openGitHubProfile": "Open GitHub profile",
+    "revealInFinder": "Reveal in Finder",
+    "revealInFileManager": "Reveal in File Manager",
     "stepper": {
       "decrease": "Decrease",
       "increase": "Increase",
@@ -1251,7 +1253,6 @@
       "moveToProjectRoot": "Project root",
       "projectSettings": "Project Settings",
       "closeProject": "Close project",
-      "revealInFinder": "Reveal in File Manager",
       "copy": "Copy",
       "copyPath": "Copy path",
       "rename": "Rename",
@@ -1608,7 +1609,6 @@
       "equalizePaneSizes": "Equalize Pane Sizes",
       "openWorktreeInEditor": "Open Worktree in Editor",
       "openFileInEditor": "Open File in Editor",
-      "revealInFinder": "Reveal in File Manager",
       "copy": "Copy",
       "worktreePath": "Worktree Path",
       "filePath": "File Path",
@@ -1933,8 +1933,7 @@
       "openIn": "Open in",
       "openInNewTab": "Open in New Tab",
       "openWithDefaultProgram": "Open with Default Program",
-      "rename": "Rename",
-      "revealInFileManager": "Reveal in File Manager"
+      "rename": "Rename"
     },
     "search": {
       "close": "Close (Esc)",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1193,6 +1193,8 @@
   },
   "ui": {
     "openGitHubProfile": "GitHub プロファイルを開く",
+    "revealInFinder": "ファインダーで表示",
+    "revealInFileManager": "ファイルマネージャーで表示",
     "stepper": {
       "decrease": "減少",
       "increase": "増やす",
@@ -1251,7 +1253,6 @@
       "moveToProjectRoot": "プロジェクトルート",
       "projectSettings": "プロジェクト設定",
       "closeProject": "プロジェクトを閉じる",
-      "revealInFinder": "ファイルマネージャーで表示",
       "copy": "コピー",
       "copyPath": "パスをコピーする",
       "rename": "名前の変更",
@@ -1608,7 +1609,6 @@
       "equalizePaneSizes": "ペインのサイズを均等化する",
       "openWorktreeInEditor": "エディタでワークツリーを開く",
       "openFileInEditor": "エディタでファイルを開く",
-      "revealInFinder": "ファイルマネージャーで表示",
       "copy": "コピー",
       "worktreePath": "ワークツリーのパス",
       "filePath": "ファイルパス",
@@ -1933,8 +1933,7 @@
       "openIn": "で開く",
       "openInNewTab": "新しいタブで開く",
       "openWithDefaultProgram": "デフォルトのプログラムで開く",
-      "rename": "名前の変更",
-      "revealInFileManager": "ファイルマネージャーで表示"
+      "rename": "名前の変更"
     },
     "search": {
       "close": "閉じる (Esc)",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1193,6 +1193,8 @@
   },
   "ui": {
     "openGitHubProfile": "GitHub 프로필 열기",
+    "revealInFinder": "Finder에서 보기",
+    "revealInFileManager": "파일 관리자에서 보기",
     "stepper": {
       "decrease": "감소",
       "increase": "증가",
@@ -1251,7 +1253,6 @@
       "moveToProjectRoot": "프로젝트 루트",
       "projectSettings": "프로젝트 설정",
       "closeProject": "프로젝트 닫기",
-      "revealInFinder": "파일 관리자에서 보기",
       "copy": "복사",
       "copyPath": "경로 복사",
       "rename": "이름 변경",
@@ -1608,7 +1609,6 @@
       "equalizePaneSizes": "패널 크기 균등화",
       "openWorktreeInEditor": "편집기에서 워크트리 열기",
       "openFileInEditor": "편집기에서 파일 열기",
-      "revealInFinder": "파일 관리자에서 보기",
       "copy": "복사",
       "worktreePath": "워크트리 경로",
       "filePath": "파일 경로",
@@ -1933,8 +1933,7 @@
       "openIn": "다음으로 열기:",
       "openInNewTab": "새 탭에서 열기",
       "openWithDefaultProgram": "기본 프로그램으로 열기",
-      "rename": "이름 변경",
-      "revealInFileManager": "파일 관리자에서 보기"
+      "rename": "이름 변경"
     },
     "search": {
       "close": "닫기 (Esc)",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1193,6 +1193,8 @@
   },
   "ui": {
     "openGitHubProfile": "打开 GitHub 配置文件",
+    "revealInFinder": "在 Finder 中显示",
+    "revealInFileManager": "在文件管理器中显示",
     "stepper": {
       "decrease": "减少",
       "increase": "增加",
@@ -1251,7 +1253,6 @@
       "moveToProjectRoot": "项目根目录",
       "projectSettings": "项目设置",
       "closeProject": "关闭项目",
-      "revealInFinder": "在文件管理器中显示",
       "copy": "复制",
       "copyPath": "复制路径",
       "rename": "重命名",
@@ -1608,7 +1609,6 @@
       "equalizePaneSizes": "均衡窗格大小",
       "openWorktreeInEditor": "在编辑器中打开工作树",
       "openFileInEditor": "在编辑器中打开文件",
-      "revealInFinder": "在文件管理器中显示",
       "copy": "复制",
       "worktreePath": "工作树路径",
       "filePath": "文件路径",
@@ -1933,8 +1933,7 @@
       "openIn": "打开方式",
       "openInNewTab": "在新标签页中打开",
       "openWithDefaultProgram": "使用默认程序打开",
-      "rename": "重命名",
-      "revealInFileManager": "在文件管理器中显示"
+      "rename": "重命名"
     },
     "search": {
       "close": "关闭 (Esc)",

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -1043,6 +1043,11 @@ test.describe("workspace kanban mode", () => {
       clientY: shellMenuTargetBox.y + shellMenuTargetBox.height / 2,
     });
     const cardMenu = page.getByRole("menu");
+    const revealLabel = await page.evaluate(() =>
+      navigator.platform.startsWith("Mac")
+        ? "Reveal in Finder"
+        : "Reveal in File Manager",
+    );
     await expect(cardMenu.getByRole("menuitem")).toHaveText([
       "Rename",
       "Regenerate Name",
@@ -1050,7 +1055,7 @@ test.describe("workspace kanban mode", () => {
       "Silence Notifications",
       "Open Work Summary",
       "Open Worktree in Editor",
-      "Reveal in File Manager",
+      revealLabel,
       "Copy",
       "Remove Session",
     ]);
@@ -1118,7 +1123,7 @@ test.describe("workspace kanban mode", () => {
       page.getByRole("menuitem", { name: "Silence Notifications" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("menuitem", { name: "Reveal in File Manager" }),
+      page.getByRole("menuitem", { name: revealLabel }),
     ).toBeVisible();
     await page.getByRole("menuitem", { name: "Rename" }).click();
     const titleInput = page.getByTestId(

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4644,10 +4644,15 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(projectMenuButton).toBeVisible();
     await projectMenuButton.click();
 
+    const revealLabel = await page.evaluate(() =>
+      navigator.platform.startsWith("Mac")
+        ? "Reveal in Finder"
+        : "Reveal in File Manager",
+    );
     const expectedProjectActions = [
       "Add source folder",
       "Project Settings",
-      "Reveal in File Manager",
+      revealLabel,
       "Copy path",
       "Close project",
     ];


### PR DESCRIPTION
## Summary

Fixes the macOS regressions introduced with the Windows support release while preserving the Windows path, IPC, and file-manager behavior.

1. **Unix IPC path limits** — restores the shorter `.tmp` staging socket so valid macOS daemon endpoints do not exceed the Darwin `sun_path` limit during atomic publication.
2. **Native path semantics** — anchors separator and case rules to the absolute root or base, preserving literal backslashes in POSIX filenames while keeping Windows drive and UNC normalization.
3. **Platform-native labels** — restores Finder wording on macOS and keeps File Manager wording on Windows and Linux across file, pane, sidebar, and kanban menus.
4. **Regression coverage** — adds boundary, rename, terminal-link, mention, path-flavor, translation, and cross-platform menu tests.

## Expected impact

| Area | Expected impact |
| --- | --- |
| macOS daemon | Restores daemon startup for accounts whose otherwise-valid socket path was pushed over the staging-path limit. |
| macOS files | Prevents literal backslashes from being rewritten as directory separators during rename, attachment, and terminal-link flows. |
| Windows | Preserves drive, UNC, mixed-separator, case-insensitive path handling and generic File Manager wording. |
| UI copy | Uses Finder on macOS and File Manager elsewhere without changing the native reveal action. |

## Design notes

- Canonical IPC endpoint names and permissions remain unchanged; only the unpublished same-directory staging suffix becomes shorter.
- Path flavor is derived from the absolute root or base. Relative references inherit that flavor, which resolves the POSIX ambiguity without weakening Windows support.
- The file-manager label decision is centralized in a small pure helper and covered independently of the test runner platform.

## Follow-up (not in this PR)

- Consider a separate migration strategy if canonical Unix socket paths themselves ever exceed the platform limit.
- Audit older, unrelated component-local basename helpers for literal-backslash handling without broadening this hotfix.

## Test plan

- [x] `pnpm run typecheck` — passes.
- [x] `pnpm run test` — 112 files, 1,348 tests pass.
- [x] `pnpm run build:frontend` — passes.
- [x] `pnpm run test:e2e` — 323 tests pass.
- [x] `pnpm run build:sidecar` — passes.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --locked --workspace --all-targets` — passes on the final full rerun.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --locked -p acorn-local-ipc --target x86_64-pc-windows-msvc` — passes.
- [x] macOS near-`sun_path` red/green regression — fails with the v1.32.0 staging suffix and passes with the fix.
- [x] `git diff --check` — passes.
- [x] Independent adversarial review — no blocker found.

## Notes

- The first full Rust run saw one transient failure in an unchanged agent-wrapper test. Its isolated rerun and the complete workspace rerun both passed; this is not caused by the hotfix.
- Existing frontend chunk-size/import warnings and established E2E diagnostics remain non-failing and are not introduced here.