### PR TITLE
chore(release): v1.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.32.1",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.32.0"
+version = "1.32.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.32.0"
+version = "1.32.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.32.1 from green `main`, correcting the macOS regressions found after the first Windows-capable release while retaining the complete three-platform release path.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.32.0 to 1.32.1.
2. **Hotfix scope** — releases the shorter Unix IPC staging path, POSIX literal-backslash filename handling, and platform-native Finder/File Manager labels from #776.
3. **Publication path** — prepares both macOS architectures and the Windows x64 NSIS updater pair with a three-platform `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| macOS daemon | Restores startup when the canonical socket is valid but the v1.32.0 staging name exceeded Darwin's Unix-socket path limit. |
| macOS files | Preserves literal backslashes through rename, mention, and terminal-link flows. |
| Windows | Retains drive/UNC path behavior, NSIS packaging, updater signing, and daemon lifecycle support. |
| Updater | Publishes a patch update for both macOS architectures and Windows x64. |

## Design notes

- 1.32.1 is a patch release because it corrects regressions without adding a new public feature or changing compatibility contracts.
- This PR changes version metadata only; the implementation was independently reviewed, fully tested, and merged in #776.
- Release notes are generated bilingually from changelog-labelled merged PRs. This version PR is excluded with `skip-changelog`.

## Follow-up (not in this PR)

- Push annotated tag `v1.32.1` after merge.
- Verify all macOS and Windows artifacts, updater signatures, `latest.json`, Latest pointer, and release-note identity.

## Test plan

- [x] `pnpm install --frozen-lockfile` — succeeds.
- [x] `pnpm run typecheck` — passes.
- [x] `node scripts/validate-release-version.mjs v1.32.1` — all version sources match.
- [x] `node scripts/validate-release-version.mjs --assert-newer v1.32.1 v1.32.0` — patch ordering passes.
- [x] Locked Cargo metadata reports Acorn `1.32.1`.
- [x] Release-focused Vitest — 4 files, 30 tests pass.
- [x] Generated release notes include #776 plus Korean and English `Fixes` summaries.
- [x] `git diff --check` — passes.
- [x] Post-#776 `main` CI — frontend, both E2E shards, and Windows NSIS/daemon smoke pass.

## Notes

- The applicable dependency security audit remains green; #776 did not change Cargo manifests, the lockfile, or the security workflow, so its post-merge push did not trigger a redundant audit.
- Windows Authenticode is still separate from Tauri updater signing. SmartScreen may warn until Authenticode/reputation is configured.