### PR TITLE
fix(ipc): preserve non-Unicode socket overrides

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/paths.rs
+++ b/src-tauri/crates/acorn-daemon/src/paths.rs
@@ -49,7 +49,7 @@ pub fn data_dir() -> std::io::Result<PathBuf> {
 
 /// Daemon control socket path. Honors `ACORN_DAEMON_SOCKET` override.
 pub fn control_socket_path() -> std::io::Result<PathBuf> {
-    if let Ok(over) = std::env::var(ENV_DAEMON_SOCKET_OVERRIDE) {
+    if let Some(over) = std::env::var_os(ENV_DAEMON_SOCKET_OVERRIDE) {
         if !over.is_empty() {
             return Ok(PathBuf::from(over));
         }
@@ -59,7 +59,7 @@ pub fn control_socket_path() -> std::io::Result<PathBuf> {
 
 /// Daemon stream socket path. Honors `ACORN_DAEMON_STREAM_SOCKET` override.
 pub fn stream_socket_path() -> std::io::Result<PathBuf> {
-    if let Ok(over) = std::env::var(ENV_DAEMON_STREAM_OVERRIDE) {
+    if let Some(over) = std::env::var_os(ENV_DAEMON_STREAM_OVERRIDE) {
         if !over.is_empty() {
             return Ok(PathBuf::from(over));
         }
@@ -198,6 +198,29 @@ mod tests {
         std::fs::remove_file(tmp.join("crashes")).ok();
         std::fs::remove_dir_all(&tmp).ok();
         std::fs::remove_dir_all(&external).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn socket_overrides_preserve_non_unicode_os_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _g = ENV_LOCK.lock();
+        let control = PathBuf::from(OsString::from_vec(b"/tmp/acorn-control-\xff.sock".to_vec()));
+        let stream = PathBuf::from(OsString::from_vec(b"/tmp/acorn-stream-\xff.sock".to_vec()));
+        unsafe {
+            std::env::set_var(ENV_DAEMON_SOCKET_OVERRIDE, &control);
+            std::env::set_var(ENV_DAEMON_STREAM_OVERRIDE, &stream);
+        }
+
+        assert_eq!(control_socket_path().unwrap(), control);
+        assert_eq!(stream_socket_path().unwrap(), stream);
+
+        unsafe {
+            std::env::remove_var(ENV_DAEMON_SOCKET_OVERRIDE);
+            std::env::remove_var(ENV_DAEMON_STREAM_OVERRIDE);
+        }
     }
 
     #[test]

--- a/src-tauri/crates/acorn-ipc/src/socket_path.rs
+++ b/src-tauri/crates/acorn-ipc/src/socket_path.rs
@@ -17,7 +17,7 @@ const ENV_OVERRIDE: &str = "ACORN_IPC_SOCKET";
 /// Resolve the canonical socket path. Errors as a plain `String` so the CLI
 /// (which has no access to `AppError`) can print it directly.
 pub fn resolve() -> Result<PathBuf, String> {
-    if let Ok(override_path) = std::env::var(ENV_OVERRIDE) {
+    if let Some(override_path) = std::env::var_os(ENV_OVERRIDE) {
         if !override_path.is_empty() {
             return Ok(PathBuf::from(override_path));
         }
@@ -36,7 +36,7 @@ mod tests {
     fn env_override_takes_precedence() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         // SAFETY: serialized via ENV_LOCK and restored before returning.
-        let prev = std::env::var(ENV_OVERRIDE).ok();
+        let prev = std::env::var_os(ENV_OVERRIDE);
         unsafe {
             std::env::set_var(ENV_OVERRIDE, "/tmp/acorn-test.sock");
         }
@@ -50,12 +50,33 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn env_override_preserves_non_unicode_os_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let prev = std::env::var_os(ENV_OVERRIDE);
+        let expected = PathBuf::from(OsString::from_vec(b"/tmp/acorn-ipc-\xff.sock".to_vec()));
+        unsafe { std::env::set_var(ENV_OVERRIDE, &expected) };
+
+        assert_eq!(resolve().expect("override resolves"), expected);
+
+        unsafe {
+            match prev {
+                Some(value) => std::env::set_var(ENV_OVERRIDE, value),
+                None => std::env::remove_var(ENV_OVERRIDE),
+            }
+        }
+    }
+
     #[test]
     fn falls_back_to_data_dir() {
         let _guard = ENV_LOCK.lock().expect("env lock");
-        let prev = std::env::var(ENV_OVERRIDE).ok();
-        let prev_data_dir = std::env::var(acorn_paths::ENV_DATA_DIR_OVERRIDE).ok();
-        let prev_profile = std::env::var(acorn_paths::ENV_PROFILE).ok();
+        let prev = std::env::var_os(ENV_OVERRIDE);
+        let prev_data_dir = std::env::var_os(acorn_paths::ENV_DATA_DIR_OVERRIDE);
+        let prev_profile = std::env::var_os(acorn_paths::ENV_PROFILE);
         unsafe {
             std::env::remove_var(ENV_OVERRIDE);
             std::env::remove_var(acorn_paths::ENV_DATA_DIR_OVERRIDE);


### PR DESCRIPTION
## Summary

IPC endpoint overrides now preserve OS-native paths so every Acorn process connects to the explicitly configured endpoint instead of silently falling back.

1. **Legacy app IPC** — resolve `ACORN_IPC_SOCKET` through `var_os` and retain the exact `PathBuf`.
2. **Daemon control IPC** — apply the same lossless resolution to `ACORN_DAEMON_SOCKET`.
3. **Daemon stream IPC** — apply the same resolution to `ACORN_DAEMON_STREAM_SOCKET`.
4. **Regression coverage** — verify all three endpoint overrides retain non-Unicode path bytes and preserve test environment values losslessly.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| App/CLI IPC override | Non-Unicode paths were treated as unset | The configured endpoint is retained exactly |
| Daemon control connection | App and daemon could derive a fallback endpoint instead | Both use the explicit control path |
| Daemon stream connection | Stream traffic could target a fallback endpoint | The explicit stream path is preserved |

## Design notes

- Socket overrides are path-valued configuration, so they remain `OsString`/`PathBuf` throughout resolution.
- Empty override values retain the existing fallback behavior.
- This PR does not change endpoint precedence, named-pipe derivation, or socket binding semantics.

## Test plan

- [x] `rustfmt --edition 2021 --check crates/acorn-daemon/src/paths.rs crates/acorn-ipc/src/socket_path.rs`
- [x] `cargo test -p acorn-daemon paths::tests` — 4 passed
- [x] `cargo test -p acorn-ipc socket_path::tests` — 3 passed
- [x] `cargo test --workspace --quiet` — all workspace and doc tests passed
- [x] `cargo clippy --workspace --all-targets` — completed with existing warnings only

## Notes

- `cargo fmt --all -- --check` currently reports a pre-existing formatting difference in `src-tauri/src/pty_env.rs` on `main`; this PR does not modify that file. Both changed Rust files pass direct `rustfmt --check`.
