### PR TITLE
fix(capabilities): surface CLI discovery access failures

### DIFF
--- a/src-tauri/src/agent_capabilities.rs
+++ b/src-tauri/src/agent_capabilities.rs
@@ -115,8 +115,7 @@ pub fn discover(provider: SessionAgentProvider) -> GoalAgentCapabilities {
 
 fn discover_codex() -> GoalAgentCapabilities {
     let provider = SessionAgentProvider::Codex;
-    let installed = cli_resolver::resolve("codex").is_ok();
-    if !installed {
+    if let Err(error) = cli_resolver::resolve("codex") {
         return GoalAgentCapabilities {
             provider,
             installed: false,
@@ -124,17 +123,26 @@ fn discover_codex() -> GoalAgentCapabilities {
             source: GoalAgentCapabilitySource::Unavailable,
             models: Vec::new(),
             effort_options: Vec::new(),
-            warning: Some("`codex` CLI was not found in the login shell PATH".to_string()),
+            warning: Some(format!("Codex CLI discovery failed: {error}")),
         };
     }
 
-    let version = cli_version("codex").ok();
+    let (version, version_warning) = match cli_version("codex") {
+        Ok(version) => (Some(version), None),
+        Err(error) => (
+            None,
+            Some(format!("Codex version discovery failed: {error}")),
+        ),
+    };
     match codex_model_catalog() {
         Ok(catalog) => {
             let (models, effort_options) = convert_codex_catalog(catalog);
-            let warning = models
-                .is_empty()
-                .then(|| "Codex app-server returned an empty model catalog".to_string());
+            let warning = combine_warnings([
+                version_warning,
+                models
+                    .is_empty()
+                    .then(|| "Codex app-server returned an empty model catalog".to_string()),
+            ]);
             GoalAgentCapabilities {
                 provider,
                 installed: true,
@@ -145,27 +153,32 @@ fn discover_codex() -> GoalAgentCapabilities {
                 warning,
             }
         }
-        Err(error) => GoalAgentCapabilities {
-            provider,
-            installed: true,
-            version,
-            source: GoalAgentCapabilitySource::Fallback,
-            models: Vec::new(),
-            effort_options: Vec::new(),
-            warning: Some(format!("Codex model discovery failed: {error}")),
-        },
+        Err(error) => {
+            let warning = combine_warnings([
+                version_warning,
+                Some(format!("Codex model discovery failed: {error}")),
+            ]);
+            GoalAgentCapabilities {
+                provider,
+                installed: true,
+                version,
+                source: GoalAgentCapabilitySource::Fallback,
+                models: Vec::new(),
+                effort_options: Vec::new(),
+                warning,
+            }
+        }
     }
 }
 
 fn discover_claude() -> GoalAgentCapabilities {
     let provider = SessionAgentProvider::Claude;
-    let installed = cli_resolver::resolve("claude").is_ok();
     let fallback_efforts = fallback_claude_efforts();
     let fallback_models = claude_models_from_help("")
         .into_iter()
         .map(|alias| claude_model_capability(alias, fallback_efforts.clone()))
         .collect();
-    if !installed {
+    if let Err(error) = cli_resolver::resolve("claude") {
         return GoalAgentCapabilities {
             provider,
             installed: false,
@@ -173,14 +186,24 @@ fn discover_claude() -> GoalAgentCapabilities {
             source: GoalAgentCapabilitySource::Unavailable,
             models: fallback_models,
             effort_options: fallback_efforts,
-            warning: Some("`claude` CLI was not found in the login shell PATH".to_string()),
+            warning: Some(format!("Claude CLI discovery failed: {error}")),
         };
     }
 
-    let version = cli_version("claude").ok();
+    let (version, version_warning) = match cli_version("claude") {
+        Ok(version) => (Some(version), None),
+        Err(error) => (
+            None,
+            Some(format!("Claude version discovery failed: {error}")),
+        ),
+    };
     let help = match cli_output("claude", &["--help"]) {
         Ok(help) => help,
         Err(error) => {
+            let warning = combine_warnings([
+                version_warning,
+                Some(format!("Claude capability discovery failed: {error}")),
+            ]);
             return GoalAgentCapabilities {
                 provider,
                 installed: true,
@@ -188,7 +211,7 @@ fn discover_claude() -> GoalAgentCapabilities {
                 source: GoalAgentCapabilitySource::Fallback,
                 models: fallback_models,
                 effort_options: fallback_efforts,
-                warning: Some(format!("Claude capability discovery failed: {error}")),
+                warning,
             };
         }
     };
@@ -210,8 +233,13 @@ fn discover_claude() -> GoalAgentCapabilities {
         source: GoalAgentCapabilitySource::ClaudeCliHelp,
         models,
         effort_options: efforts,
-        warning: None,
+        warning: version_warning,
     }
+}
+
+fn combine_warnings(warnings: impl IntoIterator<Item = Option<String>>) -> Option<String> {
+    let combined = warnings.into_iter().flatten().collect::<Vec<_>>().join(" ");
+    (!combined.is_empty()).then_some(combined)
 }
 
 fn cli_version(name: &str) -> Result<String, String> {
@@ -653,5 +681,17 @@ mod tests {
         let mut oversized = std::io::Cursor::new(oversized);
         let error = read_bounded_utf8_line(&mut oversized, APP_SERVER_MAX_LINE_BYTES).unwrap_err();
         assert!(error.contains("exceeded"));
+    }
+
+    #[test]
+    fn combines_independent_discovery_failures_without_dropping_context() {
+        assert_eq!(
+            combine_warnings([
+                Some("version lookup: permission denied".to_string()),
+                Some("model lookup: access denied".to_string()),
+            ]),
+            Some("version lookup: permission denied model lookup: access denied".to_string())
+        );
+        assert_eq!(combine_warnings([None, None]), None);
     }
 }

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -367,11 +367,7 @@ fn run_oneshot_in_dir_cancellable_with_transport_and_environment(
     prompt_transport: PromptTransport,
     environment: CommandEnvironment,
 ) -> AppResult<String> {
-    let resolved = cli_resolver::resolve(command).map_err(|_| {
-        AppError::Other(format!(
-            "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
-        ))
-    })?;
+    let resolved = resolve_ai_cli(command, settings_label)?;
     let mut command_args = args.to_vec();
     if prompt_transport == PromptTransport::Argument {
         command_args.push(prompt.to_string());
@@ -456,11 +452,7 @@ fn run_streaming_in_dir_cancellable_with_transport<F>(
 where
     F: FnMut(AiProcessStreamEvent<'_>),
 {
-    let resolved = cli_resolver::resolve(command).map_err(|_| {
-        AppError::Other(format!(
-            "`{command}` not found. Install the configured AI CLI or change the provider in {settings_label}."
-        ))
-    })?;
+    let resolved = resolve_ai_cli(command, settings_label)?;
     let mut command_args = args.to_vec();
     if prompt_transport == PromptTransport::Argument {
         command_args.push(prompt.to_string());
@@ -521,6 +513,17 @@ where
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn resolve_ai_cli(command: &str, settings_label: &str) -> AppResult<std::path::PathBuf> {
+    cli_resolver::resolve(command)
+        .map_err(|error| ai_cli_resolution_error(command, settings_label, error))
+}
+
+fn ai_cli_resolution_error(command: &str, settings_label: &str, error: AppError) -> AppError {
+    AppError::Other(format!(
+        "AI CLI discovery failed for `{command}`: {error}; change the provider in {settings_label} if this command is unavailable."
+    ))
 }
 
 fn wait_with_timeout(
@@ -1222,6 +1225,23 @@ mod tests {
 
         assert_eq!(output, b"123456");
         assert!(err.to_string().contains("exceeded the 6 byte output limit"));
+    }
+
+    #[test]
+    fn ai_cli_resolution_error_preserves_the_original_diagnostic() {
+        let error = ai_cli_resolution_error(
+            "codex",
+            "Agent settings",
+            AppError::Other(
+                "failed to read login shell configuration: permission denied".to_string(),
+            ),
+        );
+        let message = error.to_string();
+
+        assert!(message.contains("AI CLI discovery failed for `codex`"));
+        assert!(message.contains("permission denied"));
+        assert!(message.contains("failed to read login shell configuration"));
+        assert!(message.contains("Agent settings"));
     }
 
     #[test]

--- a/src-tauri/src/cli_resolver.rs
+++ b/src-tauri/src/cli_resolver.rs
@@ -194,20 +194,12 @@ printf '<<<ACORN_CLI_PATH>>>%s<<<END>>>' \"$_acorn_path\"",
                     shell.display()
                 ))
             })?;
-        let stdout = String::from_utf8_lossy(&out.stdout);
-        let extracted = extract_path(&stdout).map(str::trim).unwrap_or("");
-        if extracted.is_empty() {
-            return Err(AppError::Other(format!(
-            "`{name}` not found in your shell PATH. Install it and ensure it's available in your login shell."
-        )));
-        }
-        let path = PathBuf::from(extracted);
-        if !path.is_absolute() {
-            return Err(AppError::Other(format!(
-                "shell returned a non-absolute path for `{name}`: {extracted}"
-            )));
-        }
-        Ok(path)
+        resolve_from_shell_output(
+            name,
+            &String::from_utf8_lossy(&out.stdout),
+            &String::from_utf8_lossy(&out.stderr),
+            &out.status.to_string(),
+        )
     }
 }
 
@@ -226,34 +218,82 @@ fn windows_resolve(name: &str) -> AppResult<PathBuf> {
             "failed to invoke where.exe to resolve {name}: {err}"
         ))
     })?;
-    first_existing_windows_command(&output.stdout).ok_or_else(|| {
-        AppError::Other(format!(
-            "`{name}` not found in PATH. Install it and ensure it is available to Windows."
-        ))
-    })
+    if let Some(path) = first_existing_windows_command(&output.stdout)? {
+        return Ok(path);
+    }
+    if !output.status.success() && output.status.code() != Some(1) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        let detail = if stderr.is_empty() {
+            output.status.to_string()
+        } else {
+            format!("{}: {stderr}", output.status)
+        };
+        return Err(AppError::Other(format!(
+            "where.exe failed while resolving `{name}`: {detail}"
+        )));
+    }
+    Err(AppError::Other(format!(
+        "`{name}` not found in PATH. Install it and ensure it is available to Windows."
+    )))
+}
+
+#[cfg(windows)]
+fn windows_where_exe() -> AppResult<PathBuf> {
+    let Some(system_root) = std::env::var_os("SystemRoot") else {
+        return Ok(PathBuf::from("where.exe"));
+    };
+    let candidate = PathBuf::from(system_root)
+        .join("System32")
+        .join("where.exe");
+    match candidate.metadata() {
+        Ok(metadata) if metadata.is_file() => Ok(candidate),
+        Ok(_) => Ok(PathBuf::from("where.exe")),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(PathBuf::from("where.exe"))
+        }
+        Err(error) => Err(AppError::Other(format!(
+            "failed to inspect Windows command resolver {}: {error}",
+            candidate.display()
+        ))),
+    }
 }
 
 /// Select the first executable path emitted by `where.exe`. Windows editor
 /// shims are commonly `.cmd`/`.bat` files, so retain those alongside native
 /// executables while rejecting extensionless Unix shims and PowerShell scripts.
 #[cfg(any(windows, test))]
-fn first_existing_windows_command(stdout: &[u8]) -> Option<PathBuf> {
-    String::from_utf8_lossy(stdout)
+fn first_existing_windows_command(stdout: &[u8]) -> AppResult<Option<PathBuf>> {
+    for path in String::from_utf8_lossy(stdout)
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .map(PathBuf::from)
-        .find(|path| {
-            let launchable_extension = path
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| {
-                    ["exe", "com", "cmd", "bat"]
-                        .iter()
-                        .any(|candidate| extension.eq_ignore_ascii_case(candidate))
-                });
-            path.is_absolute() && path.is_file() && launchable_extension
-        })
+    {
+        let launchable_extension = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                ["exe", "com", "cmd", "bat"]
+                    .iter()
+                    .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+            });
+        if !path.is_absolute() || !launchable_extension {
+            continue;
+        }
+        match path.metadata() {
+            Ok(metadata) if metadata.is_file() => return Ok(Some(path)),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(AppError::Other(format!(
+                    "failed to inspect Windows command candidate {}: {error}",
+                    path.display()
+                )))
+            }
+        }
+    }
+    Ok(None)
 }
 
 /// Pull the resolved-path payload out of the marker we wrap around
