### PR TITLE
fix(scrollback): preserve history on permission errors

### DIFF
--- a/src-tauri/crates/acorn-session/src/scrollback.rs
+++ b/src-tauri/crates/acorn-session/src/scrollback.rs
@@ -6,8 +6,9 @@
 //! mount it loads via `scrollback_load` and `term.write`s the bytes back into
 //! xterm before spawning the PTY.
 //!
-//! Atomic writes use same-directory replace semantics. Files are best-effort: read errors
-//! return `None` so the UI can proceed with an empty buffer.
+//! Atomic writes use same-directory replace semantics. A missing file is an
+//! empty buffer, but other read failures remain errors so callers cannot
+//! mistake an inaccessible snapshot for an empty one and overwrite it.
 //!
 //! Callers pass the application's data directory in explicitly so this crate
 //! does not depend on the main `acorn` crate's `persistence::data_dir()`
@@ -78,24 +79,23 @@ fn trailing_utf8_slice(value: &str, max_bytes: usize) -> &str {
 
 pub fn load(data_dir: &Path, session_id: &str) -> ScrollbackResult<Option<String>> {
     let path = session_file(data_dir, session_id)?;
-    if !path.exists() {
-        return Ok(None);
-    }
     match fs::read_to_string(&path) {
         Ok(s) => Ok(Some(s)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to read scrollback");
-            Ok(None)
+            Err(err.into())
         }
     }
 }
 
 pub fn delete(data_dir: &Path, session_id: &str) -> ScrollbackResult<()> {
     let path = session_file(data_dir, session_id)?;
-    if path.exists() {
-        fs::remove_file(&path)?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
     }
-    Ok(())
 }
 
 /// Remove scrollback files for any session id not present in `keep`.
@@ -220,6 +220,83 @@ mod tests {
         let id = "550e8400-e29b-41d4-a716-446655440001";
         let got = load(&tmp, id).expect("load");
         assert!(got.is_none());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn delete_is_idempotent_for_missing_scrollback() {
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440004";
+        delete(&tmp, id).expect("missing scrollback is already deleted");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn load_propagates_non_missing_read_errors() {
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440002";
+        let path = session_file(&tmp, id).expect("session file");
+        fs::create_dir(&path).expect("create directory at scrollback file path");
+
+        let err = load(&tmp, id).expect_err("directory must not look like missing scrollback");
+        assert!(matches!(err, ScrollbackError::Io(_)));
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_propagates_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440003";
+        save(&tmp, id, "must survive an unreadable mount").expect("save");
+        let path = session_file(&tmp, id).expect("session file");
+        let original_permissions = fs::metadata(&path).expect("metadata").permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        fs::set_permissions(&path, denied_permissions).expect("deny read access");
+
+        let result = load(&tmp, id);
+
+        fs::set_permissions(&path, original_permissions).expect("restore permissions");
+        let err = result.expect_err("permission error must reach the caller");
+        match err {
+            ScrollbackError::Io(err) => {
+                assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn delete_propagates_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempdir_path();
+        let id = "550e8400-e29b-41d4-a716-446655440005";
+        save(&tmp, id, "keep until deletion is authorized").expect("save");
+        let dir = scrollback_dir(&tmp).expect("scrollback directory");
+        let original_permissions = fs::metadata(&dir).expect("metadata").permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        fs::set_permissions(&dir, denied_permissions).expect("deny directory access");
+
+        let result = delete(&tmp, id);
+
+        fs::set_permissions(&dir, original_permissions).expect("restore permissions");
+        let err = result.expect_err("permission error must reach the caller");
+        match err {
+            ScrollbackError::Io(err) => {
+                assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+
         let _ = fs::remove_dir_all(&tmp);
     }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1291,9 +1291,9 @@ export function Terminal({
     // cleanup serialises the still-empty xterm buffer and writes 0
     // bytes to disk, wiping the previously persisted scrollback. By the
     // time mount B's load runs, the disk content is already gone. The
-    // flag flips to `true` only after the initial load step settles, so
-    // earlier serialise calls (whether from the debounced output trigger
-    // or from `flushAllScrollbacks` on app close) become no-ops.
+    // flag flips to `true` only after the initial load step succeeds. If
+    // the snapshot is inaccessible, keeping saves disabled preserves it
+    // for a later launch after the permission problem is resolved.
     let savesAllowed = false;
 
     // Debounced "save scrollback to disk" trigger. Reset on every chunk
@@ -2969,15 +2969,18 @@ export function Terminal({
           await writeAndDrain("\r\n");
           if (disposed) return;
         }
+        // The persisted state has now been read (including the legitimate
+        // NotFound -> null case) and fully applied. Only this successful path
+        // may enable replacements of the on-disk snapshot.
+        savesAllowed = true;
       } catch (err) {
         console.warn("[Terminal] scrollback_load failed", err);
+        if (!disposed) {
+          term.write(
+            `\r\n${ANSI_RED}[acorn] Failed to restore scrollback; saving is disabled to protect existing data: ${formatError(err)}${ANSI_RESET}\r\n`,
+          );
+        }
       }
-
-      // Now safe to persist: the buffer either holds the prior session's
-      // restored content or starts genuinely empty. Either state is the
-      // legitimate post-load baseline, so future saves cannot accidentally
-      // overwrite still-on-disk content with a never-loaded empty buffer.
-      savesAllowed = true;
 
       if (disposed) return;
       await spawnPty();
@@ -3005,8 +3008,8 @@ export function Terminal({
       skipOutputDrain?: boolean;
     }) => {
       // `savesAllowed` flips true only after the initial scrollback_load
-      // settles. Skipping the save until then prevents a still-empty
-      // buffer from clobbering the persisted scrollback during the
+      // succeeds. Skipping the save while loading or after an error prevents
+      // a still-empty buffer from clobbering an unread snapshot during the
       // StrictMode mount → cleanup → mount cycle.
       if ((!options?.force && disposed) || !savesAllowed) return;
       try {

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -3703,4 +3703,82 @@ test.describe("terminal: spawn", () => {
       "stale disk snapshot",
     );
   });
+
+  test("keeps scrollback saves disabled when the persisted snapshot is inaccessible", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+    await tauri.handle("scrollback_load", () => {
+      throw new Error("permission denied");
+    });
+    await tauri.handle("scrollback_save", (args) => {
+      const w = window as unknown as { __scrollbackSaveCalls?: unknown[] };
+      w.__scrollbackSaveCalls = w.__scrollbackSaveCalls ?? [];
+      w.__scrollbackSaveCalls.push(args);
+      return null;
+    });
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __deniedScrollbackOutputChannelId?: number;
+      };
+      w.__deniedScrollbackOutputChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("pty_spawn", (args) => {
+      const w = window as unknown as { __ptySpawnCalls?: unknown[] };
+      w.__ptySpawnCalls = w.__ptySpawnCalls ?? [];
+      w.__ptySpawnCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as {
+              __deniedScrollbackOutputChannelId?: number;
+            }).__deniedScrollbackOutputChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __ptySpawnCalls?: unknown[] })
+              .__ptySpawnCalls?.length ?? 0,
+        ),
+      )
+      .toBeGreaterThanOrEqual(1);
+    await expect(page.locator(".xterm")).toContainText(
+      "Failed to restore scrollback; saving is disabled to protect existing data",
+    );
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__deniedScrollbackOutputChannelId",
+      "live output after denied load",
+    );
+    await expect(page.locator(".xterm")).toContainText(
+      "live output after denied load",
+    );
+
+    // A successful load schedules this output for persistence after one
+    // second. Wait past that boundary to prove the failed load keeps the
+    // replacement gate closed while the terminal itself remains usable.
+    await page.waitForTimeout(1_200);
+    const saveCalls = await page.evaluate(
+      () =>
+        (window as unknown as { __scrollbackSaveCalls?: unknown[] })
+          .__scrollbackSaveCalls?.length ?? 0,
+    );
+    expect(saveCalls).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Preserve persisted terminal history when Acorn cannot read it, instead of treating the failure as an empty snapshot that is safe to overwrite.

1. **Distinguish absence from access failure.** `scrollback::load` and `scrollback::delete` now treat only `NotFound` as an idempotent empty/missing state; permission and other I/O errors reach the caller.
2. **Fail closed in the terminal.** Scrollback saves remain disabled unless the initial snapshot is read and applied successfully. The PTY still starts, and the terminal shows an actionable warning that saving is disabled to protect existing data.
3. **Cover the data-loss boundary.** Rust tests exercise real Unix permission denial and non-missing read failures, while Playwright verifies that live PTY output continues without invoking `scrollback_save` after a denied load.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Existing scrollback is unreadable | Reported as no snapshot; later output could atomically replace it | Error is preserved; saving stays disabled and the existing file is left untouched |
| Scrollback file is genuinely missing | Empty terminal baseline | Same empty terminal baseline; future saves remain enabled |
| Terminal startup after a load error | PTY starts silently | PTY still starts, with an in-terminal preservation warning |
| Delete encounters an inaccessible path | `Path::exists()` could collapse the error into success | Permission and other non-`NotFound` failures are returned |

## Design notes

- The backend contract now makes `Ok(None)` mean exactly “no persisted file,” so the frontend can safely use successful invocation as the write-authorization boundary.
- Saving stays disabled for that terminal mount after any load/apply failure. This intentionally trades persistence of new output for preservation of a snapshot Acorn never successfully read; remounting after permissions are repaired retries the load normally.
- The PTY lifecycle is independent of persistence recovery, so a scrollback filesystem problem does not prevent the shell from remaining usable.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session scrollback::tests -- --test-threads=1` — 9 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace --locked -- --test-threads=1` — 1,045 passed, 1 existing ignored.
- [x] `pnpm test` — 112 files / 1,350 tests passed.
- [x] `pnpm typecheck` — passed.
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts` — 44 passed.
- [x] `pnpm build` — production bundle completed.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn-session --all-targets --locked` — completed with no warnings from the changed scrollback code.

## Notes

- A stricter workspace-wide Clippy run with `-D warnings` remains blocked by existing warnings in `acorn-pty`, `acorn-transcript`, and `acorn-daemon`; none are introduced by or located in this change.
- The Vite production build retains the repository's existing chunk-size and ineffective-dynamic-import warnings; the build succeeds.
