### PR TITLE
fix(terminal): surface clipboard read/write + image storage failures

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1430,14 +1430,9 @@ export function Terminal({
     };
     const readNativeClipboardImageFile =
       async (): Promise<ClipboardImageFile | null> => {
-        try {
-          const snapshot = await api.clipboardSnapshot();
-          logNativeClipboardSnapshot(snapshot);
-          return nativeClipboardImageFile(snapshot);
-        } catch (err: unknown) {
-          console.debug("[Terminal] native clipboard image snapshot failed", err);
-          return null;
-        }
+        const snapshot = await api.clipboardSnapshot();
+        logNativeClipboardSnapshot(snapshot);
+        return nativeClipboardImageFile(snapshot);
       };
     const normalizeTerminalUnicodeSpaces = () =>
       useSettings.getState().settings.experiments.normalizeTerminalUnicodeSpaces;
@@ -1514,6 +1509,10 @@ export function Terminal({
         })().catch((err: unknown) => {
           if (fallbackHadAttachment) {
             console.warn("[Terminal] clipboard image attachment failed", err);
+            showTranslatedErrorToast(
+              "toasts.terminal.clipboardImageSaveFailed",
+              err,
+            );
           } else {
             console.debug("[Terminal] clipboard image fallback skipped", err);
           }
@@ -1887,6 +1886,10 @@ export function Terminal({
         if (text.length > 0) {
           void writeClipboardText(text).catch((err: unknown) => {
             console.warn("[Terminal] clipboard write failed", err);
+            showTranslatedErrorToast(
+              "toasts.terminal.clipboardWriteFailed",
+              err,
+            );
           });
         }
         ev.preventDefault();
@@ -2317,7 +2320,11 @@ export function Terminal({
       const detail = (e as CustomEvent<TerminalPasteEventDetail>).detail;
       if (detail?.sessionId !== sessionId) return;
       void pasteNativeClipboard().catch((err: unknown) => {
-        console.debug("[Terminal] native paste failed", err);
+        console.warn("[Terminal] native paste failed", err);
+        showTranslatedErrorToast(
+          "toasts.terminal.clipboardReadFailed",
+          err,
+        );
       });
     };
     window.addEventListener(TERMINAL_PASTE_EVENT, onTerminalPaste);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -74,6 +74,11 @@
       "urlFailed": "Failed to open the external link:",
       "urlBlocked": "That link was blocked because it is not a safe external URL."
     },
+    "terminal": {
+      "clipboardReadFailed": "Failed to read the clipboard:",
+      "clipboardWriteFailed": "Failed to write to the clipboard:",
+      "clipboardImageSaveFailed": "Failed to save the clipboard image:"
+    },
     "pullRequests": {
       "mergeFailed": "Failed to merge pull request:",
       "closeFailed": "Failed to close pull request:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -74,6 +74,11 @@
       "urlFailed": "外部リンクを開けませんでした:",
       "urlBlocked": "安全な外部 URL ではないため、このリンクはブロックされました。"
     },
+    "terminal": {
+      "clipboardReadFailed": "クリップボードを読み取れませんでした:",
+      "clipboardWriteFailed": "クリップボードに書き込めませんでした:",
+      "clipboardImageSaveFailed": "クリップボード画像を保存できませんでした:"
+    },
     "pullRequests": {
       "mergeFailed": "プル リクエストのマージに失敗しました:",
       "closeFailed": "プルリクエストをクローズできませんでした:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -74,6 +74,11 @@
       "urlFailed": "외부 링크를 열지 못했습니다:",
       "urlBlocked": "안전한 외부 URL이 아니어서 링크를 차단했습니다."
     },
+    "terminal": {
+      "clipboardReadFailed": "클립보드를 읽지 못했습니다:",
+      "clipboardWriteFailed": "클립보드에 쓰지 못했습니다:",
+      "clipboardImageSaveFailed": "클립보드 이미지를 저장하지 못했습니다:"
+    },
     "pullRequests": {
       "mergeFailed": "Pull request를 병합하지 못했습니다:",
       "closeFailed": "Pull request를 닫지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -74,6 +74,11 @@
       "urlFailed": "无法打开外部链接：",
       "urlBlocked": "该链接不是安全的外部 URL，已被阻止。"
     },
+    "terminal": {
+      "clipboardReadFailed": "无法读取剪贴板：",
+      "clipboardWriteFailed": "无法写入剪贴板：",
+      "clipboardImageSaveFailed": "无法保存剪贴板图像："
+    },
     "pullRequests": {
       "mergeFailed": "无法合并拉取请求：",
       "closeFailed": "无法关闭拉取请求：",


### PR DESCRIPTION
## Summary

Three clipboard paths in `Terminal.tsx` failed silently:

- the native clipboard snapshot used for image paste swallowed its own error in a `try/catch` and returned `null`, so an access failure looked like "no image on the clipboard";
- the clipboard-image save fallback logged to `console.debug` only;
- native paste (clipboard read) logged to `console.debug` only.

Each now surfaces a toast (`clipboardImageSaveFailed`, `clipboardWriteFailed`, `clipboardReadFailed`), and the snapshot error propagates to the caller that already has a handler instead of being discarded at the source.

## Note on the previous revision

This branch also added `propagates attachment directory access errors before writing` to `clipboardImageAttachment.test.ts`. That test was dropped in this revision: the branch does not change `clipboardImageAttachment.ts`, and `main`'s implementation has since moved from `writeFile` to `open`, so the test's `expect(tauriFsMock.writeFile).not.toHaveBeenCalled()` assertion no longer describes the code under test. `main`'s existing cases for that module — the symlinked-directory and oversized-image rejections — are kept unchanged.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — passing
