### PR TITLE
fix(daemon): make PID locking permission-safe

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/lifecycle.rs
+++ b/src-tauri/crates/acorn-daemon/src/lifecycle.rs
@@ -22,8 +22,9 @@
 //!    a short timeout; on success the daemon is alive, on EOF / refused
 //!    the slot is free.
 
-use std::io;
-use std::path::PathBuf;
+use std::fs::{File, Metadata, OpenOptions, TryLockError};
+use std::io::{self, Read, Seek, Write};
+use std::path::{Path, PathBuf};
 
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 
@@ -36,10 +37,24 @@ const DAEMON_EXECUTABLE: &str = "acornd";
 /// Outcome of attempting to acquire the daemon singleton lock.
 #[derive(Debug)]
 pub enum PidLock {
-    /// We hold the lock. The file now contains our PID.
-    Acquired(PathBuf),
+    /// We hold the lock. The guard keeps the OS lock alive until it is
+    /// dropped; the reusable PID file itself remains on disk.
+    Acquired(PidLockGuard),
     /// Another daemon is already running. Field is its PID.
     AlreadyHeld(u32),
+}
+
+/// Process-lifetime ownership of the daemon PID file.
+#[derive(Debug)]
+pub struct PidLockGuard {
+    path: PathBuf,
+    _file: File,
+}
+
+impl PidLockGuard {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 /// Attempt to acquire the singleton lock. Returns immediately — no
@@ -47,26 +62,127 @@ pub enum PidLock {
 /// to make a policy decision (refuse-to-start vs. wait-and-replace).
 pub fn try_acquire_pid_lock() -> io::Result<PidLock> {
     let path = paths::pid_file_path()?;
-    if path.exists() {
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(pid) = contents.trim().parse::<u32>() {
-                if is_our_daemon(pid) {
-                    return Ok(PidLock::AlreadyHeld(pid));
-                }
-            }
+    let mut file = open_pid_file(&path)?;
+    match file.try_lock() {
+        Ok(()) => {}
+        Err(TryLockError::WouldBlock) => {
+            let pid = read_pid_file(&mut file)?.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "daemon PID lock is held before a valid PID claim was published",
+                )
+            })?;
+            return Ok(PidLock::AlreadyHeld(pid));
         }
-        // Stale file (process gone, unparseable, or PID was recycled
-        // by an unrelated binary). Reclaim it.
+        Err(TryLockError::Error(err)) => return Err(err),
+    }
+
+    if let Some(pid) = read_pid_file(&mut file)? {
+        if is_our_daemon(pid) {
+            return Ok(PidLock::AlreadyHeld(pid));
+        }
+        // Stale claim (process gone or PID was recycled by an unrelated
+        // binary). The exclusive OS lock makes replacement atomic with
+        // respect to every current daemon contender.
     }
     let me = std::process::id();
-    std::fs::write(&path, me.to_string())?;
-    Ok(PidLock::Acquired(path))
+    #[cfg(unix)]
+    file.set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o600))?;
+    file.set_len(0)?;
+    file.rewind()?;
+    file.write_all(me.to_string().as_bytes())?;
+    file.flush()?;
+    Ok(PidLock::Acquired(PidLockGuard { path, _file: file }))
 }
 