@@ -266,6 +306,39 @@ fn extract_path(stdout: &str) -> Option<&str> {
     let rest = &stdout[start..];
     let end = rest.find(end_marker)?;
     Some(&rest[..end])
+}
+
+#[cfg(any(not(windows), test))]
+fn resolve_from_shell_output(
+    name: &str,
+    stdout: &str,
+    stderr: &str,
+    status: &str,
+) -> AppResult<PathBuf> {
+    let extracted = extract_path(stdout).ok_or_else(|| {
+        let stderr = stderr.trim();
+        let detail = if stderr.is_empty() {
+            format!("login shell exited with {status}")
+        } else {
+            format!("login shell exited with {status}: {stderr}")
+        };
+        AppError::Other(format!(
+            "failed to resolve `{name}` because the {detail} before returning a CLI path"
+        ))
+    })?;
+    let extracted = extracted.trim();
+    if extracted.is_empty() {
+        return Err(AppError::Other(format!(
+            "`{name}` not found in your shell PATH. Install it and ensure it's available in your login shell."
+        )));
+    }
+    let path = PathBuf::from(extracted);
+    if !path.is_absolute() {
+        return Err(AppError::Other(format!(
+            "shell returned a non-absolute path for `{name}`: {extracted}"
+        )));
+    }
+    Ok(path)
 }
 
 /// Test-only helper to manipulate the cache directly. Production code should
