### PR TITLE
fix(projects): preserve remembered folders on access errors

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7105,15 +7105,13 @@ fn get_last_project_parent_folder_from_dir(
 ) -> AppResult<Option<String>> {
     let remembered = match persistence::load_last_project_parent_folder_from_dir(data_dir) {
         Ok(value) => value,
+        Err(AppError::Io(err)) if err.kind() != io::ErrorKind::NotFound => {
+            tracing::warn!(error = %err, "remembered project parent marker is inaccessible");
+            return Err(AppError::Io(err));
+        }
         Err(err) => {
-            tracing::warn!(error = %err, "failed to load remembered project parent folder");
-            if let Err(clear_err) = persistence::clear_last_project_parent_folder_from_dir(data_dir)
-            {
-                tracing::warn!(
-                    error = %clear_err,
-                    "failed to clear invalid remembered project parent folder"
-                );
-            }
+            tracing::warn!(error = %err, "clearing invalid remembered project parent folder");
+            persistence::clear_last_project_parent_folder_from_dir(data_dir)?;
             return Ok(None);
         }
     };
@@ -7121,33 +7119,43 @@ fn get_last_project_parent_folder_from_dir(
         return Ok(None);
     };
 
-    if !path.is_dir() {
-        if let Err(err) = persistence::clear_last_project_parent_folder_from_dir(data_dir) {
-            tracing::warn!(
-                error = %err,
-                path = %path.display(),
-                "failed to clear missing remembered project parent folder"
-            );
+    match std::fs::metadata(&path) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            tracing::warn!(path = %path.display(), "clearing remembered project parent because it is not a directory");
+            persistence::clear_last_project_parent_folder_from_dir(data_dir)?;
+            return Ok(None);
         }
-        return Ok(None);
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            tracing::warn!(path = %path.display(), "clearing missing remembered project parent folder");
+            persistence::clear_last_project_parent_folder_from_dir(data_dir)?;
+            return Ok(None);
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, path = %path.display(), "remembered project parent folder is inaccessible");
+            return Err(AppError::Io(err));
+        }
     }
 
     match remember_folder_grant(state, &path) {
         Ok(path) => Ok(Some(path.to_string_lossy().into_owned())),
+        Err(AppError::Io(err)) if err.kind() == io::ErrorKind::NotFound => {
+            tracing::warn!(path = %path.display(), "clearing remembered project parent folder that vanished during validation");
+            persistence::clear_last_project_parent_folder_from_dir(data_dir)?;
+            Ok(None)
+        }
+        Err(AppError::InvalidPath(err)) => {
+            tracing::warn!(error = %err, path = %path.display(), "clearing invalid remembered project parent folder");
+            persistence::clear_last_project_parent_folder_from_dir(data_dir)?;
+            Ok(None)
+        }
         Err(err) => {
             tracing::warn!(
                 error = %err,
                 path = %path.display(),
-                "remembered project parent folder is no longer accessible"
+                "remembered project parent folder is temporarily inaccessible"
             );
-            if let Err(clear_err) = persistence::clear_last_project_parent_folder_from_dir(data_dir)
-            {
-                tracing::warn!(
-                    error = %clear_err,
-                    "failed to clear inaccessible remembered project parent folder"
-                );
-            }
-            Ok(None)
+            Err(err)
         }
     }
 }
@@ -17858,6 +17866,151 @@ mod tests {
             crate::persistence::load_last_project_parent_folder_from_dir(app_data.path()).unwrap(),
             None
         );
