### PR TITLE
fix(transcripts): surface access failures in title and resume flows

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7973,7 +7973,7 @@ fn session_title_readiness_inner(
 ) -> AppResult<SessionTitleReadinessResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
-    let title_input = resolve_title_input_for_session(&session, id);
+    let title_input = resolve_title_input_for_session(&session, id)?;
     let transcript_id = title_input
         .as_ref()
         .map(|input| input.transcript_id.as_str());
@@ -8042,7 +8042,7 @@ fn generate_session_title_inner(
 ) -> AppResult<GenerateSessionTitleResult> {
     let id = parse_id(&id)?;
     let session = state.sessions.get(&id)?;
-    let title_input = resolve_title_input_for_session(&session, id);
+    let title_input = resolve_title_input_for_session(&session, id)?;
     let transcript_id = title_input
         .as_ref()
         .map(|input| input.transcript_id.as_str());
@@ -8067,7 +8067,7 @@ fn generate_session_title_inner(
     let generated =
         crate::session_titles::generate_title(&ai, prompt.as_deref(), &title_input.title_context)?;
     let latest = state.sessions.get(&id)?;
-    let current_title_input = resolve_title_input_for_session(&latest, id);
+    let current_title_input = resolve_title_input_for_session(&latest, id)?;
     let current_transcript_id = current_title_input
         .as_ref()
         .map(|input| input.transcript_id.as_str());
@@ -8120,11 +8120,11 @@ fn can_store_generated_session_title(
 fn resolve_title_input_for_session(
     session: &Session,
     id: Uuid,
-) -> Option<crate::session_titles::ResolvedTitleInput> {
+) -> AppResult<Option<crate::session_titles::ResolvedTitleInput>> {
     if session.mode == SessionMode::Chat {
         crate::session_titles::resolve_chat_title_input(id)
     } else {
-        crate::session_titles::resolve_title_input(id)
+        Ok(crate::session_titles::resolve_title_input(id))
     }
 }
 

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -917,7 +917,7 @@ pub fn load_chat_session_state(session_id: &str) -> AppResult<ChatSessionState> 
     load_chat_session_state_from_dir(&data_dir()?, session_id)
 }
 
-fn load_chat_session_state_from_dir(
+pub(crate) fn load_chat_session_state_from_dir(
     base_dir: &Path,
     session_id: &str,
 ) -> AppResult<ChatSessionState> {

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -108,9 +108,29 @@ pub fn resolve_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput>
     })
 }
 
-pub fn resolve_chat_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput> {
-    let state = crate::persistence::load_chat_session_state(&session_id.to_string()).ok()?;
-    chat_title_input_from_state(&state)
+/// Resolve the title input for a chat session.
+///
+/// `Ok(None)` means the session genuinely has nothing to title yet —
+/// `load_chat_session_state` already maps a missing file to an empty state — so
+/// the only failures reaching here are real ones: the state file is unreadable,
+/// corrupt, or belongs to another session. Those must not be reported as "no
+/// input", because the caller turns that into a silent `Skipped` for a title
+/// the user explicitly asked to generate.
+pub fn resolve_chat_title_input(
+    session_id: uuid::Uuid,
+) -> AppResult<Option<ResolvedTitleInput>> {
+    let state = crate::persistence::load_chat_session_state(&session_id.to_string())?;
+    Ok(chat_title_input_from_state(&state))
+}
+
+#[cfg(test)]
+fn resolve_chat_title_input_from_dir(
+    base_dir: &std::path::Path,
+    session_id: uuid::Uuid,
+) -> AppResult<Option<ResolvedTitleInput>> {
+    let state =
+        crate::persistence::load_chat_session_state_from_dir(base_dir, &session_id.to_string())?;
+    Ok(chat_title_input_from_state(&state))
 }
 
 pub fn chat_title_input_from_state(
@@ -220,20 +240,55 @@ pub fn resolve_native_session(session_id: uuid::Uuid) -> Option<agent_resume::Li
         }
     }
 
-    todos::locate_transcript_for(&session_id.to_string())
-        .ok()
-        .flatten()
-        .map(|path| agent_resume::LiveTranscript {
+    match todos::locate_transcript_for(&session_id.to_string()) {
+        Ok(path) => path.map(|path| agent_resume::LiveTranscript {
             path,
             kind: acorn_agent::AgentKind::Claude,
             id: session_id.to_string(),
-        })
+        }),
+        Err(error) => {
+            // Same treatment as the `live_transcript_checked` arm above: a
+            // lookup that failed is not evidence there is no transcript.
+            tracing::debug!(
+                %session_id,
+                error = %error,
+                "session title: transcript path lookup failed"
+            );
+            None
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use acorn_session::{Session, SessionKind};
+
+    #[test]
+    fn chat_title_input_reports_an_unreadable_state_file() {
+        let base = tempfile::tempdir().expect("temp data dir");
+        let session_id = uuid::Uuid::new_v4();
+
+        // A session with no state file yet has nothing to title — not an error.
+        assert!(
+            resolve_chat_title_input_from_dir(base.path(), session_id)
+                .expect("a missing state file is an empty session")
+                .is_none()
+        );
+
+        // A state file that exists but cannot be parsed is a real failure. It
+        // must not be reported as "nothing to title", which the command turns
+        // into a silent Skipped for a title the user asked to generate.
+        let chat_dir = base.path().join("chat-sessions");
+        std::fs::create_dir_all(&chat_dir).expect("create chat session dir");
+        std::fs::write(chat_dir.join(format!("{session_id}.json")), b"{ not json")
+            .expect("write corrupt state");
+
+        assert!(
+            resolve_chat_title_input_from_dir(base.path(), session_id).is_err(),
+            "an unreadable chat state must not look like an empty session"
+        );
+    }
 
     #[test]
     fn prompt_contains_transcript_context_and_rules() {


### PR DESCRIPTION
## Summary — first slice only

This branch is now **just the `session_titles` slice** of the original 1,040-line change. The rest follows separately; see below.

`resolve_chat_title_input` ended in `.ok()?`, so every failure became "nothing to title". `load_chat_session_state` already maps a missing file to an empty state, so the only failures reaching that `.ok()` were real: the state file is unreadable, corrupt, or belongs to another session.

The caller turns `None` into `GenerateSessionTitleStatus::Skipped`. A user who clicked "generate title" therefore got a silent no-op, with nothing saying the session state could not be read. It now propagates, and the three `resolve_title_input_for_session` call sites — all already in `AppResult` functions — carry it.

`resolve_native_session`'s `locate_transcript_for` lookup gets the same treatment its `live_transcript_checked` sibling already had: a failed lookup is logged rather than folded into "no transcript".

## Why the branch was split

The original revision does not rebase: 34 conflict hunks across `agent_history.rs`, `agent_resume.rs`, `agent_resume_persister.rs`, `commands.rs`, `session_titles.rs`, and `todos.rs`, because `main` has independently reworked all of them. Each hunk is a judgement between two implementations rather than a merge, so it has to be re-authored — and 1,000 lines of that across the resume and history flows is not reviewable in one pass.

Remaining slices, in order:

1. ~~`session_titles.rs`~~ — this PR
2. `todos.rs::locate_transcript_for` and its callers
3. `agent_resume.rs` + `agent_resume_persister.rs`
4. `agent_history.rs` — the largest
5. the frontend half (`AgentResumeModal.tsx`, `App.tsx`, `RightPanel.tsx`) once the backend contract settles

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` — 859 passed, 1 ignored
- [x] Negative control: restoring the swallow makes `chat_title_input_reports_an_unreadable_state_file` fail.

The test uses a `_from_dir` seam (`load_chat_session_state_from_dir` widened to `pub(crate)`) rather than `ACORN_DATA_DIR` so it does not race other env-mutating tests.
