### PR TITLE
fix(shell): preserve non-Unicode shell paths

### DIFF
--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -131,7 +131,7 @@ fn shell_resolve(name: &str) -> AppResult<PathBuf> {
     }
     #[cfg(not(windows))]
     {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell = crate::shell_runtime::interactive_shell().program;
         // `command -v` reports aliases in interactive zsh, which is exactly the
         // shell mode we need for rc-loaded PATH. Prefer shell-specific external
         // command lookup first, then fall back to POSIX `command -v`.
@@ -156,7 +156,8 @@ printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' \"$_acorn_path\"",
             .output()
             .map_err(|e| {
                 AppError::Other(format!(
-                    "failed to invoke shell {shell} to resolve {name}: {e}"
+                    "failed to invoke shell {} to resolve {name}: {e}",
+                    shell.display()
                 ))
             })?;
         let stdout = String::from_utf8_lossy(&out.stdout);

--- a/src-tauri/src/shell_env.rs
+++ b/src-tauri/src/shell_env.rs
@@ -171,7 +171,7 @@ fn shell_capture() -> Option<HashMap<String, String>> {
     }
     #[cfg(not(windows))]
     {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell = crate::shell_runtime::interactive_shell().program;
         let script = build_capture_script(CAPTURED_VARS);
         let out = Command::new(&shell)
             .args(["-l", "-i", "-c", &script])
@@ -402,7 +402,7 @@ mod tests {
         // Re-purpose CAPTURED_VARS to include our marker var temporarily.
         let probe_vars = ["LANG", "ACORN_SHELL_ENV_TEST"];
         let script = build_capture_script(&probe_vars);
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+        let shell = crate::shell_runtime::interactive_shell().program;
         let out = Command::new(&shell)
             .args(["-l", "-i", "-c", &script])
             .output()

--- a/src-tauri/src/shell_runtime.rs
+++ b/src-tauri/src/shell_runtime.rs
@@ -25,12 +25,16 @@ pub fn interactive_shell() -> InteractiveShell {
     }
     #[cfg(not(windows))]
     {
-        let program = std::env::var_os("SHELL")
-            .filter(|value| !value.is_empty())
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("/bin/sh"));
-        shell_from_program(program)
+        shell_from_program(unix_shell_program(std::env::var_os("SHELL")))
     }
+}
+
+#[cfg(any(not(windows), test))]
+fn unix_shell_program(value: Option<std::ffi::OsString>) -> PathBuf {
+    value
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/bin/sh"))
 }
 
 fn shell_from_program(program: PathBuf) -> InteractiveShell {
@@ -176,5 +180,24 @@ mod tests {
             shell_from_program(PathBuf::from("/bin/zsh")).args,
             vec!["-l"]
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_non_unicode_shell_paths() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let expected = PathBuf::from(OsString::from_vec(b"/opt/shell-\xff".to_vec()));
+
+        assert_eq!(
+            unix_shell_program(Some(expected.clone().into_os_string())),
+            expected
+        );
+        assert_eq!(
+            unix_shell_program(Some(OsString::new())),
+            Path::new("/bin/sh")
+        );
+        assert_eq!(unix_shell_program(None), Path::new("/bin/sh"));
     }
 }


### PR DESCRIPTION
## Summary

Every Unix shell-dependent path now uses Acorn's OS-native shell resolver, preventing valid non-Unicode `SHELL` paths from silently becoming `/bin/sh`.

1. **CLI discovery** — resolve external agent CLIs with the same lossless shell program used by PTY startup.
2. **Environment capture** — launch login-shell environment capture through that shared program path.
3. **Diagnostic fidelity** — render shell invocation errors from `PathBuf` without requiring the path to be UTF-8.
4. **Regression coverage** — verify non-Unicode shell paths are preserved while missing and empty values still fall back to `/bin/sh`.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| CLI lookup | Non-Unicode `SHELL` was ignored and `/bin/sh` searched a different PATH | The configured shell performs lookup |
| PTY environment capture | Non-Unicode `SHELL` caused capture through `/bin/sh` | The configured shell captures its login environment |
| PTY startup | Already preserved the OS-native path | Remains unchanged and now shares behavior with both callers |

## Design notes

- `shell_runtime` remains the single source of truth for empty/missing fallback behavior.
- The shell path stays as `OsString`/`PathBuf` through process launch.
- Shell flags, capture format, CLI lookup script, and Windows behavior are unchanged.

## Test plan

- [x] `rustfmt --edition 2021 --check src/cli_resolver.rs src/shell_env.rs src/shell_runtime.rs`
- [x] `cargo test --lib shell_runtime::tests` — 3 passed
- [x] `cargo test --lib cli_resolver::tests` — 10 passed
- [x] `cargo test --lib shell_env::tests -- --test-threads=1` — 10 passed, 1 ignored
- [x] `cargo test --workspace --quiet -- --test-threads=1` — all workspace and doc tests passed
- [x] `cargo clippy --workspace --all-targets` — completed with existing warnings only

## Notes

- A parallel focused run exposed the existing shared `shell_env` test-cache race: `apply_to_command_layers_cached_path` observed another test's cached PATH. The module and full workspace both pass with one test thread; this PR does not change cache synchronization.
- `cargo fmt --all -- --check` currently reports a pre-existing formatting difference in `src-tauri/src/pty_env.rs` on `main`; this PR does not modify that file. All changed Rust files pass direct `rustfmt --check`.
