### PR TITLE
fix(persistence): preserve inaccessible state-file entries

### DIFF
--- a/src-tauri/crates/acorn-platform/src/fs.rs
+++ b/src-tauri/crates/acorn-platform/src/fs.rs
@@ -6,6 +6,26 @@ use std::path::Path;
 
 use tempfile::NamedTempFile;
 
+/// Read an optional file without collapsing filesystem errors into absence.
+///
+/// `None` means no directory entry exists at `path`. In particular, a
+/// dangling symlink remains an error even though following it produces
+/// `NotFound`; callers must not treat an occupied but unreadable state-file
+/// path as a fresh file that is safe to replace.
+pub fn read_optional(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(read_error) if read_error.kind() == io::ErrorKind::NotFound => {
+            match fs::symlink_metadata(path) {
+                Ok(_) => Err(read_error),
+                Err(metadata_error) if metadata_error.kind() == io::ErrorKind::NotFound => Ok(None),
+                Err(metadata_error) => Err(metadata_error),
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Atomically replace `path` with `contents` after flushing it to disk.
 pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
     write_atomic_with_mode(path, contents, false)
@@ -73,6 +93,50 @@ fn set_private(_path: &Path) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn optional_read_distinguishes_missing_from_existing_files() {
+        let scratch = tempfile::tempdir().unwrap();
+        let path = scratch.path().join("state.json");
+
+        assert_eq!(read_optional(&path).unwrap(), None);
+        fs::write(&path, b"state").unwrap();
+        assert_eq!(read_optional(&path).unwrap(), Some(b"state".to_vec()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn optional_read_rejects_a_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let scratch = tempfile::tempdir().unwrap();
+        let path = scratch.path().join("state.json");
+        symlink(scratch.path().join("missing-target"), &path).unwrap();
+
+        let error = read_optional(&path).expect_err("dangling symlink occupies the path");
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+        assert!(fs::symlink_metadata(path).unwrap().file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn optional_read_propagates_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let scratch = tempfile::tempdir().unwrap();
+        let path = scratch.path().join("state.json");
+        fs::write(&path, b"state").unwrap();
+        let original_permissions = fs::metadata(&path).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        fs::set_permissions(&path, denied_permissions).unwrap();
+
+        let result = read_optional(&path);
+
+        fs::set_permissions(&path, original_permissions).unwrap();
+        let error = result.expect_err("permission failure must not look missing");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
 
     #[test]
     fn replaces_an_existing_destination_repeatedly() {

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -407,28 +407,31 @@ pub fn load_sessions() -> AppResult<Vec<Session>> {
 /// as authoritative. A missing file is considered clean (legitimate empty).
 pub fn load_sessions_with_status() -> AppResult<(Vec<Session>, bool)> {
     let path = sessions_path()?;
-    if !path.exists() {
-        tracing::info!(path = %path.display(), "sessions file missing, starting empty");
-        return Ok((Vec::new(), true));
-    }
+    Ok(load_sessions_from_path_with_status(&path))
+}
 
-    let bytes = match fs::read(&path) {
-        Ok(b) => b,
+fn load_sessions_from_path_with_status(path: &Path) -> (Vec<Session>, bool) {
+    let bytes = match acorn_platform::fs::read_optional(path) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            tracing::info!(path = %path.display(), "sessions file missing, starting empty");
+            return (Vec::new(), true);
+        }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to read sessions file");
-            return Ok((Vec::new(), false));
+            return (Vec::new(), false);
         }
     };
 
     match serde_json::from_slice::<Vec<Session>>(&bytes) {
         Ok(sessions) => {
             tracing::info!(count = sessions.len(), "loaded sessions from disk");
-            Ok((sessions, true))
+            (sessions, true)
         }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to parse sessions file");
-            backup_corrupt_file(&path);
-            Ok((Vec::new(), false))
+            backup_corrupt_file(path);
+            (Vec::new(), false)
         }
     }
 }
@@ -475,26 +478,30 @@ pub fn load_projects() -> AppResult<Vec<Project>> {
 
 pub fn load_projects_with_status() -> AppResult<(Vec<Project>, bool)> {
     let path = projects_path()?;
-    if !path.exists() {
-        tracing::info!(path = %path.display(), "projects file missing, starting empty");
-        return Ok((Vec::new(), true));
-    }
-    let bytes = match fs::read(&path) {
-        Ok(b) => b,
+    Ok(load_projects_from_path_with_status(&path))
+}
+
+fn load_projects_from_path_with_status(path: &Path) -> (Vec<Project>, bool) {
+    let bytes = match acorn_platform::fs::read_optional(path) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => {
+            tracing::info!(path = %path.display(), "projects file missing, starting empty");
+            return (Vec::new(), true);
+        }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to read projects file");
-            return Ok((Vec::new(), false));
+            return (Vec::new(), false);
         }
     };
     match serde_json::from_slice::<Vec<Project>>(&bytes) {
         Ok(projects) => {
             tracing::info!(count = projects.len(), "loaded projects from disk");
-            Ok((projects, true))
+            (projects, true)
         }
         Err(err) => {
             tracing::warn!(path = %path.display(), error = %err, "failed to parse projects file");
-            backup_corrupt_file(&path);
-            Ok((Vec::new(), false))
+            backup_corrupt_file(path);
+            (Vec::new(), false)
         }
     }
 }
@@ -761,11 +768,10 @@ fn load_chat_session_state_from_dir(
 ) -> AppResult<ChatSessionState> {
     let session_id = parse_chat_session_id(session_id)?;
     let path = chat_session_path_for_data_dir(base_dir, &session_id);
-    if !path.exists() {
+    let Some(bytes) = acorn_platform::fs::read_optional(&path)? else {
         return Ok(ChatSessionState::empty(session_id));
-    }
+    };
 
-    let bytes = fs::read(&path)?;
     let state = serde_json::from_slice::<ChatSessionState>(&bytes).map_err(|err| {
         backup_corrupt_file(&path);
         AppError::Other(format!("failed to parse chat session state: {err}"))
@@ -962,10 +968,9 @@ fn load_graph_run_state_from_dir(
 ) -> AppResult<Option<GraphRunState>> {
     let session_id = parse_chat_session_id(session_id)?;
     let path = graph_run_path_for_data_dir(base_dir, &session_id);
-    if !path.exists() {
+    let Some(bytes) = acorn_platform::fs::read_optional(&path)? else {
         return Ok(None);
-    }
-    let bytes = fs::read(&path)?;
+    };
     let state = serde_json::from_slice::<GraphRunState>(&bytes).map_err(|err| {
         backup_corrupt_file(&path);
         AppError::Other(format!("failed to parse Graph run state: {err}"))
@@ -1191,6 +1196,27 @@ mod tests {
             .exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn graph_run_load_rejects_a_dangling_state_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let session_id = Uuid::new_v4();
+        let graph_dir = graph_runs_dir_for_data_dir(dir.path());
+        fs::create_dir_all(&graph_dir).unwrap();
+        let path = graph_run_path_for_data_dir(dir.path(), &session_id);
+        symlink(graph_dir.join("missing-target.json"), &path).unwrap();
+
+        let error = load_graph_run_state_from_dir(dir.path(), &session_id.to_string())
+            .expect_err("occupied state path must not look absent");
+
+        assert!(
+            matches!(error, AppError::Io(ref error) if error.kind() == std::io::ErrorKind::NotFound)
+        );
+        assert!(fs::symlink_metadata(path).unwrap().file_type().is_symlink());
+    }
+
     #[test]
     fn graph_run_update_rejects_a_stale_human_revision() {
         let dir = tempfile::tempdir().expect("temp dir");
@@ -1334,6 +1360,56 @@ mod tests {
         let sessions = load_sessions().expect("load should not error on missing file");
         // Cannot assert empty without test isolation — at least confirm it returns.
         let _ = sessions;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inaccessible_session_and_project_files_are_not_clean_empty_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state_dir = tmp.path().join("state");
+        fs::create_dir(&state_dir).unwrap();
+        let sessions = state_dir.join(SESSIONS_FILE);
+        let projects = state_dir.join(PROJECTS_FILE);
+        fs::write(&sessions, b"[]").unwrap();
+        fs::write(&projects, b"[]").unwrap();
+        let original_permissions = fs::metadata(&state_dir).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        fs::set_permissions(&state_dir, denied_permissions).unwrap();
+
+        let session_result = load_sessions_from_path_with_status(&sessions);
+        let project_result = load_projects_from_path_with_status(&projects);
+
+        fs::set_permissions(&state_dir, original_permissions).unwrap();
+        assert!(session_result.0.is_empty());
+        assert!(!session_result.1, "session load must be marked unclean");
+        assert!(project_result.0.is_empty());
+        assert!(!project_result.1, "project load must be marked unclean");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_session_and_project_symlinks_are_not_clean_empty_state() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = tmp.path().join(SESSIONS_FILE);
+        let projects = tmp.path().join(PROJECTS_FILE);
+        symlink(tmp.path().join("missing-sessions.json"), &sessions).unwrap();
+        symlink(tmp.path().join("missing-projects.json"), &projects).unwrap();
+
+        assert!(!load_sessions_from_path_with_status(&sessions).1);
+        assert!(!load_projects_from_path_with_status(&projects).1);
+        assert!(fs::symlink_metadata(sessions)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(fs::symlink_metadata(projects)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[test]
@@ -1518,6 +1594,38 @@ mod tests {
 
         message.session_id = Some(session_id);
         assert_eq!(reloaded.messages, vec![message]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn append_chat_message_does_not_replace_a_dangling_state_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let session_id = Uuid::new_v4();
+        let chat_dir = chat_sessions_dir_for_data_dir(tmp.path());
+        fs::create_dir_all(&chat_dir).unwrap();
+        let path = chat_session_path_for_data_dir(tmp.path(), &session_id);
+        symlink(chat_dir.join("missing-target.json"), &path).unwrap();
+        let message = ChatMessage {
+            id: "msg-protected".to_string(),
+            session_id: None,
+            turn_id: None,
+            role: ChatRole::User,
+            content: "do not replace unread state".to_string(),
+            graph_prompt_plan: None,
+            created_at: Utc::now(),
+            status: Some(ChatMessageStatus::Complete),
+            metadata: None,
+        };
+
+        let error = append_chat_message_in_dir(tmp.path(), &session_id.to_string(), message)
+            .expect_err("append must stop before replacing an occupied state path");
+
+        assert!(
+            matches!(error, AppError::Io(ref error) if error.kind() == std::io::ErrorKind::NotFound)
+        );
+        assert!(fs::symlink_metadata(path).unwrap().file_type().is_symlink());
     }
 
     #[test]

--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -73,10 +72,9 @@ fn settings_path() -> AppResult<PathBuf> {
 
 fn load_all() -> AppResult<SettingsMap> {
     let path = settings_path()?;
-    if !path.exists() {
+    let Some(bytes) = acorn_platform::fs::read_optional(&path)? else {
         return Ok(SettingsMap::new());
-    }
-    let bytes = fs::read(&path)?;
+    };
     serde_json::from_slice::<SettingsMap>(&bytes)
         .map_err(|err| AppError::Other(format!("failed to parse project settings: {err}")))
 }
@@ -162,6 +160,7 @@ fn normalize_settings(mut settings: ProjectSettings) -> ProjectSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -221,6 +220,26 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("GitHub-style pull request"));
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_does_not_replace_a_dangling_settings_symlink() {
+        use std::os::unix::fs::symlink;
+
+        with_data_dir(|data_dir| {
+            let path = data_dir.join(PROJECT_SETTINGS_FILE);
+            symlink(data_dir.join("missing-settings.json"), &path).unwrap();
+            let repo = PathBuf::from("/tmp/acorn-protected-settings-repo");
+
+            let error = update(&repo, ProjectSettings::default())
+                .expect_err("update must stop before replacing an occupied settings path");
+
+            assert!(
+                matches!(error, AppError::Io(ref error) if error.kind() == std::io::ErrorKind::NotFound)
+            );
+            assert!(fs::symlink_metadata(path).unwrap().file_type().is_symlink());
         });
     }
 


### PR DESCRIPTION
## Summary

Make optional persistence reads distinguish a truly absent file from an inaccessible or otherwise occupied state-file path.

1. **Define one optional-read contract.** Add `acorn_platform::fs::read_optional`, where `None` means no filesystem entry exists and permission errors, invalid file types, and dangling symlinks remain errors.
2. **Protect boot cleanliness decisions.** Session and project loaders now mark inaccessible or dangling state files unclean instead of reporting an authoritative empty store, preserving the existing pane-reconciliation and scrollback-prune guards.
3. **Stop per-record replacement after failed reads.** Project settings, chat session state, and Graph run state propagate optional-read failures before their read-modify-write flows can publish a replacement.
4. **Exercise real failure modes.** Regression tests cover Unix permission denial and dangling symlinks, including assertions that chat and project-settings mutations leave the occupied path intact.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| State-file parent is inaccessible | `Path::exists()` could report false and classify the store as cleanly empty | Load is unclean and destructive empty-state reconciliation stays guarded |
| Chat or project-settings path is a dangling symlink | Treated as new state and atomically replaced during mutation | Mutation fails before writing and the symlink remains intact |
| Optional state file is genuinely absent | Empty/default state | Same empty/default state |
| Existing readable file | Parsed normally | Same parsed state |

## Design notes

- The helper reads first, then uses `symlink_metadata` only to disambiguate a `NotFound` read. This avoids a separate positive-existence precheck while still recognizing a dangling symlink as an occupied path.
- A race that creates an entry between the read and metadata check fails closed for that attempt; the caller can retry rather than replace state it did not read.
- Per-record chat and project-settings mutations already load before saving, so propagating the read error is sufficient to stop replacement in those flows.

## Follow-up (not in this PR)

- Session and project stores still need the separately proposed process-wide write fence when boot loading is unclean. This PR makes their cleanliness signal authoritative but intentionally does not introduce the broader read-only-mode behavior or touch every mutation surface.
- The remembered project-parent marker has different recovery semantics because its caller currently clears both malformed and inaccessible values; it will be handled as a separate work unit.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-platform fs::tests -- --test-threads=1` — 5 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib persistence::tests -- --test-threads=1` — 21 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib project_settings::tests -- --test-threads=1` — 6 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace --locked -- --test-threads=1` — 1,049 passed, 1 existing ignored.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn-platform -p acorn --lib --tests --locked` — completed; no warning points to the changed optional-read code.
- [x] `rustfmt --edition 2021 src-tauri/crates/acorn-platform/src/fs.rs src-tauri/src/persistence.rs src-tauri/src/project_settings.rs` and `git diff --check` — clean.

## Notes

- Repository-wide `cargo fmt --all --check` remains blocked by a pre-existing formatting diff in `src-tauri/src/pty_env.rs`; that unrelated file is not changed here.
- Clippy continues to report the repository's existing warnings in unrelated modules and pre-existing tests; this change introduces no new Clippy diagnostic.
