### PR TITLE
fix(theme): preserve background files + surface storage access errors

### DIFF
--- a/src/lib/background.test.ts
+++ b/src/lib/background.test.ts
@@ -165,6 +165,26 @@ describe("importBackgroundImage", () => {
     ).rejects.toThrow(/Invalid managed background image path/);
     expect(tauriFsMock.remove).not.toHaveBeenCalled();
   });
+
+  it("surfaces a failed removal instead of reporting success", async () => {
+    tauriFsMock.readDir.mockResolvedValue([
+      { name: "abcd1234.png", isFile: true, isDirectory: false },
+    ]);
+    tauriFsMock.remove.mockRejectedValue(new Error("permission denied"));
+
+    await expect(
+      removeBackgroundImage("backgrounds/abcd1234.png"),
+    ).rejects.toThrow(/permission denied/);
+  });
+
+  it("stays a no-op when the image is already gone", async () => {
+    tauriFsMock.readDir.mockResolvedValue([]);
+
+    await expect(
+      removeBackgroundImage("backgrounds/abcd1234.png"),
+    ).resolves.toBeUndefined();
+    expect(tauriFsMock.remove).not.toHaveBeenCalled();
+  });
 });
 
 describe("backgroundCssVarsForState", () => {

--- a/src/lib/background.ts
+++ b/src/lib/background.ts
@@ -140,8 +140,18 @@ export async function removeBackgroundImage(
     throw new Error("Invalid managed background image path");
   }
   const dir = await ensureBackgroundsDir();
-  const absolute = await join(dir, relativePath.slice(BG_DIR.length + 1));
-  await remove(absolute).catch(() => {});
+  const name = relativePath.slice(BG_DIR.length + 1);
+  const absolute = await join(dir, name);
+
+  // Deleting the background is something the user asked for, so a failure has
+  // to reach them. Presence comes from the directory listing rather than
+  // `exists()`, which reports a metadata access failure as `false` and would
+  // turn "could not read it" into a silent success. An entry that is already
+  // gone stays a no-op.
+  const entries = await readDir(dir);
+  if (entries.some((entry) => entry.name === name)) {
+    await remove(absolute);
+  }
 }
 
 export function backgroundCssVarsForState(


### PR DESCRIPTION
## Summary

`removeBackgroundImage` ended in `await remove(absolute).catch(() => {})`. Deleting the background is something the user explicitly asked for, so swallowing the failure meant the UI reported it as removed while the file stayed on disk and kept rendering.

The failure now propagates. Presence is read from the directory listing rather than `exists()` — `exists()` delegates to `Path::exists()` and reports a metadata access failure as `false`, which would turn "could not read it" back into a silent success. An entry that is genuinely already gone stays a no-op, so repeated removal is still idempotent.

## Note on the previous revision

The rest of this branch is already on `main`, in a stronger form:

- `ensureRealDirectory(dir, "Background image directory")` replaces the raw `mkdir(dir, { recursive: true })` proposed here, and additionally rejects a symlinked directory.
- `writeNewPrivateFile` replaces `writeFile`, adding `createNew: true`, `mode: 0o600`, a short-write check, and cleanup of a partially written file.
- `isManagedBackgroundRelativePath` / `MANAGED_BACKGROUND_NAME_PATTERN` gate the path before anything is touched; this branch's `relativePathForEntry` helper had no equivalent validation.

Rebasing as written would have dropped those, so only the swallowed removal — which `main` still has — is changed.

The opportunistic cleanup loop in `saveBackgroundImage` keeps its `catch`: it is not an action the user requested, and a leftover file there is harmless. Worth noting its comment ("Directory may have just been created") is now stale, since `ensureBackgroundsDir()` runs immediately before it.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — passing
- [x] Negative control: restoring `.catch(() => {})` makes `surfaces a failed removal instead of reporting success` fail.

`stays a no-op when the image is already gone` pins the other half so the change does not make repeated removal throw.
