### PR TITLE
fix(todos): preserve transcript access failures in the panel

### DIFF
--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -20,7 +20,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::fs::{File, Metadata};
-use std::io::{BufRead, BufReader, Read};
+use std::io::{self, BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
@@ -99,20 +99,25 @@ fn locate_transcript_in(
     session_id: &str,
     limits: ReplayLimits,
 ) -> AppResult<Option<PathBuf>> {
-    if !root.exists() {
-        return Ok(None);
+    match root.try_exists() {
+        Ok(true) => {}
+        Ok(false) => return Ok(None),
+        Err(error) => return Err(error.into()),
     }
     let target = transcript_file_name(session_id)?;
     // The configured root itself may intentionally be a symlink (for example,
     // to another volume). Resolve it once, then reject links below that root.
     let canonical_root = match root.canonicalize() {
         Ok(root) => root,
-        Err(_) => return Ok(None),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
     };
     let entries = match std::fs::read_dir(&canonical_root) {
         Ok(e) => e,
-        Err(_) => return Ok(None),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
     };
+    let mut first_error = None;
     for (index, entry) in entries.enumerate() {
         if index >= limits.max_project_dir_entries {
             return Err(limit_error(
@@ -120,28 +125,53 @@ fn locate_transcript_in(
                 limits.max_project_dir_entries,
             ));
         }
-        let Ok(entry) = entry else { continue };
-        let Ok(entry_type) = entry.file_type() else {
-            continue;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
+        };
+        let entry_type = match entry.file_type() {
+            Ok(entry_type) => entry_type,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
         };
         if !entry_type.is_dir() {
             continue;
         }
         let candidate = entry.path().join(&target);
-        let Ok(candidate_meta) = std::fs::symlink_metadata(&candidate) else {
-            continue;
+        let candidate_meta = match std::fs::symlink_metadata(&candidate) {
+            Ok(candidate_meta) => candidate_meta,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
         };
         if candidate_meta.file_type().is_symlink() || !candidate_meta.is_file() {
             continue;
         }
-        let Ok(resolved) = candidate.canonicalize() else {
-            continue;
+        let resolved = match candidate.canonicalize() {
+            Ok(resolved) => resolved,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                continue;
+            }
         };
         if resolved.starts_with(&canonical_root) {
             return Ok(Some(resolved));
         }
     }
-    Ok(None)
+    match first_error {
+        Some(error) => Err(error.into()),
+        None => Ok(None),
+    }
 }
 
 fn transcript_file_name(session_id: &str) -> AppResult<String> {
@@ -790,6 +820,40 @@ mod tests {
             .unwrap();
 
         assert_eq!(located, path.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn missing_projects_root_remains_an_empty_lookup() {
+        let parent = tempfile::tempdir().unwrap();
+        let missing = parent.path().join("missing-projects");
+
+        assert!(locate_transcript_in(&missing, SESSION_ID, small_limits())
+            .unwrap()
+            .is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn transcript_lookup_propagates_unreadable_project_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let unreadable = root.path().join("unreadable-project");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_dir(&unreadable).is_ok() {
+            std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+            return;
+        }
+
+        let result = locate_transcript_in(root.path(), SESSION_ID, small_limits());
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let error = result.expect_err("access failure must not look like a missing transcript");
+        assert!(matches!(
+            error,
+            AppError::Io(ref error) if error.kind() == io::ErrorKind::PermissionDenied
+        ));
     }
 
     #[cfg(unix)]

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -498,6 +498,55 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledWith(100);
   });
 
+  it("keeps the Todos tab visible when transcript access fails", async () => {
+    useAppStore.setState({
+      sessions: [
+        {
+          id: "local-todos",
+          name: "claude",
+          repo_path: "/Users/tester",
+          worktree_path: "/Users/tester",
+          branch: "HEAD",
+          isolated: false,
+          project_scoped: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "default",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+          agent_provider: "claude",
+        },
+      ],
+      activeSessionId: "local-todos",
+      activeTabId: "local-todos",
+      activeProject: REPO,
+      rightTab: "history",
+    });
+    mockApi.readSessionTodos.mockRejectedValue(
+      new Error("transcript permission denied"),
+    );
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+    await flushPromises();
+
+    expect(mockApi.readSessionTodos).toHaveBeenCalledWith(
+      "local-todos",
+      "/Users/tester",
+    );
+    const todosButton = buttonContaining(container, "Todos");
+    act(() => todosButton.click());
+    expect(container.textContent).toContain("transcript permission denied");
+  });
+
   it("filters agent history by provider", async () => {
     useAppStore.setState({ rightTab: "history" });
     mockApi.listAgentHistory.mockResolvedValue([

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -341,7 +341,7 @@ export function RightPanel() {
     active?.id ?? null,
     active?.worktree_path ?? null,
   );
-  const showTodos = todosState.todos.length > 0;
+  const showTodos = todosState.todos.length > 0 || todosState.error !== null;
   const isCodeGitRepo = useIsGitRepository(
     codePanelRepoPath,
     gitRepoProbeVersion,
@@ -522,7 +522,9 @@ export function RightPanel() {
       ) : null}
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
-          active && showTodos ? (
+          active && todosState.error ? (
+            <div className="p-3 text-xs text-danger">{todosState.error}</div>
+          ) : active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noTodos")} />


### PR DESCRIPTION
## Summary

This PR stops Claude todo transcript access failures from being presented as an empty todo list.

1. **Checked transcript discovery** — distinguishes a genuinely missing projects root, project directory, or transcript from canonicalization, traversal, metadata, and permission failures.
2. **Sibling-safe lookup** — remembers failures while scanning project directories so a later readable transcript can still win; if no match is provable, the first access failure is returned.
3. **Visible panel errors** — keeps the Todos tab available when its request fails and renders the existing request error instead of silently hiding the tab.
4. **Regression coverage** — covers missing roots, unreadable project directories, and the frontend error presentation.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Claude projects/transcript path is unreadable | Todos silently become empty and the tab disappears | The Todos tab remains available and shows the access error |
| Projects root or requested transcript is absent | Empty todo list | Empty todo list (unchanged) |
| Another project directory errors but a valid transcript is found | Lookup could discard the failure as empty | The readable exact match still wins |
| Transcript safety and replay budgets | Enforced | Unchanged |

## Design notes

- `NotFound` remains an optional lookup result because directories and transcripts may legitimately be absent or disappear during polling.
- Non-`NotFound` entry errors are retained while the bounded scan continues. This avoids letting an unrelated unreadable sibling mask a valid later match, without claiming an empty result when the scan was incomplete.
- The frontend hook already stored request failures. The rendering path now treats that error as a reason to retain the otherwise data-driven Todos tab.
- Status polling continues to treat marker-less transcript discovery as a best-effort heuristic; this PR changes the explicit Todos request, whose `AppResult` and UI already have an error contract.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib todos::tests` — 17 passed.
- [x] `pnpm exec vitest run src/components/RightPanel.test.tsx` — 21 passed.
- [x] `pnpm typecheck`
- [x] `pnpm build:frontend`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib -- --skip top_level_wrappers_create_one_provider_independent_invocation_owner --skip codex_wrapper_maps_current_tui_user_turn_to_turn_start` — 748 passed, 1 ignored, 2 intentionally filtered.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib agent_wrappers::tests::codex_wrapper_maps_current_tui_user_turn_to_turn_start -- --exact --nocapture` — passed on immediate isolated rerun.
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests` — passed with pre-existing warnings only.
- [x] `rustfmt --edition 2021 --check src-tauri/src/todos.rs`
- [x] `git diff --check`

## Notes

The repository's known `top_level_wrappers_create_one_provider_independent_invocation_owner` local harness hang remains excluded. One unrelated wrapper shell-capture test returned an empty fixture once during the first full run and passed immediately in isolation; the clean full run filters that pre-existing flake.
