### PR TITLE
fix(theme): preserve user themes + surface storage access errors

### DIFF
--- a/src/lib/themes.catalog.test.ts
+++ b/src/lib/themes.catalog.test.ts
@@ -483,6 +483,33 @@ describe("catalog theme persistence", () => {
     expect(tauriFsMock.readTextFile).toHaveBeenCalledTimes(1);
   });
 
+  it("does not treat an inaccessible catalog as an empty one", async () => {
+    // `exists()` reports a metadata access failure as `false`. The directory
+    // listing still shows the file, so the read must be attempted and its
+    // access error surfaced — reporting "no installed themes" here would let
+    // the next write erase the real records.
+    tauriFsMock.exists.mockImplementation((path: string) =>
+      Promise.resolve(!path.endsWith("catalog.json")),
+    );
+    tauriFsMock.readDir.mockResolvedValue([
+      { name: "catalog.json", isFile: true, isDirectory: false },
+    ]);
+    // Only the catalog file is unreadable; the themes directory itself still
+    // passes its checks, so the rejection can only come from the metadata read.
+    const directoryStat = { isFile: false, isDirectory: true, isSymlink: false };
+    tauriFsMock.lstat.mockImplementation((path: string) =>
+      path.endsWith("catalog.json")
+        ? Promise.reject(new Error("permission denied"))
+        : Promise.resolve(directoryStat),
+    );
+
+    await expect(uninstallCatalogTheme("note")).rejects.toThrow(
+      /permission denied/,
+    );
+    expect(tauriFsMock.writeTextFile).not.toHaveBeenCalled();
+    expect(tauriFsMock.remove).not.toHaveBeenCalled();
+  });
+
   it("removes only files recorded as catalog-managed", async () => {
     tauriFsMock.readTextFile.mockResolvedValue(
       JSON.stringify({

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -7,6 +7,7 @@ import {
   readDir,
   remove,
   writeTextFile,
+  type DirEntry,
 } from "@tauri-apps/plugin-fs";
 import { create } from "zustand";
 import { ensureRealDirectory } from "./safeAppLocalFs";
@@ -510,9 +511,22 @@ function installedMetadataFromUnknown(value: unknown): InstalledThemeMetadata {
 
 async function readInstalledMetadata(
   dir: string,
+  entries?: DirEntry[],
 ): Promise<InstalledThemeMetadata> {
   const path = await join(dir, INSTALLED_METADATA_FILE);
-  if (!(await exists(path))) return emptyInstalledMetadata();
+  if (!(await exists(path))) {
+    // `exists()` delegates to `Path::exists()`, which reports a metadata
+    // access failure as `false`. Taking that at face value would report an
+    // unreadable catalog as empty, and the next write would overwrite the real
+    // installed-theme records. Confirm against the directory listing, which
+    // fails loudly instead of guessing.
+    const directoryEntries = entries ?? (await readDir(dir));
+    if (
+      !directoryEntries.some((entry) => entry.name === INSTALLED_METADATA_FILE)
+    ) {
+      return emptyInstalledMetadata();
+    }
+  }
   const contents = await readBoundedRegularTextFile(
     path,
     MAX_INSTALLED_THEME_METADATA_BYTES,
@@ -540,10 +554,8 @@ async function writeInstalledMetadata(
 export async function loadUserThemes(): Promise<AcornTheme[]> {
   try {
     const dir = await ensureThemesDir();
-    const [entries, metadata] = await Promise.all([
-      readDir(dir),
-      readInstalledMetadata(dir),
-    ]);
+    const entries = await readDir(dir);
+    const metadata = await readInstalledMetadata(dir, entries);
     const themes: AcornTheme[] = [];
 
     for (const entry of entries) {


### PR DESCRIPTION
## Summary

`readInstalledMetadata` gated its read on `exists(catalog.json)`. `exists()` delegates to `Path::exists()`, which reports a metadata access failure as `false`, so an unreadable catalog was indistinguishable from a missing one — it returned `emptyInstalledMetadata()`, and the next `writeInstalledMetadata` overwrote the real installed-theme records.

A negative `exists()` is now confirmed against the directory listing before it is accepted. `readDir` fails loudly on a directory it cannot list, and when the entry is present the read proceeds through `readBoundedRegularTextFile` and surfaces its own access error. `loadUserThemes` already lists the directory, so it passes that listing in instead of paying for a second one.

## Note on the previous revision

The rest of this branch is already on `main`, in a stronger form:

- `ensureRealDirectory(dir, …)` replaces the `mkdir(dir, { recursive: true })` proposed here, and additionally rejects a symlinked themes directory.
- `readBoundedRegularTextFile` replaces the `stat` + plain `readTextFile` pair, adding a `MAX_INSTALLED_THEME_METADATA_BYTES` bound, a symlink check, and a post-open identity re-check.

Rebasing the branch as written would have traded the bounded no-follow read for an unbounded `readTextFile`, so only the `exists()` gap — which `main` still has — is changed here.

`assertRegularFileOrMissing` keeps its `exists()` fast path: a false negative there cannot lose data. Install writes through `createNew: true` and would fail loudly if the file were really present, and uninstall skipping a removal leaves a stray file rather than dropping records.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — passing
- [x] Negative control: restoring the early `return emptyInstalledMetadata()` makes the new test fail with `"Theme note is not managed by the catalog"`, confirming it exercises the metadata read rather than an earlier check.

The first draft of that test mocked `lstat` to reject for every path, so it passed vacuously off `ensureThemesDir`'s directory check. It now rejects only for `catalog.json`.
