### PR TITLE
fix(git): preserve repository discovery access failures

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11463,7 +11463,7 @@ pub async fn github_origin_slug(
 pub async fn is_git_repository(state: State<'_, AppState>, repo_path: String) -> AppResult<bool> {
     let repo_path = authorize_registered_repository(state.inner(), Path::new(&repo_path))?;
     run_blocking("is_git_repository", move || {
-        Ok(git_ops::is_git_repository(&repo_path))
+        git_ops::is_git_repository(&repo_path)
     })
     .await
 }

--- a/src-tauri/src/git_ops.rs
+++ b/src-tauri/src/git_ops.rs
@@ -1,9 +1,9 @@
-use git2::{DiffOptions, Repository};
+use git2::{DiffOptions, ErrorCode, Repository};
 use serde::Serialize;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
@@ -141,18 +141,48 @@ pub fn web_url_for_commit(repo_path: &Path, sha: &str) -> AppResult<Option<Strin
 /// layer (commit URLs, PR listing).
 pub fn github_owner_repo(repo_path: &Path) -> AppResult<Option<String>> {
     let repo = ensure_repo(repo_path)?;
+    // libgit2 may report an unreadable repository config as a missing remote.
+    // Open the repository-local config explicitly so access and parse failures
+    // stay distinguishable from a repository that genuinely has no `origin`.
+    let config_path = repo.commondir().join("config");
+    drop(File::open(&config_path).map_err(|err| {
+        AppError::Io(io::Error::new(
+            err.kind(),
+            format!(
+                "failed to open repository config at {}: {err}",
+                config_path.display()
+            ),
+        ))
+    })?);
+    drop(git2::Config::open(&config_path)?);
     let remote = match repo.find_remote("origin") {
         Ok(r) => r,
-        Err(_) => return Ok(None),
+        Err(err) if err.code() == ErrorCode::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
     };
-    let Ok(url) = remote.url() else {
-        return Ok(None);
-    };
+    let url = remote.url()?;
     Ok(parse_github_owner_repo(url))
 }
 
-pub fn is_git_repository(repo_path: &Path) -> bool {
-    Repository::discover(repo_path).is_ok()
+pub fn is_git_repository(repo_path: &Path) -> AppResult<bool> {
+    let start = match repo_path.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => repo_path.to_path_buf(),
+        Err(err) => {
+            return Err(AppError::Io(io::Error::new(
+                err.kind(),
+                format!(
+                    "failed to inspect repository path at {}: {err}",
+                    repo_path.display()
+                ),
+            )));
+        }
+    };
+    match Repository::discover(&start) {
+        Ok(_) => Ok(true),
+        Err(err) if err.code() == ErrorCode::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
 }
 
 fn parse_github_owner_repo(remote: &str) -> Option<String> {
@@ -1155,6 +1185,115 @@ mod tests {
         ));
         fs::create_dir_all(&dir).expect("create temp dir");
         dir
+    }
+
+    #[test]
+    fn repository_probe_distinguishes_non_repo_from_repo() {
+        let root = unique_temp_dir("repository-probe");
+
+        assert!(!is_git_repository(&root).expect("inspect non-repository"));
+        let repo = Repository::init(&root).expect("init repository");
+        assert!(is_git_repository(&root).expect("inspect repository"));
+
+        drop(repo);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repository_probe_surfaces_path_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_temp_dir("repository-probe-permission");
+        let blocked = root.join("blocked");
+        let candidate = blocked.join("candidate");
+        fs::create_dir_all(&candidate).expect("create candidate");
+        let original_permissions = fs::metadata(&blocked).unwrap().permissions();
+        fs::set_permissions(&blocked, fs::Permissions::from_mode(0o000))
+            .expect("deny repository parent access");
+
+        let result = is_git_repository(&candidate);
+
+        fs::set_permissions(&blocked, original_permissions).expect("restore repository access");
+        match result {
+            Err(AppError::Io(error)) => {
+                assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+                assert!(error
+                    .to_string()
+                    .contains("failed to inspect repository path"));
+            }
+            other => panic!("expected permission error, got {other:?}"),
+        }
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn github_origin_distinguishes_missing_remote_from_valid_remote() {
+        let root = unique_temp_dir("github-origin");
+        let repo = Repository::init(&root).expect("init repository");
+
+        assert_eq!(github_owner_repo(&root).unwrap(), None);
+        repo.remote("origin", "git@github.com:Acme/Widgets.git")
+            .expect("create origin");
+        assert_eq!(
+            github_owner_repo(&root).unwrap().as_deref(),
+            Some("Acme/Widgets")
+        );
+
+        drop(repo);
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn github_origin_surfaces_non_utf8_remote_url() {
+        let root = unique_temp_dir("github-origin-non-utf8");
+        let repo = Repository::init(&root).expect("init repository");
+        let config_path = repo.path().join("config");
+        drop(repo);
+        let mut config = fs::read(&config_path).expect("read repository config");
+        config.extend_from_slice(b"\n[remote \"origin\"]\n\turl = git@github.com:acme/");
+        config.push(0xff);
+        config.extend_from_slice(b".git\n");
+        fs::write(&config_path, config).expect("write non-UTF-8 origin");
+
+        match github_owner_repo(&root) {
+            Err(AppError::Git(error)) => {
+                assert!(error.to_string().to_ascii_lowercase().contains("utf-8"));
+            }
+            other => panic!("expected remote URL error, got {other:?}"),
+        }
+
+        fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn github_origin_surfaces_repository_config_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_temp_dir("github-origin-permission");
+        let repo = Repository::init(&root).expect("init repository");
+        repo.remote("origin", "git@github.com:acme/widgets.git")
+            .expect("create origin");
+        let config_path = repo.path().join("config");
+        drop(repo);
+        let original_permissions = fs::metadata(&config_path).unwrap().permissions();
+        fs::set_permissions(&config_path, fs::Permissions::from_mode(0o000))
+            .expect("deny repository config access");
+
+        let result = github_owner_repo(&root);
+
+        fs::set_permissions(&config_path, original_permissions).expect("restore config access");
+        match result {
+            Err(AppError::Io(error)) => {
+                assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+                assert!(error
+                    .to_string()
+                    .contains(&config_path.display().to_string()));
+            }
+            other => panic!("expected config access error, got {other:?}"),
+        }
+        fs::remove_dir_all(&root).ok();
     }
 
     fn commit_file(

--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -183,6 +183,7 @@ fn normalize_settings(mut settings: ProjectSettings) -> ProjectSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     fn with_data_dir(test: impl FnOnce(&Path)) {
         let dir = tempfile::tempdir().unwrap();

--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -98,24 +98,36 @@ fn save_all(settings: &SettingsMap) -> AppResult<()> {
     Ok(())
 }
 
-pub fn key_for_repo(repo_path: &Path) -> String {
-    if let Ok(Some(slug)) = git_ops::github_owner_repo(repo_path) {
-        return format!("github:{}", slug.to_ascii_lowercase());
+pub fn key_for_repo(repo_path: &Path) -> AppResult<String> {
+    if git_ops::is_git_repository(repo_path)? {
+        if let Some(slug) = git_ops::github_owner_repo(repo_path)? {
+            return Ok(format!("github:{}", slug.to_ascii_lowercase()));
+        }
     }
-    let path = repo_path
-        .canonicalize()
-        .unwrap_or_else(|_| repo_path.to_path_buf());
-    format!("path:{}", path.display())
+    let path = match repo_path.canonicalize() {
+        Ok(path) => path,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => repo_path.to_path_buf(),
+        Err(err) => {
+            return Err(AppError::Io(std::io::Error::new(
+                err.kind(),
+                format!(
+                    "failed to resolve project settings key for {}: {err}",
+                    repo_path.display()
+                ),
+            )));
+        }
+    };
+    Ok(format!("path:{}", path.display()))
 }
 
 pub fn get(repo_path: &Path) -> AppResult<ProjectSettingsRecord> {
-    let key = key_for_repo(repo_path);
+    let key = key_for_repo(repo_path)?;
     let settings = load_all()?.get(&key).cloned().unwrap_or_default();
     Ok(ProjectSettingsRecord { key, settings })
 }
 
 pub fn update(repo_path: &Path, settings: ProjectSettings) -> AppResult<ProjectSettingsRecord> {
-    let key = key_for_repo(repo_path);
+    let key = key_for_repo(repo_path)?;
     let settings = normalize_settings(settings);
     let mut all = load_all()?;
     all.insert(key.clone(), settings.clone());
@@ -124,7 +136,7 @@ pub fn update(repo_path: &Path, settings: ProjectSettings) -> AppResult<ProjectS
 }
 
 pub fn remove(repo_path: &Path) -> AppResult<()> {
-    let key = key_for_repo(repo_path);
+    let key = key_for_repo(repo_path)?;
     let mut all = load_all()?;
     if all.remove(&key).is_some() {
         save_all(&all)?;
@@ -221,6 +233,31 @@ mod tests {
                 .unwrap_or("")
                 .contains("GitHub-style pull request"));
         });
+    }
+
+    #[test]
+    fn github_repo_key_uses_normalized_origin_slug() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        repo.remote("origin", "https://github.com/Acme/Widgets.git")
+            .unwrap();
+
+        assert_eq!(key_for_repo(dir.path()).unwrap(), "github:acme/widgets");
+    }
+
+    #[test]
+    fn project_key_does_not_fall_back_after_remote_url_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let config_path = repo.path().join("config");
+        drop(repo);
+        let mut config = fs::read(&config_path).unwrap();
+        config.extend_from_slice(b"\n[remote \"origin\"]\n\turl = git@github.com:acme/");
+        config.push(0xff);
+        config.extend_from_slice(b".git\n");
+        fs::write(config_path, config).unwrap();
+
+        assert!(matches!(key_for_repo(dir.path()), Err(AppError::Git(_))));
     }
 
     #[test]

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -61,14 +61,60 @@ pub fn ensure_repo(path: &Path) -> AppResult<Repository> {
 }
 
 pub fn project_root_for_path(path: &Path) -> AppResult<PathBuf> {
-    if let Ok(repo) = Repository::discover(path) {
-        if let Some(workdir) = repo.workdir() {
-            return Ok(workdir
-                .canonicalize()
-                .unwrap_or_else(|_| workdir.to_path_buf()));
+    let path = path.canonicalize()?;
+    match Repository::discover(&path) {
+        Ok(repo) => {
+            let Some(workdir) = repo.workdir() else {
+                return Ok(path);
+            };
+            workdir.canonicalize().map_err(|err| {
+                AppError::Io(std::io::Error::new(
+                    err.kind(),
+                    format!(
+                        "failed to resolve repository workdir '{}': {err}",
+                        workdir.display()
+                    ),
+                ))
+            })
         }
+        Err(err)
+            if err.code() == git2::ErrorCode::NotFound
+                && !repository_marker_in_ancestry(&path)? =>
+        {
+            Ok(path)
+        }
+        Err(err) => Err(AppError::Git(err)),
     }
-    path.canonicalize().map_err(AppError::from)
+}
+
+/// Libgit2 can report a broken or inaccessible `.git` entry as `NotFound`.
+/// Before treating that code as proof a picked folder is not a repository,
+/// verify that no repository marker exists anywhere in its ancestry.
+fn repository_marker_in_ancestry(path: &Path) -> AppResult<bool> {
+    let metadata = std::fs::metadata(path)?;
+    let mut directory = if metadata.is_dir() {
+        Some(path)
+    } else {
+        path.parent()
+    };
+    while let Some(current) = directory {
+        let marker = current.join(".git");
+        match std::fs::symlink_metadata(&marker) {
+            Ok(_) => return Ok(true),
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(AppError::Io(std::io::Error::new(
+                    err.kind(),
+                    format!(
+                        "failed to inspect repository marker '{}': {err}",
+                        marker.display()
+                    ),
+                )));
+            }
+        }
+        directory = current.parent();
+    }
+    Ok(false)
 }
 
 fn walk_to_existing_ancestor(path: &Path) -> PathBuf {
@@ -1524,6 +1570,53 @@ mod tests {
             resolved.canonicalize().unwrap(),
             root.canonicalize().unwrap(),
         );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn project_root_for_path_preserves_broken_repository_marker_error() {
+        let root = unique_temp_dir("project-root-broken-marker");
+        let subdir = root.join("packages").join("web");
+        std::fs::create_dir_all(&subdir).expect("nested dirs");
+        std::fs::write(root.join(".git"), "gitdir: missing-admin-dir\n")
+            .expect("write broken git marker");
+
+        let error = project_root_for_path(&subdir)
+            .expect_err("a broken repository marker must not look like a non-Git folder");
+
+        assert!(matches!(error, AppError::Git(_)));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repository_marker_probe_preserves_directory_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_temp_dir("project-root-marker-permission");
+        let original_permissions = std::fs::metadata(&root)
+            .expect("read original permissions")
+            .permissions();
+        std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o000))
+            .expect("deny directory access");
+        let permission_denied = matches!(
+            std::fs::symlink_metadata(root.join(".git")),
+            Err(error) if error.kind() == ErrorKind::PermissionDenied
+        );
+        if !permission_denied {
+            std::fs::set_permissions(&root, original_permissions).unwrap();
+            std::fs::remove_dir_all(&root).ok();
+            return;
+        }
+
+        let result = repository_marker_in_ancestry(&root);
+
+        std::fs::set_permissions(&root, original_permissions).expect("restore directory access");
+        let error = result.expect_err("marker access failure must be preserved");
+        assert!(matches!(
+            error,
+            AppError::Io(ref error) if error.kind() == ErrorKind::PermissionDenied
+        ));
         std::fs::remove_dir_all(&root).ok();
     }
 


### PR DESCRIPTION
## Summary

`git_ops::is_git_repository` was `Repository::discover(repo_path).is_ok()`, so a directory Acorn could not inspect was reported as "not a git repository". It now returns `AppResult<bool>` and preserves the access error, with the same treatment applied to project-root discovery, `project_settings::key_for_repo`, and the worktree probes that shared the pattern.

## Note on the previous revision — one commit was dropped

This branch had a second commit, `fix(git): preserve SSH alias probe errors`, which is **not** included. It was written against the older `is_github_host(host, resolve_ssh_alias)` shape that shelled out to `ssh -G <host>` to resolve a remote's host alias. `main` has since removed that call deliberately:

> We must not use `ssh -G` here: the alias originates in a repository-controlled remote, and OpenSSH configuration evaluation can execute `Match exec` commands.

`main` now parses only a simple exact `Host` block out of `~/.ssh/config`, through `open_regular_nofollow` and bounded by `MAX_SSH_CONFIG_BYTES`. Rebasing that commit would have restored `ssh -G` on a repository-controlled value, so it was skipped rather than resolved.

The same commit also loosened the slug check from `validate_github_slug` to `owner_repo.contains('/')`, which `main` is stricter about.

If the SSH-alias probe errors are still worth surfacing, that should be a fresh change on top of `main`'s config-parsing implementation.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` — 840 passed, 1 ignored
- [x] `grep -n '"-G"' src-tauri/src/git_ops.rs` — no match; the `ssh -G` path is not reintroduced
- [x] `validate_github_slug` still gates remote parsing

The test module in `project_settings.rs` needed `use std::fs;` added: `main` dropped the module-level import when it moved to `read_bounded_regular_file`, and this branch's new test uses it.