-/// Best-effort removal of the PID file. Called on graceful shutdown.
-/// Non-fatal if the file is already gone or owned by someone else.
-pub fn release_pid_lock(path: &PathBuf) {
-    let _ = std::fs::remove_file(path);
+fn open_pid_file(path: &Path) -> io::Result<File> {
+    loop {
+        match std::fs::symlink_metadata(path) {
+            Ok(before) => {
+                validate_pid_file_metadata(path, &before)?;
+                let file = match OpenOptions::new().read(true).write(true).open(path) {
+                    Ok(file) => file,
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    Err(err) => return Err(err),
+                };
+                let opened = file.metadata()?;
+                validate_pid_file_metadata(path, &opened)?;
+                validate_same_pid_file(path, &before, &opened)?;
+                return Ok(file);
+            }
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                let mut options = OpenOptions::new();
+                options.read(true).write(true).create_new(true);
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::OpenOptionsExt;
+                    options.mode(0o600);
+                }
+                match options.open(path) {
+                    Ok(file) => return Ok(file),
+                    Err(err) if err.kind() == io::ErrorKind::AlreadyExists => continue,
+                    Err(err) => return Err(err),
+                }
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn validate_pid_file_metadata(path: &Path, metadata: &Metadata) -> io::Result<()> {
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("daemon PID lock is not a regular file: {}", path.display()),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() > 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "daemon PID lock must not be hard-linked: {}",
+                    path.display()
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_same_pid_file(path: &Path, before: &Metadata, opened: &Metadata) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    if before.dev() != opened.dev() || before.ino() != opened.ino() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("daemon PID lock changed while opening: {}", path.display()),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn validate_same_pid_file(_path: &Path, _before: &Metadata, _opened: &Metadata) -> io::Result<()> {
+    Ok(())
+}
+
+fn read_pid_file(file: &mut File) -> io::Result<Option<u32>> {
+    const MAX_PID_BYTES: u64 = 32;
+
+    file.rewind()?;
+    let mut bytes = Vec::with_capacity(MAX_PID_BYTES as usize + 1);
+    file.take(MAX_PID_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_PID_BYTES {
+        return Ok(None);
+    }
+    let Ok(contents) = std::str::from_utf8(&bytes) else {
+        return Ok(None);
+    };
+    Ok(contents.trim().parse::<u32>().ok())
 }
 
 /// A PID claim is valid only while that process exists and its executable
@@ -217,7 +333,8 @@ mod tests {
         let tmp = short_tmp_root().join(format!("acn-pid-{}", uuid::Uuid::new_v4().simple()));
         unsafe { std::env::set_var(paths::ENV_DATA_DIR_OVERRIDE, &tmp) };
         match try_acquire_pid_lock().unwrap() {
-            PidLock::Acquired(path) => {
+            PidLock::Acquired(lock) => {
+                let path = lock.path().to_path_buf();
                 assert!(path.exists());
                 let pid: u32 = std::fs::read_to_string(&path)
                     .unwrap()
@@ -225,11 +342,41 @@ mod tests {
                     .parse()
                     .unwrap();
                 assert_eq!(pid, std::process::id());
-                release_pid_lock(&path);
-                assert!(!path.exists());
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    assert_eq!(
+                        std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                        0o600
+                    );
+                }
+                drop(lock);
+                assert!(path.exists(), "the reusable lock inode stays on disk");
             }
             PidLock::AlreadyHeld(_) => panic!("expected acquire on fresh dir"),
         }
+        unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn pid_lock_stays_exclusive_for_the_guard_lifetime() {
+        let _g = ENV_LOCK.lock();
+        let tmp = short_tmp_root().join(format!("acn-pid-held-{}", uuid::Uuid::new_v4().simple()));
+        unsafe { std::env::set_var(paths::ENV_DATA_DIR_OVERRIDE, &tmp) };
+        let first = match try_acquire_pid_lock().unwrap() {
+            PidLock::Acquired(lock) => lock,
+            PidLock::AlreadyHeld(pid) => panic!("fresh lock already held by {pid}"),
+        };
+
+        assert!(matches!(
+            try_acquire_pid_lock().unwrap(),
+            PidLock::AlreadyHeld(pid) if pid == std::process::id()
+        ));
+
+        let path = first.path().to_path_buf();
+        drop(first);
+        assert!(path.exists());
         unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
         let _ = std::fs::remove_dir_all(&tmp);
     }
@@ -269,6 +416,76 @@ mod tests {
                 panic!("recycled PID should have been reclaimed, got {pid}")
             }
         }
+        unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_lock_does_not_overwrite_an_inaccessible_claim() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _g = ENV_LOCK.lock();
+        let tmp =
+            short_tmp_root().join(format!("acn-pid-denied-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        unsafe { std::env::set_var(paths::ENV_DATA_DIR_OVERRIDE, &tmp) };
+        let pidfile = paths::pid_file_path().unwrap();
+        std::fs::write(&pidfile, "stale-but-private").unwrap();
+        let original_permissions = std::fs::metadata(&pidfile).unwrap().permissions();
+        let mut denied_permissions = original_permissions.clone();
+        denied_permissions.set_mode(0o000);
+        std::fs::set_permissions(&pidfile, denied_permissions).unwrap();
+
+        let result = try_acquire_pid_lock();
+
+        std::fs::set_permissions(&pidfile, original_permissions).unwrap();
+        assert!(matches!(
+            result,
+            Err(ref err) if err.kind() == io::ErrorKind::PermissionDenied
+        ));
+        assert_eq!(
+            std::fs::read_to_string(&pidfile).unwrap(),
+            "stale-but-private"
+        );
+        unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_lock_rejects_symlinks_and_hard_links_without_clobbering_peers() {
+        use std::os::unix::fs::symlink;
+
+        let _g = ENV_LOCK.lock();
+        let tmp = short_tmp_root().join(format!("acn-pid-link-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        unsafe { std::env::set_var(paths::ENV_DATA_DIR_OVERRIDE, &tmp) };
+        let pidfile = paths::pid_file_path().unwrap();
+        let sentinel = tmp.join("sentinel");
+        std::fs::write(&sentinel, "do-not-replace").unwrap();
+
+        symlink(&sentinel, &pidfile).unwrap();
+        assert_eq!(
+            try_acquire_pid_lock().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).unwrap(),
+            "do-not-replace"
+        );
+
+        std::fs::remove_file(&pidfile).unwrap();
+        std::fs::hard_link(&sentinel, &pidfile).unwrap();
+        assert_eq!(
+            try_acquire_pid_lock().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            std::fs::read_to_string(&sentinel).unwrap(),
+            "do-not-replace"
+        );
+
         unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/crates/acorn-daemon/src/lifecycle.rs
+++ b/src-tauri/crates/acorn-daemon/src/lifecycle.rs
@@ -40,8 +40,9 @@ pub enum PidLock {
     /// We hold the lock. The guard keeps the OS lock alive until it is
     /// dropped; the reusable PID file itself remains on disk.
     Acquired(PidLockGuard),
-    /// Another daemon is already running. Field is its PID.
-    AlreadyHeld(u32),
+    /// Another daemon is already running. The PID is diagnostic-only and may
+    /// be unavailable when the platform denies reads through a contended lock.
+    AlreadyHeld { pid: Option<u32> },
 }
 
 /// Process-lifetime ownership of the daemon PID file.
@@ -63,27 +64,21 @@ impl PidLockGuard {
 pub fn try_acquire_pid_lock() -> io::Result<PidLock> {
     let path = paths::pid_file_path()?;
     let mut file = open_pid_file(&path)?;
-    // Windows denies reads through every handle while another process holds
-    // an exclusive file lock. Capture the published claim before attempting
-    // the lock so the contended path never has to read a locked range.
-    let published_pid = read_pid_file(&mut file)?;
     match file.try_lock() {
         Ok(()) => {}
         Err(TryLockError::WouldBlock) => {
-            let pid = published_pid.ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "daemon PID lock is held before a valid PID claim was published",
-                )
-            })?;
-            return Ok(PidLock::AlreadyHeld(pid));
+            // The lock is the authoritative ownership signal. Unix normally
+            // still permits the diagnostic PID read, while Windows rejects
+            // every read through a second handle until the lock is released.
+            let pid = read_pid_file(&mut file).ok().flatten();
+            return Ok(PidLock::AlreadyHeld { pid });
         }
         Err(TryLockError::Error(err)) => return Err(err),
     }
 
     if let Some(pid) = read_pid_file(&mut file)? {
         if is_our_daemon(pid) {
-            return Ok(PidLock::AlreadyHeld(pid));
+            return Ok(PidLock::AlreadyHeld { pid: Some(pid) });
         }
         // Stale claim (process gone or PID was recycled by an unrelated
         // binary). The exclusive OS lock makes replacement atomic with
@@ -357,7 +352,7 @@ mod tests {
                     .unwrap();
                 assert_eq!(pid, std::process::id());
             }
-            PidLock::AlreadyHeld(_) => panic!("expected acquire on fresh dir"),
+            PidLock::AlreadyHeld { .. } => panic!("expected acquire on fresh dir"),
         }
         unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
         let _ = std::fs::remove_dir_all(&tmp);
@@ -370,13 +365,17 @@ mod tests {
         unsafe { std::env::set_var(paths::ENV_DATA_DIR_OVERRIDE, &tmp) };
         let first = match try_acquire_pid_lock().unwrap() {
             PidLock::Acquired(lock) => lock,
-            PidLock::AlreadyHeld(pid) => panic!("fresh lock already held by {pid}"),
+            PidLock::AlreadyHeld { pid } => panic!("fresh lock already held by {pid:?}"),
         };
 
-        assert!(matches!(
-            try_acquire_pid_lock().unwrap(),
-            PidLock::AlreadyHeld(pid) if pid == std::process::id()
-        ));
+        let second_pid = match try_acquire_pid_lock().unwrap() {
+            PidLock::AlreadyHeld { pid } => pid,
+            PidLock::Acquired(_) => panic!("a second lock must not be acquired"),
+        };
+        #[cfg(unix)]
+        assert_eq!(second_pid, Some(std::process::id()));
+        #[cfg(windows)]
+        assert_eq!(second_pid, None);
 
         let path = first.path().to_path_buf();
         drop(first);
@@ -396,7 +395,9 @@ mod tests {
         std::fs::write(&pidfile, u32::MAX.to_string()).unwrap();
         match try_acquire_pid_lock().unwrap() {
             PidLock::Acquired(_) => {}
-            PidLock::AlreadyHeld(pid) => panic!("reclaim should have happened, got {pid}"),
+            PidLock::AlreadyHeld { pid } => {
+                panic!("reclaim should have happened, got {pid:?}")
+            }
         }
         unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };
         let _ = std::fs::remove_dir_all(&tmp);
@@ -416,8 +417,8 @@ mod tests {
         std::fs::write(&pidfile, std::process::id().to_string()).unwrap();
         match try_acquire_pid_lock().unwrap() {
             PidLock::Acquired(_) => {}
-            PidLock::AlreadyHeld(pid) => {
-                panic!("recycled PID should have been reclaimed, got {pid}")
+            PidLock::AlreadyHeld { pid } => {
+                panic!("recycled PID should have been reclaimed, got {pid:?}")
             }
         }
         unsafe { std::env::remove_var(paths::ENV_DATA_DIR_OVERRIDE) };

--- a/src-tauri/crates/acorn-daemon/src/lifecycle.rs
+++ b/src-tauri/crates/acorn-daemon/src/lifecycle.rs
@@ -63,10 +63,14 @@ impl PidLockGuard {
 pub fn try_acquire_pid_lock() -> io::Result<PidLock> {
     let path = paths::pid_file_path()?;
     let mut file = open_pid_file(&path)?;
+    // Windows denies reads through every handle while another process holds
+    // an exclusive file lock. Capture the published claim before attempting
+    // the lock so the contended path never has to read a locked range.
+    let published_pid = read_pid_file(&mut file)?;
     match file.try_lock() {
         Ok(()) => {}
         Err(TryLockError::WouldBlock) => {
-            let pid = read_pid_file(&mut file)?.ok_or_else(|| {
+            let pid = published_pid.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::WouldBlock,
                     "daemon PID lock is held before a valid PID claim was published",
@@ -336,12 +340,6 @@ mod tests {
             PidLock::Acquired(lock) => {
                 let path = lock.path().to_path_buf();
                 assert!(path.exists());
-                let pid: u32 = std::fs::read_to_string(&path)
-                    .unwrap()
-                    .trim()
-                    .parse()
-                    .unwrap();
-                assert_eq!(pid, std::process::id());
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
@@ -352,6 +350,12 @@ mod tests {
                 }
                 drop(lock);
                 assert!(path.exists(), "the reusable lock inode stays on disk");
+                let pid: u32 = std::fs::read_to_string(&path)
+                    .unwrap()
+                    .trim()
+                    .parse()
+                    .unwrap();
+                assert_eq!(pid, std::process::id());
             }
             PidLock::AlreadyHeld(_) => panic!("expected acquire on fresh dir"),
         }

--- a/src-tauri/crates/acorn-daemon/src/paths.rs
+++ b/src-tauri/crates/acorn-daemon/src/paths.rs
@@ -12,7 +12,7 @@
 //! ├── daemon.sock             (daemon control socket)
 //! ├── daemon-stream.sock      (daemon stream socket — split from control to
 //! │                            avoid head-of-line blocking under burst load)
-//! ├── daemon.pid              (lockfile; presence implies daemon claim)
+//! ├── daemon.pid              (reusable lockfile; OS lock implies live claim)
 //! ├── daemon.log              (current log; rotated to .1 / .2 on size)
 //! ├── daemon.log.1
 //! ├── daemon.log.2
@@ -67,8 +67,9 @@ pub fn stream_socket_path() -> std::io::Result<PathBuf> {
     acorn_paths::local_ipc_endpoint("daemon-stream")
 }
 
-/// PID lockfile path. The daemon writes its PID here on startup and
-/// inspects it on subsequent startups to detect a running peer.
+/// PID lockfile path. The daemon holds an OS lock and writes its PID here on
+/// startup. The inode is reused across runs; file presence alone is not a
+/// liveness signal.
 pub fn pid_file_path() -> std::io::Result<PathBuf> {
     Ok(data_dir()?.join("daemon.pid"))
 }

--- a/src-tauri/crates/acorn-daemon/src/socket.rs
+++ b/src-tauri/crates/acorn-daemon/src/socket.rs
@@ -56,7 +56,7 @@ fn bind_one(path: &Path) -> io::Result<acorn_local_ipc::Listener> {
 }
 
 /// Clean up socket files. Called on graceful shutdown. Non-fatal on
-/// failure — best-effort symmetric with `release_pid_lock`.
+/// failure — endpoint cleanup is independent of the reusable PID lockfile.
 pub fn cleanup_paths(control: &PathBuf, stream: &PathBuf) {
     acorn_local_ipc::cleanup(control);
     acorn_local_ipc::cleanup(stream);

--- a/src-tauri/src/bin/acornd.rs
+++ b/src-tauri/src/bin/acornd.rs
@@ -168,8 +168,8 @@ fn run_serve(detach: bool) -> io::Result<()> {
     init_tracing();
 
     // 4) Acquire the singleton lock.
-    let pid_path = match daemon::lifecycle::try_acquire_pid_lock()? {
-        daemon::lifecycle::PidLock::Acquired(path) => path,
+    let pid_lock = match daemon::lifecycle::try_acquire_pid_lock()? {
+        daemon::lifecycle::PidLock::Acquired(lock) => lock,
         daemon::lifecycle::PidLock::AlreadyHeld(pid) => {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
@@ -182,7 +182,7 @@ fn run_serve(detach: bool) -> io::Result<()> {
     let listeners = match daemon::socket::bind_both() {
         Ok(l) => l,
         Err(e) => {
-            daemon::lifecycle::release_pid_lock(&pid_path);
+            drop(pid_lock);
             return Err(e);
         }
     };
@@ -212,7 +212,7 @@ fn run_serve(detach: bool) -> io::Result<()> {
     //    on a panic the crash hook fires first, then unwinding hits
     //    these via destructors.
     daemon::socket::cleanup_paths(&control_path, &stream_path);
-    daemon::lifecycle::release_pid_lock(&pid_path);
+    drop(pid_lock);
     tracing::info!("acornd exited");
 
     serve_result

--- a/src-tauri/src/bin/acornd.rs
+++ b/src-tauri/src/bin/acornd.rs
@@ -170,11 +170,12 @@ fn run_serve(detach: bool) -> io::Result<()> {
     // 4) Acquire the singleton lock.
     let pid_lock = match daemon::lifecycle::try_acquire_pid_lock()? {
         daemon::lifecycle::PidLock::Acquired(lock) => lock,
-        daemon::lifecycle::PidLock::AlreadyHeld(pid) => {
-            return Err(io::Error::new(
-                io::ErrorKind::AlreadyExists,
-                format!("daemon already running (pid {pid})"),
-            ));
+        daemon::lifecycle::PidLock::AlreadyHeld { pid } => {
+            let message = pid.map_or_else(
+                || "daemon already running".to_string(),
+                |pid| format!("daemon already running (pid {pid})"),
+            );
+            return Err(io::Error::new(io::ErrorKind::AlreadyExists, message));
         }
     };
 


### PR DESCRIPTION
## Summary

This makes the daemon singleton claim fail closed on filesystem access errors and removes PID-file startup races.

1. **Exclusive singleton ownership.** Replace the exists/read/write sequence with an OS file lock held by a process-lifetime guard, so concurrent daemon starts cannot both acquire the claim.
2. **Fail-closed file handling.** Propagate PID-file metadata, open, read, and write failures instead of treating unreadable state as stale; reject symlinks, non-regular files, and Unix hard links without touching their targets.
3. **Stable lifecycle semantics.** Reuse the lock inode across daemon runs, tighten Unix permissions to 0600, and release ownership by dropping the guard rather than unlinking a path another process could recreate.
4. **Cross-platform contention.** Treat the OS lock as authoritative and make the diagnostic PID optional because Windows denies reads through a second handle while the lock is held.
5. **Regression coverage.** Cover simultaneous acquisition, stale and recycled PID recovery, permission denial, link rejection, persisted lockfiles, owner-only modes, and platform-specific contended-read behavior.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Concurrent startup | Check-then-write race could let multiple processes claim startup | OS locking serializes every contender |
| Access errors | Unreadable claims were treated as stale and could be overwritten | Startup fails with the original filesystem error |
| Windows contention | A second daemon failed with a raw locked-range read error | It reports that a daemon is already running; PID detail is omitted when Windows withholds it |
| Path safety | Writes followed links and graceful cleanup unlinked by pathname | Link-shaped claims are rejected and the locked inode is retained |
| Lockfile privacy | Existing modes were preserved and new modes followed defaults | Unix lockfiles are normalized to 0600 |

## Design notes

- The held OS lock is authoritative for daemons using this implementation. The PID and executable check remains after lock acquisition to avoid starting beside a live legacy daemon that wrote a PID but did not hold an OS lock.
- Reading the PID after a contended lock is diagnostic only. Unix normally permits it; Windows returns the same locked-range error that proves the other owner is active, so the public outcome carries `Option<u32>`.
- The PID file intentionally remains after shutdown. Its presence is no longer a liveness signal; keeping the same inode avoids an unlock/unlink/recreate window during handoff.
- Socket cleanup remains independent and still occurs before the PID guard is released.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-daemon` — 51 passed after the Windows contract adjustment.
- [x] `cargo test --workspace -- --test-threads=1` — full Rust workspace passed before the Windows-only follow-up.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --bin acornd` — passed.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml -p acorn-daemon --target x86_64-pc-windows-msvc` — passed.
- [x] `cargo clippy -p acorn-daemon --lib` — passed with existing warnings only.
- [x] `git diff --check` — passed.

## Notes

- A macOS cross-check of the complete Windows `acornd` binary is blocked by missing MSVC C headers for native dependencies; the daemon crate itself cross-checks successfully and CI runs the native Windows test binary.
- `cargo clippy --workspace --all-targets -- -D warnings` is currently blocked by pre-existing warnings in acorn-pty, acorn-transcript, acorn-ipc, and unchanged daemon files. None point to the PID-lock implementation in this PR.