### PR TITLE
fix(terminal): restore live output after undoing session removal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8463,7 +8463,7 @@ fn spawn_via_daemon<R: Runtime>(
             id,
             pid,
             output_token,
-            replay_scrollback,
+            daemon_attach_replay_scrollback(false, replay_scrollback),
         )
         .map_err(|e| {
             format!(
@@ -8525,13 +8525,25 @@ fn spawn_via_daemon<R: Runtime>(
         id,
         outcome.pid,
         output_token,
-        replay_scrollback,
+        daemon_attach_replay_scrollback(true, replay_scrollback),
     )
     .map_err(|e| {
         format!(
             "daemon stream attach failed: {e}; retry the attachment instead of starting a duplicate local PTY"
         )
     })
+}
+
+fn daemon_attach_replay_scrollback(freshly_spawned: bool, requested_replay: bool) -> bool {
+    if !freshly_spawned {
+        return requested_replay;
+    }
+
+    // A freshly spawned daemon PTY has a new ring, so replay cannot duplicate
+    // the frontend's restored disk snapshot. Replaying closes the spawn-to-
+    // attach gap where a shell or immediately resumed TUI can finish its
+    // initial draw before the daemon stream subscriber is registered.
+    true
 }
 
 fn daemon_spawn_name_for_session(session: Option<&Session>, id: Uuid) -> String {
@@ -11262,7 +11274,8 @@ mod tests {
     use super::{
         auto_title_enabled_for_new_session, can_store_generated_session_title,
         collect_memory_usage_from_roots, configured_git_identity, create_unique_worktree,
-        daemon_spawn_name_for_session, detach_requested_by_stale_renderer, font_name_from_path,
+        daemon_attach_replay_scrollback, daemon_spawn_name_for_session,
+        detach_requested_by_stale_renderer, font_name_from_path,
         infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
         normalize_session_goal, normalize_session_graph, poll_defers_to_hook,
         remove_linked_worktree_at_path, restore_pending_session_removal, seed_initial_commit,
@@ -15264,6 +15277,18 @@ mod tests {
         assert!(should_route_session_to_daemon(true, None));
         assert!(should_route_session_to_daemon(false, Some(daemon_id)));
         assert!(!should_route_session_to_daemon(false, None));
+    }
+
+    #[test]
+    fn existing_daemon_attach_honors_frontend_replay_plan() {
+        assert!(daemon_attach_replay_scrollback(false, true));
+        assert!(!daemon_attach_replay_scrollback(false, false));
+    }
+
+    #[test]
+    fn fresh_daemon_attach_replays_output_emitted_during_spawn() {
+        assert!(daemon_attach_replay_scrollback(true, false));
+        assert!(daemon_attach_replay_scrollback(true, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Restored sessions now reconnect to all output from their newly created terminal, so resuming an agent after undoing session and worktree removal no longer leaves a stale, apparently frozen screen.

1. **Fresh PTY replay** — always replay the new daemon PTY ring during its first stream attachment, closing the gap between spawning the shell and registering the output stream.
2. **Existing-session preservation** — keep honoring the frontend replay plan when attaching to an already-live daemon session, avoiding duplicate restored scrollback.
3. **Regression coverage** — cover both fresh and existing daemon attachment policies.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Undo session + worktree removal, then resume agent | Initial shell/TUI output could be dropped, leaving history visible but the live screen apparently frozen | New PTY output emitted before stream attachment is replayed and the resumed TUI stays live |
| Reattach an already-live daemon PTY | Frontend-selected replay behavior | Unchanged |

## Design notes

- Disk scrollback belongs to the removed PTY generation, while a restored session receives a newly spawned daemon PTY with a fresh ring. Replaying that fresh ring cannot duplicate the old disk snapshot.
- The fix stays at the daemon spawn/attach boundary rather than delaying destructive session removal for the toast lifetime. Deferring removal would leave an agent running after the user closed it and would change existing close semantics.
- Existing daemon sessions still use the frontend's replay decision, preserving restart and resident-terminal behavior.

## Test plan

- [x] `pnpm run build:sidecar` — staged release sidecars on the latest `main` base
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `cargo test --quiet --manifest-path src-tauri/Cargo.toml -p acorn --lib -- --test-threads=1` — 747 passed, 1 ignored
- [x] `git diff --check`