+        assert!(state.folder_grants.lock().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_remembered_project_parent_marker_is_preserved() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let app_data = tempfile::tempdir().unwrap();
+        let parent_root = tempfile::tempdir().unwrap();
+        let parent = parent_root.path().join("projects");
+        std::fs::create_dir(&parent).unwrap();
+        crate::persistence::save_last_project_parent_folder_to_dir(app_data.path(), &parent)
+            .unwrap();
+        let marker = app_data.path().join("last-project-parent-folder.json");
+        let original_permissions = std::fs::metadata(&marker).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        std::fs::set_permissions(&marker, denied_permissions).unwrap();
+        let state = crate::state::AppState::default();
+
+        let result = super::get_last_project_parent_folder_from_dir(&state, app_data.path());
+
+        assert!(matches!(
+            result,
+            Err(AppError::Io(ref err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+        assert!(
+            marker.exists(),
+            "permission errors must not delete the marker"
+        );
+        std::fs::set_permissions(&marker, original_permissions).unwrap();
+        assert_eq!(
+            crate::persistence::load_last_project_parent_folder_from_dir(app_data.path()).unwrap(),
+            Some(parent)
+        );
+        assert!(state.folder_grants.lock().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inaccessible_remembered_project_parent_marker_directory_is_not_reported_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let app_root = tempfile::tempdir().unwrap();
+        let app_data = app_root.path().join("state");
+        std::fs::create_dir(&app_data).unwrap();
+        let parent_root = tempfile::tempdir().unwrap();
+        let parent = parent_root.path().join("projects");
+        std::fs::create_dir(&parent).unwrap();
+        crate::persistence::save_last_project_parent_folder_to_dir(&app_data, &parent).unwrap();
+        let marker = app_data.join("last-project-parent-folder.json");
+        let original_permissions = std::fs::metadata(&app_data).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        std::fs::set_permissions(&app_data, denied_permissions).unwrap();
+        let state = crate::state::AppState::default();
+
+        let result = super::get_last_project_parent_folder_from_dir(&state, &app_data);
+
+        std::fs::set_permissions(&app_data, original_permissions).unwrap();
+        assert!(matches!(
+            result,
+            Err(AppError::Io(ref err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+        assert!(marker.exists(), "inaccessible marker must remain on disk");
+        assert_eq!(
+            crate::persistence::load_last_project_parent_folder_from_dir(&app_data).unwrap(),
+            Some(parent)
+        );
+        assert!(state.folder_grants.lock().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inaccessible_remembered_project_parent_is_preserved() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let app_data = tempfile::tempdir().unwrap();
+        let parent_root = tempfile::tempdir().unwrap();
+        let parent = parent_root.path().join("projects");
+        std::fs::create_dir(&parent).unwrap();
+        crate::persistence::save_last_project_parent_folder_to_dir(app_data.path(), &parent)
+            .unwrap();
+        let original_permissions = std::fs::metadata(parent_root.path()).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        std::fs::set_permissions(parent_root.path(), denied_permissions).unwrap();
+        let state = crate::state::AppState::default();
+
+        let result = super::get_last_project_parent_folder_from_dir(&state, app_data.path());
+
+        std::fs::set_permissions(parent_root.path(), original_permissions).unwrap();
+        assert!(matches!(
+            result,
+            Err(AppError::Io(ref err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+        assert_eq!(
+            crate::persistence::load_last_project_parent_folder_from_dir(app_data.path()).unwrap(),
+            Some(parent)
+        );
+        assert!(state.folder_grants.lock().is_empty());
+    }
+
+    #[test]
+    fn malformed_remembered_project_parent_marker_is_cleared() {
+        let app_data = tempfile::tempdir().unwrap();
+        let marker = app_data.path().join("last-project-parent-folder.json");
+        std::fs::write(&marker, b"not-json").unwrap();
+        let state = crate::state::AppState::default();
+
+        let restored =
+            super::get_last_project_parent_folder_from_dir(&state, app_data.path()).unwrap();
+
+        assert_eq!(restored, None);
+        assert!(!marker.exists());
+        assert!(state.folder_grants.lock().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remembered_project_parent_cleanup_permission_error_is_returned() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let app_data = tempfile::tempdir().unwrap();
+        let marker = app_data.path().join("last-project-parent-folder.json");
+        std::fs::write(&marker, b"not-json").unwrap();
+        let original_permissions = std::fs::metadata(app_data.path()).unwrap().permissions();
+        let mut read_only_permissions = original_permissions.clone();
+        read_only_permissions.set_mode(0o500);
+        std::fs::set_permissions(app_data.path(), read_only_permissions).unwrap();
+        let state = crate::state::AppState::default();
+
+        let result = super::get_last_project_parent_folder_from_dir(&state, app_data.path());
+
+        std::fs::set_permissions(app_data.path(), original_permissions).unwrap();
+        assert!(matches!(
+            result,
+            Err(AppError::Io(ref err))
+                if err.kind() == std::io::ErrorKind::PermissionDenied
+        ));
+        assert!(marker.exists(), "failed cleanup must not report success");
         assert!(state.folder_grants.lock().is_empty());
     }
 }

--- a/src/components/NewProjectDialog.tsx
+++ b/src/components/NewProjectDialog.tsx
@@ -68,9 +68,10 @@ export function NewProjectDialog({
           setParentPath(path ?? "");
         }
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled && !locationPickedRef.current) {
           setParentPath("");
+          setError(errorMessage(err));
         }
       });
     void api

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4092,6 +4092,39 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(page.getByLabel("Project location")).toHaveValue("");
   });
 
+  test("New project reports a remembered-folder permission error and still allows recovery", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("get_last_project_parent_folder", () => {
+      throw new Error("permission denied while reading remembered folder");
+    });
+    await tauri.handle(
+      "select_project_parent_folder",
+      () => "/tmp/recovered-parent",
+    );
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "New project" }).click();
+
+    await expect(page.getByLabel("Project location")).toHaveValue("");
+    await expect(
+      page.getByRole("alert").filter({
+        hasText: "permission denied while reading remembered folder",
+      }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Choose" }).click();
+    await expect(page.getByLabel("Project location")).toHaveValue(
+      "/tmp/recovered-parent",
+    );
+    await expect(
+      page.getByRole("alert").filter({
+        hasText: "permission denied while reading remembered folder",
+      }),
+    ).toHaveCount(0);
+  });
+
   test("New project can override long-name safe warnings", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Remembered project locations now survive temporary filesystem access failures instead of being silently forgotten.

1. **Marker reads** — read the remembered-folder marker directly and distinguish a genuinely missing file from permission errors and dangling path state.
2. **Evidence-based cleanup** — clear the marker only when its contents are malformed, its target is missing, or the target is definitively not a directory; propagate access and cleanup failures without deleting state.
3. **User recovery** — surface restore failures in the New Project dialog while keeping the folder picker available and clearing the error after a successful choice.
4. **Regression coverage** — cover unreadable marker files and directories, inaccessible remembered targets, malformed markers, cleanup failures, and the frontend recovery flow.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Marker or remembered directory is temporarily inaccessible | Marker could be treated as missing and deleted | Marker is preserved and the access error is surfaced |
| Marker is malformed, target is missing, or target is not a directory | Marker is cleared | Marker remains authoritatively cleared |
| Invalid-marker cleanup itself fails | Failure was logged and hidden | Failure is returned; the marker remains available for repair/retry |
| New Project restore fails | Location silently appeared empty | Dialog explains the error and allows choosing a replacement location |

## Design notes

- Cleanup is intentionally limited to states established by positive filesystem evidence. `PermissionDenied` and other transient I/O failures remain retryable.
- A folder grant is created only after metadata validation and canonicalization succeed, so inaccessible paths never enter the grant set.
- The dialog does not block project creation after a restore error; choosing a folder replaces the stale state through the existing save path.

## Test plan

- [x] `cargo test remembered_project_parent -- --test-threads=1` — 8 passed.
- [x] `cargo test --workspace --locked -- --test-threads=1` — 1,046 passed, 1 existing ignored.
- [x] `pnpm test` — 112 files / 1,350 tests passed.
- [x] `pnpm typecheck` — passed.
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 55 passed.
- [x] `cargo clippy -p acorn --lib --tests` — passed with existing repository warnings.
- [x] `git diff --check` — passed.

## Notes

- `cargo fmt --all --check` still reports the pre-existing formatting difference in `src-tauri/src/pty_env.rs`; this PR does not modify that file.

