### PR TITLE
fix(daemon): roll back failed stream attachments

### DIFF
--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -209,7 +209,7 @@ pub fn attach<R: Runtime>(
 
     let registry_for_thread = Arc::clone(&registry);
     let handle_for_thread = Arc::clone(&handle);
-    std::thread::Builder::new()
+    let spawn_result = std::thread::Builder::new()
         .name(format!("acorn-daemon-stream-{session_id}"))
         .spawn(move || {
             pump_loop(
@@ -221,8 +221,28 @@ pub fn attach<R: Runtime>(
                 stop,
                 handle_for_thread,
             );
-        })?;
-    Ok(())
+        });
+    complete_attachment_spawn(&registry, session_id, &handle, spawn_result)
+}
+
+/// Finish publishing an attachment only when its pump thread exists. The
+/// registry entry is inserted before spawning so a concurrent attach can
+/// supersede it safely; if the OS refuses the worker thread, remove only this
+/// generation instead of leaving a handle that makes later calls believe the
+/// dead attachment is live.
+fn complete_attachment_spawn(
+    registry: &StreamRegistry,
+    session_id: Uuid,
+    handle: &Arc<StreamAttachment>,
+    spawn_result: std::io::Result<std::thread::JoinHandle<()>>,
+) -> std::io::Result<()> {
+    match spawn_result {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            registry.drop_attachment_if_current(&session_id, handle);
+            Err(err)
+        }
+    }
 }
 
 fn pump_loop<R: Runtime>(
@@ -387,6 +407,28 @@ mod tests {
         assert!(registry.attachment_matches_output_token(&id, Some(7)));
         assert!(!registry.attachment_matches_output_token(&id, Some(8)));
         assert!(registry.attachment_matches_output_token(&id, None));
+    }
+
+    #[test]
+    fn failed_pump_spawn_removes_the_unstarted_attachment() {
+        let registry = StreamRegistry::new();
+        let id = Uuid::new_v4();
+        let handle = test_attachment();
+        registry.insert(id, Arc::clone(&handle));
+
+        let result = complete_attachment_spawn(
+            &registry,
+            id,
+            &handle,
+            Err(std::io::Error::other("forced pump spawn failure")),
+        );
+
+        assert_eq!(
+            result.expect_err("spawn failure is returned").kind(),
+            std::io::ErrorKind::Other
+        );
+        assert!(!registry.contains(&id));
+        assert!(handle.stop.load(Ordering::SeqCst));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Daemon stream attachment startup now fails cleanly instead of leaving a stale registry entry after the OS rejects its pump thread.

1. **Generation-safe rollback** — remove only the attachment generation whose pump failed to start.
2. **Retry recovery** — mark that unstarted handle stopped so later attach calls do not short-circuit against dead state.
3. **Regression coverage** — inject a worker-spawn failure and verify the error remains visible while the registry is restored.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Daemon stream socket connects but its pump thread cannot start | `pty_spawn` returns an error, but the registry still reports the session attached and retries can no-op | The exact spawn error is returned and the unstarted attachment is removed, so retry can attach normally |
| An older pump exits after a newer attachment replaces it | Older generation must not remove the replacement | Existing pointer-identity guard remains authoritative |

## Design notes

- Attachment insertion stays before thread creation because that preserves the existing supersession ordering for concurrent renderer generations.
- Rollback uses `drop_attachment_if_current`, the same pointer-identity contract used when pump threads exit. It cannot remove a replacement that won the session id in the meantime.
- The connected stream remains owned by the failed spawn closure and is closed when thread creation fails; no extra socket lifecycle is introduced.

## Test plan

- [x] `cargo test --lib daemon_stream::tests -- --test-threads=1` — 4 passed
- [x] `cargo clippy --lib --all-targets` — passed with pre-existing warnings
- [x] `rustfmt --edition 2021 --check src/daemon_stream.rs`
- [x] `git diff --check`