@@ -313,6 +386,35 @@ mod tests {
     }
 
     #[test]
+    fn shell_output_preserves_startup_errors_when_markers_are_missing() {
+        let error = resolve_from_shell_output(
+            "codex",
+            "shell banner only",
+            "zsh: /private/.zshrc: Permission denied",
+            "exit status: 1",
+        )
+        .expect_err("missing markers must remain a shell failure");
+        let message = error.to_string();
+
+        assert!(message.contains("Permission denied"), "got: {message}");
+        assert!(message.contains("exit status: 1"), "got: {message}");
+        assert!(!message.contains("not found in your shell PATH"));
+    }
+
+    #[test]
+    fn shell_output_keeps_empty_markers_as_a_missing_cli() {
+        let error = resolve_from_shell_output(
+            "codex",
+            "<<<ACORN_CLI_PATH>>><<<END>>>",
+            "",
+            "exit status: 0",
+        )
+        .expect_err("an empty path must remain a missing CLI");
+
+        assert!(error.to_string().contains("not found in your shell PATH"));
+    }
+
+    #[test]
     fn windows_command_output_accepts_cmd_shims_and_skips_ps1() {
         let directory = tempfile::tempdir().unwrap();
         let extensionless = directory.path().join("code");
@@ -329,9 +431,29 @@ mod tests {
         );
 
         assert_eq!(
-            first_existing_windows_command(output.as_bytes()),
+            first_existing_windows_command(output.as_bytes()).unwrap(),
             Some(command)
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn windows_command_output_preserves_candidate_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let command = directory.path().join("code.cmd");
+        std::fs::write(&command, b"@echo off").unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let output = format!("{}\r\n", command.display());
+        let result = first_existing_windows_command(output.as_bytes());
+
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let error = result.expect_err("inaccessible candidate must remain an error");
+        assert!(error
+            .to_string()
+            .contains("failed to inspect Windows command candidate"));
     }
 
     #[test]

--- a/src/components/AutonomousGoalDialog.tsx
+++ b/src/components/AutonomousGoalDialog.tsx
@@ -1637,13 +1637,21 @@ export function AutonomousGoalDialog({
                   <Notice
                     tone={
                       selectedAgentCapabilities?.installed === false ||
-                      selectedAgentCapabilities?.source === "fallback"
+                      selectedAgentCapabilities?.source === "fallback" ||
+                      selectedAgentCapabilities?.warning
                         ? "neutral"
                         : "info"
                     }
                     density="compact"
                   >
-                    {capabilityStatusText()}
+                    <span className="flex flex-col gap-1">
+                      <span>{capabilityStatusText()}</span>
+                      {selectedAgentCapabilities?.warning ? (
+                        <span data-goal-capability-warning>
+                          {selectedAgentCapabilities.warning}
+                        </span>
+                      ) : null}
+                    </span>
                   </Notice>
 
                   {modelConfig.single_model ? (

--- a/src/components/GraphSessionDialog.tsx
+++ b/src/components/GraphSessionDialog.tsx
@@ -32,6 +32,7 @@ import {
   Modal,
   ModalFooter,
   ModalHeader,
+  Notice,
   Select,
   TextInput,
   type SelectItem,
@@ -79,6 +80,9 @@ export function GraphSessionDialog({
   const [agentCapabilities, setAgentCapabilities] =
     useState<GoalAgentCapabilities | null>(null);
   const [capabilitiesLoading, setCapabilitiesLoading] = useState(false);
+  const [capabilitiesError, setCapabilitiesError] = useState<string | null>(
+    null,
+  );
   const [customModel, setCustomModel] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -92,6 +96,7 @@ export function GraphSessionDialog({
     );
     setAgentCapabilities(null);
     setCapabilitiesLoading(false);
+    setCapabilitiesError(null);
     setCustomModel(false);
     setSubmitting(false);
     setError(null);
@@ -103,18 +108,23 @@ export function GraphSessionDialog({
     if (!hasModelCatalog(provider)) {
       setAgentCapabilities(null);
       setCapabilitiesLoading(false);
+      setCapabilitiesError(null);
       return;
     }
     let cancelled = false;
     setAgentCapabilities(null);
     setCapabilitiesLoading(true);
+    setCapabilitiesError(null);
     void api
       .getGoalAgentCapabilities(provider)
       .then((capabilities) => {
         if (!cancelled) setAgentCapabilities(capabilities);
       })
-      .catch(() => {
-        if (!cancelled) setAgentCapabilities(null);
+      .catch((capabilityError: unknown) => {
+        if (!cancelled) {
+          setAgentCapabilities(null);
+          setCapabilitiesError(String(capabilityError));
+        }
       })
       .finally(() => {
         if (!cancelled) setCapabilitiesLoading(false);
@@ -133,6 +143,7 @@ export function GraphSessionDialog({
     draft.objective.trim().length > 0 &&
     validation.valid &&
     !submitting;
+  const capabilityWarning = agentCapabilities?.warning ?? capabilitiesError;
 
   const modelOptions = useMemo<SelectItem[]>(() => {
     const models = agentCapabilities?.models ?? [];
@@ -411,6 +422,16 @@ export function GraphSessionDialog({
               )}
             </Field>
           </div>
+          {capabilityWarning ? (
+            <Notice
+              tone="neutral"
+              density="compact"
+              className="col-span-2"
+              data-graph-capability-warning
+            >
+              {capabilityWarning}
+            </Notice>
+          ) : null}
         </div>
         <GraphPresetToolbar
           graph={draft}

--- a/tests/e2e/capability-errors.spec.ts
+++ b/tests/e2e/capability-errors.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+test("shows CLI discovery access errors in Loop model settings", async ({
+  page,
+  tauri,
+}) => {
+  await tauri.respond("list_projects", [PROJECT]);
+  await tauri.handle("get_goal_agent_capabilities", (args) => ({
+    provider: args?.provider === "claude" ? "claude" : "codex",
+    installed: false,
+    version: null,
+    source: "unavailable",
+    models: [],
+    effort_options: [],
+    warning: "CLI discovery failed: Permission denied while reading ~/.zshrc",
+  }));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Project demo" }).hover();
+  await page
+    .getByRole("button", { name: "Create session in this project" })
+    .click();
+  await page
+    .getByRole("menuitem", { name: "New Loop session", exact: true })
+    .click();
+
+  const dialog = page.getByRole("dialog", { name: "New Loop session" });
+  await dialog
+    .getByRole("button", { name: "Agent & Model", exact: true })
+    .click();
+
+  await expect(dialog.locator("[data-goal-capability-warning]")).toContainText(
+    "Permission denied while reading ~/.zshrc",
+  );
+});
+
+test("shows CLI discovery access errors in Graph model settings", async ({
+  page,
+  tauri,
+}) => {
+  await tauri.respond("list_projects", [PROJECT]);
+  await tauri.handle("get_goal_agent_capabilities", (args) => ({
+    provider: args?.provider === "claude" ? "claude" : "codex",
+    installed: false,
+    version: null,
+    source: "unavailable",
+    models: [],
+    effort_options: [],
+    warning: "CLI discovery failed: Permission denied while reading ~/.zshrc",
+  }));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Project demo" }).hover();
+  await page
+    .getByRole("button", { name: "Create session in this project" })
+    .click();
+  await page.getByRole("menuitem", { name: "New Graph session" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "New Graph session" });
+  await expect(dialog.locator("[data-graph-capability-warning]")).toContainText(
+    "Permission denied while reading ~/.zshrc",
+  );
+});


### PR DESCRIPTION
## Summary

CLI discovery failures now keep their real cause and remain visible wherever users configure Loop or Graph agents.

1. **Preserve resolver failures.** Distinguish an empty resolver marker (CLI genuinely absent) from a missing marker (login-shell startup failure), retain shell stderr/status, and propagate Windows resolver/candidate metadata access errors.
2. **Retain every capability diagnostic.** Preserve CLI resolution, version, and model/help discovery failures instead of replacing or discarding earlier errors.
3. **Preserve execution diagnostics.** Keep resolver access and login-shell failures intact when one-shot or streaming AI execution starts, instead of replacing them with a generic not-installed message.
4. **Show actionable errors.** Render backend capability warnings in both Loop agent/model settings and the Graph session dialog, including command-level failures.
5. **Protect the user-visible contract.** Add browser coverage proving permission errors reach both configuration surfaces.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Login-shell access failure | Reported as CLI not installed | Reports the shell status and original access error |
| Version + model discovery | Version failure silently discarded | Independent failures are combined in one warning |
| Loop agent settings | Generic unavailable/fallback text only | Generic status plus the actionable backend warning |
| Graph agent settings | Capability failures hidden | Capability warning displayed in the dialog |
| Windows command probing | Inaccessible resolver/candidate treated as absent | Access error remains distinguishable from absence |
| AI execution startup | Resolver access failure reported as CLI not installed | Original resolver diagnostic reaches chat, title, and generation callers with settings context |

## Design notes

- `GoalAgentCapabilities` remains the compatibility boundary: discovery still returns fallback models where available, while `warning` carries diagnostics. This avoids turning a recoverable catalog failure into a blocked session-creation flow.
- One-shot and streaming AI execution share the same resolver wrapper, so every native generation surface retains the resolver failure before any child process is started.
- The resolver treats a present-but-empty marker as the only positive “not found” signal on Unix. Missing markers mean the login shell did not complete Acorn's resolver script and therefore retain status/stderr.
- Windows keeps `where.exe` exit code 1 as the normal no-match result, while resolver metadata failures, candidate metadata failures, and abnormal `where.exe` exits propagate.
- PR #797 also touches the Unix shell program line in `cli_resolver.rs`; the behaviors are independent and any merge conflict should be mechanical.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml cli_resolver::tests -- --test-threads=1` — 13 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml agent_capabilities::tests -- --test-threads=1` — 3 passed.
- [x] `cargo test -p acorn --lib ai::tests -- --test-threads=1` — 17 passed after adding execution-path coverage.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace -- --test-threads=1` — app 752 passed, 1 ignored; all workspace and doc tests passed.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets` — passed with pre-existing warnings only.
- [x] `cargo check -p acorn` and `cargo clippy -p acorn --lib` — passed after the execution-path update with pre-existing warnings only.
- [x] `pnpm run typecheck` — passed.
- [x] `pnpm test` — 1,350 passed.
- [x] `pnpm exec playwright test tests/e2e/capability-errors.spec.ts` — 2 passed.
- [x] `pnpm test:e2e` — 327 passed.
- [x] `rustfmt --edition 2021 --check src-tauri/src/agent_capabilities.rs src-tauri/src/cli_resolver.rs src-tauri/src/ai.rs` — passed.
- [x] `git diff --check` — passed.

## Notes

- Clippy reports existing warnings outside this change; this PR adds no new clippy warning.
