### PR TITLE
fix(paths): preserve non-Unicode data overrides

### DIFF
--- a/src-tauri/crates/acorn-paths/src/lib.rs
+++ b/src-tauri/crates/acorn-paths/src/lib.rs
@@ -26,8 +26,15 @@ pub fn default_profile() -> &'static str {
 }
 
 fn profile_from_env() -> io::Result<Option<String>> {
-    let Ok(raw) = std::env::var(ENV_PROFILE) else {
-        return Ok(None);
+    let raw = match std::env::var(ENV_PROFILE) {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("{ENV_PROFILE} is not valid Unicode"),
+            ));
+        }
     };
     let profile = raw.trim();
     if profile.is_empty() {
@@ -75,13 +82,14 @@ fn ensure_private_dir(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+fn data_dir_override_from(raw: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    raw.filter(|value| !value.is_empty()).map(PathBuf::from)
+}
+
 pub fn data_dir() -> io::Result<PathBuf> {
-    if let Ok(over) = std::env::var(ENV_DATA_DIR_OVERRIDE) {
-        if !over.is_empty() {
-            let p = PathBuf::from(over);
-            ensure_private_dir(&p)?;
-            return Ok(p);
-        }
+    if let Some(path) = data_dir_override_from(std::env::var_os(ENV_DATA_DIR_OVERRIDE)) {
+        ensure_private_dir(&path)?;
+        return Ok(path);
     }
 
     let base = base_data_dir()?;
@@ -186,6 +194,22 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn data_dir_override_preserves_non_unicode_os_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let mut component = format!("acorn-paths-non-unicode-{}-", std::process::id()).into_bytes();
+        component.push(0xff);
+        let tmp = std::env::temp_dir().join(OsString::from_vec(component));
+
+        assert_eq!(
+            data_dir_override_from(Some(tmp.clone().into_os_string())),
+            Some(tmp)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn data_dir_tightens_existing_permissions() {
         let _guard = ENV_LOCK.lock().unwrap();
         let tmp =
@@ -213,6 +237,26 @@ mod tests {
         }
 
         assert_eq!(data_dir().unwrap_err().kind(), io::ErrorKind::InvalidInput);
+
+        unsafe { std::env::remove_var(ENV_PROFILE) };
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn profile_rejects_non_unicode_values() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_DATA_DIR_OVERRIDE);
+            std::env::set_var(ENV_PROFILE, OsString::from_vec(vec![0xff]));
+        }
+
+        assert_eq!(
+            effective_profile().unwrap_err().kind(),
+            io::ErrorKind::InvalidInput
+        );
 
         unsafe { std::env::remove_var(ENV_PROFILE) };
     }

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -347,7 +347,7 @@ fn copy_legacy_file_if_missing(
 }
 
 fn data_dir_override_is_set() -> bool {
-    std::env::var(acorn_paths::ENV_DATA_DIR_OVERRIDE)
+    std::env::var_os(acorn_paths::ENV_DATA_DIR_OVERRIDE)
         .map(|value| !value.is_empty())
         .unwrap_or(false)
 }
@@ -1399,6 +1399,26 @@ mod tests {
             std::env::set_var(
                 acorn_paths::ENV_DATA_DIR_OVERRIDE,
                 "/tmp/acorn-explicit-data-dir",
+            );
+            std::env::remove_var(acorn_paths::ENV_PROFILE);
+        }
+
+        assert!(!should_migrate_legacy_prod_files().unwrap());
+
+        unsafe { std::env::remove_var(acorn_paths::ENV_DATA_DIR_OVERRIDE) };
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn legacy_migration_skips_non_unicode_data_dir_override() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(
+                acorn_paths::ENV_DATA_DIR_OVERRIDE,
+                OsString::from_vec(vec![b'/', b't', b'm', b'p', b'/', 0xff]),
             );
             std::env::remove_var(acorn_paths::ENV_PROFILE);
         }


### PR DESCRIPTION
## Summary

Acorn now preserves OS-native data-directory paths and refuses invalid profile identifiers instead of silently selecting another runtime data location.

1. **Lossless data override resolution** — read `ACORN_DATA_DIR` as an OS string so valid non-Unicode paths are retained rather than treated as unset.
2. **Fail-closed profile selection** — return `InvalidInput` when `ACORN_PROFILE` is non-Unicode, matching its existing ASCII-only identifier contract.
3. **Migration consistency** — use the same OS-string presence check before legacy production migration so an explicit non-Unicode override cannot receive unrelated legacy files.
4. **Regression coverage** — cover non-Unicode path preservation, profile rejection, and migration suppression.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Explicit data location | A non-Unicode `ACORN_DATA_DIR` was silently ignored | The exact OS path is selected, or its filesystem error is surfaced |
| Profile selection | A non-Unicode `ACORN_PROFILE` silently fell back to the build default | Configuration fails with `InvalidInput` |
| Legacy migration | A non-Unicode override could be misclassified as unset | Explicit overrides always suppress legacy production migration |

## Design notes

- Path-valued configuration stays in `OsString`/`PathBuf`; it is not converted through UTF-8.
- `ACORN_PROFILE` remains a Unicode, ASCII-safe path segment because it is an identifier rather than an arbitrary path.
- The persistence migration guard deliberately shares the same `var_os` semantics as `acorn-paths::data_dir` so selection and migration cannot disagree.

## Test plan

- [x] `rustfmt --edition 2021 --check crates/acorn-paths/src/lib.rs src/persistence.rs`
- [x] `cargo test -p acorn-paths` — 8 passed
- [x] `cargo test --lib persistence::tests::legacy_migration_skips` — 2 passed
- [x] `cargo test --workspace` — all workspace and doc tests passed
- [x] `cargo clippy --workspace --all-targets` — completed with existing warnings only

## Notes

- `cargo fmt --all -- --check` currently reports a pre-existing formatting difference in `src-tauri/src/pty_env.rs` on `main`; this PR does not modify that file. Both changed Rust files pass direct `rustfmt --check`.
