### PR TITLE
fix(settings): surface project settings access errors

### DIFF
--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -73,10 +73,17 @@ fn settings_path() -> AppResult<PathBuf> {
 
 fn load_all() -> AppResult<SettingsMap> {
     let path = settings_path()?;
-    if !path.exists() {
-        return Ok(SettingsMap::new());
-    }
-    let bytes = fs::read(&path)?;
+    load_all_from(&path)
+}
+
+fn load_all_from(path: &Path) -> AppResult<SettingsMap> {
+    let bytes = match fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(SettingsMap::new());
+        }
+        Err(err) => return Err(err.into()),
+    };
     serde_json::from_slice::<SettingsMap>(&bytes)
         .map_err(|err| AppError::Other(format!("failed to parse project settings: {err}")))
 }
@@ -222,6 +229,28 @@ mod tests {
                 .unwrap_or("")
                 .contains("GitHub-style pull request"));
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn settings_load_surfaces_parent_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let blocked = dir.path().join("blocked");
+        let path = blocked.join(PROJECT_SETTINGS_FILE);
+        fs::create_dir(&blocked).unwrap();
+        fs::write(&path, b"{}").unwrap();
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = load_all_from(&path);
+
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o700)).unwrap();
+        match result {
+            Err(AppError::Io(err)) => assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied),
+            other => panic!("expected permission error, got {other:?}"),
+        }
+        assert_eq!(fs::read(&path).unwrap(), b"{}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Project settings now distinguish a missing settings file from one that cannot be accessed, preventing updates from rebuilding state from an accidental empty map.

1. **Fail-closed loading:** read the settings file directly and treat only `NotFound` as an empty settings map.
2. **Error propagation:** preserve permission and other I/O failures for get, update, and remove call paths.
3. **Regression coverage:** verify an inaccessible parent directory returns `PermissionDenied` and leaves the existing settings file unchanged.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Inaccessible settings file | Could appear missing through `Path::exists` | Returns the underlying access error |
| Subsequent settings updates | Could overwrite from an empty in-memory map | Stop before the atomic write |
| Missing settings file | Starts with an empty map | Unchanged |

## Design notes

The JSON schema, parse-error behavior, and atomic writer are unchanged. The loader now follows the same missing-versus-inaccessible contract expected by mutating callers without adding a separate state layer.

## Test plan

- [x] `rustfmt --edition 2021 --check src-tauri/src/project_settings.rs`
- [x] `cargo test --lib project_settings::tests` — 6 passed
- [x] `cargo test --workspace --quiet -- --test-threads=1` — passed
- [x] `cargo clippy --workspace --all-targets` — passed with existing warnings

## Notes

The workspace-wide `cargo fmt --all -- --check` remains blocked by a pre-existing formatting difference in `src-tauri/src/pty_env.rs`; this PR does not modify that file.