### PR TITLE
fix(ipc): surface endpoint failures + retain accepted requests

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4577,13 +4577,15 @@ pub fn ipc_restart<R: Runtime>(
         handle.signal_stop();
         std::thread::sleep(std::time::Duration::from_millis(250));
     }
-    let new_handle = crate::ipc::server::start(app.clone(), state.inner().clone());
-    let started = new_handle.is_some();
-    *state.ipc_handle.lock() = new_handle;
-    if started {
-        Ok(())
-    } else {
-        Err("ipc server failed to start; see app logs for details".to_string())
+    match crate::ipc::server::start(app.clone(), state.inner().clone()) {
+        Ok(handle) => {
+            *state.ipc_handle.lock() = Some(handle);
+            Ok(())
+        }
+        Err(err) => {
+            *state.ipc_handle.lock() = None;
+            Err(format!("IPC server failed to start: {err}"))
+        }
     }
 }
 

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -107,25 +107,31 @@ const CONNECTION_POLL_INTERVAL: Duration = Duration::from_millis(5);
 /// shutdown handle on success, or `None` if bind failed (rest of the app
 /// remains usable). The listener is non-blocking and polls its `running`
 /// flag so `ipc_restart` can stop it without process-level signals.
-pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServerHandle> {
-    let path = match socket_path::resolve() {
-        Ok(p) => p,
-        Err(err) => {
-            tracing::warn!(error = %err, "ipc: could not resolve socket path; server disabled");
-            return None;
-        }
-    };
-    let listener = match acorn_local_ipc::bind(&path) {
-        Ok(l) => l,
-        Err(err) => {
-            tracing::warn!(
-                error = %err,
-                path = %path.display(),
-                "ipc: bind failed; server disabled",
-            );
-            return None;
-        }
-    };
+/// Spawn the IPC server on a dedicated background thread. The listener is
+/// non-blocking and polls its `running` flag so `ipc_restart` can stop it
+/// without process-level signals.
+///
+/// The error is returned rather than only logged: boot can ignore it and leave
+/// the rest of the app usable, while `ipc_restart` — which the user triggered —
+/// can tell them which step failed instead of pointing at the log file.
+pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Result<IpcServerHandle, String> {
+    let path = socket_path::resolve()
+        .map_err(|err| format!("could not resolve the IPC socket path: {err}"))?;
+    let listener = bind_listener(&path)?;
+    tracing::info!(path = %path.display(), "ipc: listening");
+
+    let running = Arc::new(AtomicBool::new(true));
+    let running_for_thread = running.clone();
+    std::thread::Builder::new()
+        .name("acorn-ipc-listener".to_string())
+        .spawn(move || run_listener(listener, app, state, running_for_thread))
+        .map_err(|err| format!("could not start the IPC listener thread: {err}"))?;
+    Ok(IpcServerHandle { running })
+}
+
+fn bind_listener(path: &Path) -> Result<Listener, String> {
+    let listener = acorn_local_ipc::bind(path)
+        .map_err(|err| format!("could not bind the IPC socket {}: {err}", path.display()))?;
     // Keep accepted streams nonblocking too. On Windows, `Accept` makes
     // interprocess toggle each connected named pipe back to blocking inside
     // `accept()`, which can race a newly connected client with ERROR_NO_DATA.
@@ -133,26 +139,14 @@ pub fn start<R: Runtime>(app: AppHandle<R>, state: AppState) -> Option<IpcServer
         // Required for the shutdown poll. Bail rather than fall back to
         // blocking accept — a blocking listener could never honour a stop
         // signal and would leak its thread on every restart.
-        tracing::warn!(
-            error = %err,
-            "ipc: set_nonblocking failed; server disabled",
-        );
-        return None;
+        drop(listener);
+        acorn_local_ipc::cleanup(path);
+        return Err(format!(
+            "could not set the IPC socket {} to non-blocking mode: {err}",
+            path.display()
+        ));
     }
-    tracing::info!(path = %path.display(), "ipc: listening");
-
-    let running = Arc::new(AtomicBool::new(true));
-    let running_for_thread = running.clone();
-    let spawn_result = std::thread::Builder::new()
-        .name("acorn-ipc-listener".to_string())
-        .spawn(move || run_listener(listener, app, state, running_for_thread));
-    match spawn_result {
-        Ok(_) => Some(IpcServerHandle { running }),
-        Err(err) => {
-            tracing::warn!(error = %err, "ipc: listener thread failed to start");
-            None
-        }
-    }
+    Ok(listener)
 }
 
 fn run_listener<R: Runtime>(
@@ -1149,6 +1143,32 @@ mod tests {
             std::env::temp_dir().join(format!("acorn-ipc-{label}-{}-{nanos}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_listener_surfaces_socket_parent_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let blocked = root.path().join("blocked");
+        let socket = blocked.join("ipc.sock");
+        std::fs::create_dir(&blocked).unwrap();
+        let original = std::fs::metadata(&blocked).unwrap().permissions();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = bind_listener(&socket);
+
+        let denied = matches!(
+            std::fs::metadata(&socket),
+            Err(ref error) if error.kind() == std::io::ErrorKind::PermissionDenied
+        );
+        std::fs::set_permissions(&blocked, original).unwrap();
+        if denied {
+            let error = result.expect_err("a denied socket parent must fail");
+            assert!(error.contains("could not bind the IPC socket"));
+            assert!(error.contains(&socket.display().to_string()));
+        }
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -704,7 +704,15 @@ pub fn run() {
             // listener thread; if bind fails it logs and the app keeps
             // running with IPC disabled. The returned handle lets
             // `ipc_restart` cycle the listener without process restart.
-            let handle = ipc::server::start(app.handle().clone(), state.inner().clone());
+            // Boot stays best-effort: a disabled IPC server must not stop the
+            // app from starting. `ipc_restart` surfaces the reason on demand.
+            let handle = match ipc::server::start(app.handle().clone(), state.inner().clone()) {
+                Ok(handle) => Some(handle),
+                Err(err) => {
+                    tracing::warn!(error = %err, "ipc: server disabled");
+                    None
+                }
+            };
             *state.ipc_handle.lock() = handle;
 
             // Resolve and cache the `acornd` binary location now so the


### PR DESCRIPTION
## Summary

`ipc::server::start` logged every failure and returned `None`. `ipc_restart` is an action the user triggers from the UI, but all it could answer with was `"ipc server failed to start; see app logs for details"` — whether the socket path could not be resolved, the bind was denied, the listener could not be made non-blocking, or the thread failed to spawn was invisible.

`start` now returns the reason. Boot stays best-effort and keeps the app usable with IPC disabled; `ipc_restart` reports the concrete step that failed.

`bind_listener` additionally cleans up the socket it just created when `set_nonblocking` fails, so a failed restart does not leave the endpoint behind for the next attempt to trip over.

## Note on the previous revision — rewritten, and two commits dropped

The branch was re-authored on current `main` rather than rebased, because three of its five commits collided with hardening `main` has since gained.

**Kept, but corrected:**

- `bind_listener` used `ListenerNonblockingMode::Accept`. `main` uses `Both`, and its comment explains why: *"On Windows, `Accept` makes interprocess toggle each connected named pipe back to blocking inside `accept()`, which can race a newly connected client with ERROR_NO_DATA."* `Both` is kept.
- The `acorn-ipc` diagnostic printed the socket path raw. `main` routes it through `terminal_safe_field(...)` to stop escape-sequence injection into the user's terminal. That is kept, and the marker-error string is sanitised the same way.

**Dropped — `fix(ipc): retain requests across worker spawn failures`:** it replaced the per-connection thread spawn with a `dispatch_connection` helper that ran the handler inline when the spawn failed. That drops `ConnectionPermit`, `main`'s cap on concurrent handlers, and running a handler inline on the accept thread lets one client stall the accept loop. Retaining a request across a spawn failure is worth doing, but it needs to keep the permit and stay off the accept thread.

**Dropped — `fix(ipc): preserve context and boot worker failures`:** it built on the commit above.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` — 850 passed, 1 ignored
- [x] `cargo test … -p acorn --lib bind_listener` — 1 passed

The new test skips its assertions when the sandbox still permits access to a `0o000` directory (root, or a filesystem without POSIX permissions), rather than failing spuriously there.
