### PR TITLE
fix(statusbar): replace inline app errors with a copyable badge

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -12,9 +12,11 @@ import {
   Activity,
   AlertCircle,
   Bell,
+  Check,
   CheckCheck,
   Clock,
   Columns3,
+  Copy,
   Gauge,
   Kanban,
   Loader2,
@@ -29,6 +31,7 @@ import {
   providerSupportsTokenUsage,
   resolveSessionAgentProvider,
 } from "../lib/agentProvider";
+import { writeClipboardText } from "../lib/clipboardText";
 import { cn } from "../lib/cn";
 import { createInFlightCoalescer } from "../lib/inFlightCoalescer";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -50,7 +53,13 @@ import { useTranslation } from "../lib/useTranslation";
 import { useAppStore, type WorkspaceViewMode } from "../store";
 import { MemoryBreakdownModal } from "./MemoryBreakdownModal";
 import { Tooltip } from "./Tooltip";
-import { Select, StatusDot, type SelectOption, type StatusTone } from "./ui";
+import {
+  Button,
+  Select,
+  StatusDot,
+  type SelectOption,
+  type StatusTone,
+} from "./ui";
 
 const MEMORY_POLL_MS = 2000;
 const TOKEN_USAGE_POLL_MS = 60_000;
@@ -359,6 +368,7 @@ export function StatusBar() {
             the main view. */}
         <ServicesStatusButton />
         {showSessionActivity ? <SessionNotificationsButton /> : null}
+        {error ? <ErrorStatusButton error={error} /> : null}
         {showSessionCount ? (
           <span className="whitespace-nowrap">
             {statusBarFormat(t, "statusBar.sessionCount", {
@@ -427,13 +437,6 @@ export function StatusBar() {
             <span className="whitespace-nowrap">
               {statusBarText(t, "statusBar.working")}
             </span>
-          ) : null}
-          {error ? (
-            <Tooltip label={error} side="top" multiline>
-              <span className="truncate whitespace-nowrap text-danger">
-                {statusBarFormat(t, "statusBar.error", { error })}
-              </span>
-            </Tooltip>
           ) : null}
           {showGithubAccount && prAccount ? (
             <Tooltip
@@ -812,6 +815,177 @@ const NOTIFICATION_KIND_KEYS: Record<
   waiting_for_input: "statusBar.notifications.kind.waitingForInput",
   errored: "statusBar.notifications.kind.errored",
 };
+
+function ErrorStatusButton({ error }: { error: string }) {
+  const t = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Tooltip
+        label={statusBarText(t, "statusBar.errors.tooltip")}
+        side="top"
+      >
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          aria-label={statusBarText(t, "statusBar.errors.ariaLabel")}
+          className="relative flex h-5 items-center gap-1.5 rounded px-1.5 text-danger transition hover:bg-danger/10"
+        >
+          <AlertCircle size={12} />
+          <span className="min-w-3 rounded-full bg-danger px-1 text-center text-[9px] leading-3 text-white">
+            1
+          </span>
+        </button>
+      </Tooltip>
+      {open ? (
+        <ErrorStatusDropdown
+          anchor={triggerRef.current}
+          error={error}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function ErrorStatusDropdown({
+  anchor,
+  error,
+  onClose,
+}: {
+  anchor: HTMLElement | null;
+  error: string;
+  onClose: () => void;
+}) {
+  const t = useTranslation();
+  const showToast = useToasts((state) => state.show);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [position, setPosition] = useState<{
+    left: number;
+    bottom: number;
+  } | null>(null);
+
+  useEffect(() => {
+    setCopied(false);
+  }, [error]);
+
+  useLayoutEffect(() => {
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    setPosition({
+      left: rect.left,
+      bottom: Math.max(8, window.innerHeight - rect.top + 6),
+    });
+  }, [anchor]);
+
+  useLayoutEffect(() => {
+    if (!ref.current || !position) return;
+    const rect = ref.current.getBoundingClientRect();
+    const overflowRight = position.left + rect.width - (window.innerWidth - 8);
+    if (overflowRight > 0) {
+      setPosition((current) =>
+        current
+          ? { ...current, left: Math.max(8, current.left - overflowRight) }
+          : current,
+      );
+    }
+  }, [position]);
+
+  useEffect(() => {
+    function onDown(event: MouseEvent) {
+      if (ref.current?.contains(event.target as Node)) return;
+      if (anchor?.contains(event.target as Node)) return;
+      onClose();
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("resize", onClose);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("resize", onClose);
+    };
+  }, [anchor, onClose]);
+
+  if (!position) return null;
+
+  const copyError = async () => {
+    try {
+      await writeClipboardText(error);
+      setCopied(true);
+      showToast(statusBarText(t, "statusBar.errors.actions.copied"));
+    } catch (copyFailure) {
+      setCopied(false);
+      console.warn("[StatusBar] error log clipboard write failed", copyFailure);
+      showToast(statusBarText(t, "statusBar.errors.actions.copyFailed"));
+    }
+  };
+
+  const dismissError = () => {
+    useAppStore.getState().consumeError();
+    onClose();
+  };
+
+  return createPortal(
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label={statusBarText(t, "statusBar.errors.title")}
+      style={{
+        position: "fixed",
+        left: position.left,
+        bottom: position.bottom,
+        zIndex: 60,
+      }}
+      className="flex max-h-[420px] w-[28rem] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-md border border-danger/35 bg-bg-elevated shadow-2xl"
+    >
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <AlertCircle size={14} className="shrink-0 text-danger" />
+        <div className="min-w-0">
+          <div className="font-mono text-xs text-fg">
+            {statusBarText(t, "statusBar.errors.title")}
+          </div>
+          <div className="font-mono text-[10px] text-danger">
+            {statusBarText(t, "statusBar.errors.activeCount")}
+          </div>
+        </div>
+      </div>
+      <div className="min-h-0 overflow-auto p-3">
+        <div className="mb-1.5 font-mono text-[10px] uppercase tracking-wide text-fg-muted">
+          {statusBarText(t, "statusBar.errors.messageLabel")}
+        </div>
+        <pre className="whitespace-pre-wrap break-all rounded border border-border bg-bg-sidebar p-2.5 font-mono text-[11px] leading-relaxed text-danger select-text">
+          {error}
+        </pre>
+      </div>
+      <div className="flex items-center justify-end gap-2 border-t border-border px-3 py-2">
+        <Button variant="dangerGhost" size="xs" onClick={dismissError}>
+          <X size={12} />
+          {statusBarText(t, "statusBar.errors.actions.dismiss")}
+        </Button>
+        <Button variant="dangerSoft" size="xs" onClick={() => void copyError()}>
+          {copied ? <Check size={12} /> : <Copy size={12} />}
+          {statusBarText(
+            t,
+            copied
+              ? "statusBar.errors.actions.copied"
+              : "statusBar.errors.actions.copy",
+          )}
+        </Button>
+      </div>
+    </div>,
+    document.body,
+  );
+}
 
 function SessionNotificationsButton() {
   const t = useTranslation();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -948,6 +948,19 @@
       "turn_interrupted": "agent turn interrupted",
       "shell_prompt": "shell prompt detected"
     },
+    "errors": {
+      "ariaLabel": "Application errors",
+      "tooltip": "1 application error",
+      "title": "Application error",
+      "activeCount": "1 active error",
+      "messageLabel": "Error log",
+      "actions": {
+        "copy": "Copy error log",
+        "copied": "Error log copied",
+        "copyFailed": "Failed to copy error log.",
+        "dismiss": "Dismiss error"
+      }
+    },
     "notifications": {
       "ariaLabel": "Session notifications",
       "tooltipEmpty": "No unread session notifications",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -948,6 +948,19 @@
       "turn_interrupted": "エージェントのターンが中断されました",
       "shell_prompt": "シェルプロンプトが検出されました"
     },
+    "errors": {
+      "ariaLabel": "アプリケーションエラー",
+      "tooltip": "アプリケーションエラー1件",
+      "title": "アプリケーションエラー",
+      "activeCount": "有効なエラー1件",
+      "messageLabel": "エラーログ",
+      "actions": {
+        "copy": "エラーログをコピー",
+        "copied": "エラーログをコピーしました",
+        "copyFailed": "エラーログをコピーできませんでした。",
+        "dismiss": "エラーを閉じる"
+      }
+    },
     "notifications": {
       "ariaLabel": "セッション通知",
       "tooltipEmpty": "未読のセッション通知はありません",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -948,6 +948,19 @@
       "turn_interrupted": "에이전트 작업 중단",
       "shell_prompt": "셸 프롬프트 감지"
     },
+    "errors": {
+      "ariaLabel": "애플리케이션 오류",
+      "tooltip": "애플리케이션 오류 1개",
+      "title": "애플리케이션 오류",
+      "activeCount": "활성 오류 1개",
+      "messageLabel": "오류 로그",
+      "actions": {
+        "copy": "오류 로그 복사",
+        "copied": "오류 로그 복사됨",
+        "copyFailed": "오류 로그를 복사하지 못했습니다.",
+        "dismiss": "오류 닫기"
+      }
+    },
     "notifications": {
       "ariaLabel": "세션 알림",
       "tooltipEmpty": "읽지 않은 세션 알림 없음",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -948,6 +948,19 @@
       "turn_interrupted": "智能体轮次已中断",
       "shell_prompt": "检测到 shell 提示"
     },
+    "errors": {
+      "ariaLabel": "应用错误",
+      "tooltip": "1 个应用错误",
+      "title": "应用错误",
+      "activeCount": "1 个当前错误",
+      "messageLabel": "错误日志",
+      "actions": {
+        "copy": "复制错误日志",
+        "copied": "已复制错误日志",
+        "copyFailed": "无法复制错误日志。",
+        "dismiss": "关闭错误"
+      }
+    },
     "notifications": {
       "ariaLabel": "会话通知",
       "tooltipEmpty": "没有未读会话通知",

--- a/tests/e2e/statusbar.spec.ts
+++ b/tests/e2e/statusbar.spec.ts
@@ -76,6 +76,59 @@ async function enableAgentTokenUsage(
 }
 
 test.describe("status bar", () => {
+  test("shows application errors as a badge with copy and dismiss actions", async ({
+    page,
+    tauri,
+  }) => {
+    const errorLog =
+      "invalid path: not a linked git worktree: /private/tmp/acorn/scratchpad/dev-tree";
+    await tauri.handle("list_projects", () => {
+      throw new Error(
+        "invalid path: not a linked git worktree: /private/tmp/acorn/scratchpad/dev-tree",
+      );
+    });
+    await tauri.handle("plugin:clipboard-manager|write_text", (args) => {
+      const target = window as unknown as { __errorLogCopies?: string[] };
+      target.__errorLogCopies = target.__errorLogCopies ?? [];
+      target.__errorLogCopies.push((args as { text?: string })?.text ?? "");
+      return undefined;
+    });
+
+    await page.goto("/");
+
+    const footer = page.locator("footer");
+    const errorButton = footer.getByRole("button", {
+      name: "Application errors",
+    });
+    await expect(errorButton).toBeVisible();
+    await expect(errorButton).toContainText("1");
+    await expect(footer.getByText(errorLog, { exact: true })).toHaveCount(0);
+
+    await errorButton.click();
+
+    const dialog = page.getByRole("dialog", { name: "Application error" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText(errorLog);
+    await dialog.getByRole("button", { name: "Copy error log" }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __errorLogCopies?: string[] })
+              .__errorLogCopies?.at(-1) ?? null,
+        ),
+      )
+      .toBe(errorLog);
+    await expect(
+      dialog.getByRole("button", { name: "Error log copied" }),
+    ).toBeVisible();
+
+    await dialog.getByRole("button", { name: "Dismiss error" }).click();
+
+    await expect(errorButton).toHaveCount(0);
+    await expect(dialog).toHaveCount(0);
+  });
+
   test("service status tooltip renders service rows with icons", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Application errors now stay visible without crowding status-bar context, while the full diagnostic remains available on demand.

1. **Compact error indicator** — replace the raw inline error string with a red alert icon and count badge alongside session notifications.
2. **Actionable error details** — open a bounded popover with the complete, selectable error log plus native clipboard copy, copied-state feedback, dismissal, outside-click, and Escape handling.
3. **Localized and tested flow** — add English, Korean, Japanese, and Simplified Chinese copy and exercise the badge, raw-log display, native clipboard payload, and dismissal in Playwright.

## Expected impact
| Area | Before | After |
| --- | --- | --- |
| Status-bar layout | Long backend paths consume the status bar and displace session context | A fixed-size error badge preserves the status-bar layout |
| Error diagnostics | Full text is only exposed inline or through a tooltip | Click the badge to inspect, select, and copy the complete error log |
| Recovery | Error state has no direct status-bar dismissal action | Dismiss the active error from the details popover |

## Design notes
- The existing single global application error remains the source of truth, so the badge count is intentionally one and no persistence or backend contracts change.
- Clipboard writes use the shared native clipboard helper, retaining the browser fallback used by frontend development.
- Copied-state feedback resets when the active error changes, preventing feedback from a previous diagnostic from carrying over.

## Test plan
- [x] `pnpm run test` — 112 test files and 1,348 tests passed
- [x] `pnpm run build` — TypeScript and Vite production build passed
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts` — 10 status-bar tests passed
- [x] Playwright visual check with a long mocked worktree-path error — badge, popover wrapping, actions, and fixed status-bar height verified