### PR TITLE
fix(daemon): surface status and log-path access failures

### DIFF
--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -9,6 +9,7 @@
 //! sites do not have to know which side served them.
 
 use serde::Serialize;
+use std::io;
 use std::path::{Path, PathBuf};
 use tauri::State;
 use uuid::Uuid;
@@ -31,8 +32,8 @@ pub struct DaemonStatus {
     pub session_count_total: Option<u32>,
     pub session_count_alive: Option<u32>,
     /// Absolute path to the daemon log file (for "open log" buttons in
-    /// Settings). `None` when the data dir cannot be resolved on this
-    /// platform.
+    /// Settings). `None` when the data dir cannot be resolved; `last_error`
+    /// carries the reason.
     pub log_path: Option<String>,
     /// Last error message, if the most recent operation failed. Reset
     /// to `None` on a successful subsequent call.
@@ -42,9 +43,7 @@ pub struct DaemonStatus {
 #[tauri::command]
 pub fn daemon_status(state: State<'_, AppState>) -> DaemonStatus {
     let enabled = state.daemon_bridge.is_enabled();
-    let log_path = crate::daemon_bridge::data_dir_path()
-        .ok()
-        .map(|p| p.join("daemon.log").display().to_string());
+    let (log_path, log_path_error) = daemon_log_path(crate::daemon_bridge::data_dir_path());
 
     if !enabled {
         return DaemonStatus {
@@ -55,7 +54,7 @@ pub fn daemon_status(state: State<'_, AppState>) -> DaemonStatus {
             session_count_total: None,
             session_count_alive: None,
             log_path,
-            last_error: None,
+            last_error: log_path_error,
         };
     }
 
@@ -68,7 +67,7 @@ pub fn daemon_status(state: State<'_, AppState>) -> DaemonStatus {
             session_count_total: Some(snap.session_count_total),
             session_count_alive: Some(snap.session_count_alive),
             log_path,
-            last_error: None,
+            last_error: log_path_error,
         },
         Err(BridgeError::Disabled) => DaemonStatus {
             running: false,
@@ -78,7 +77,7 @@ pub fn daemon_status(state: State<'_, AppState>) -> DaemonStatus {
             session_count_total: None,
             session_count_alive: None,
             log_path,
-            last_error: None,
+            last_error: log_path_error,
         },
         Err(err) => DaemonStatus {
             running: false,
@@ -88,8 +87,26 @@ pub fn daemon_status(state: State<'_, AppState>) -> DaemonStatus {
             session_count_total: None,
             session_count_alive: None,
             log_path,
-            last_error: Some(err.to_string()),
+            last_error: combine_status_errors(Some(err.to_string()), log_path_error),
         },
+    }
+}
+
+fn daemon_log_path(data_dir: io::Result<PathBuf>) -> (Option<String>, Option<String>) {
+    match data_dir {
+        Ok(path) => (Some(path.join("daemon.log").display().to_string()), None),
+        Err(err) => (
+            None,
+            Some(format!("failed to resolve daemon log path: {err}")),
+        ),
+    }
+}
+
+fn combine_status_errors(primary: Option<String>, secondary: Option<String>) -> Option<String> {
+    match (primary, secondary) {
+        (Some(primary), Some(secondary)) => Some(format!("{primary}; {secondary}")),
+        (Some(error), None) | (None, Some(error)) => Some(error),
+        (None, None) => None,
     }
 }
 
@@ -343,7 +360,7 @@ fn agent_kind_to_str(k: AgentKind) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_daemon_adoption_paths;
+    use super::*;
     use crate::state::AppState;
 
     #[test]
@@ -390,5 +407,30 @@ mod tests {
         );
 
         assert!(validate_daemon_adoption_paths(&state, registered.path(), &linked).is_err());
+    }
+
+    #[test]
+    fn daemon_log_path_preserves_access_errors() {
+        let error = io::Error::new(io::ErrorKind::PermissionDenied, "permission denied");
+
+        let (path, last_error) = daemon_log_path(Err(error));
+
+        assert_eq!(path, None);
+        assert_eq!(
+            last_error.as_deref(),
+            Some("failed to resolve daemon log path: permission denied")
+        );
+    }
+
+    #[test]
+    fn daemon_status_preserves_bridge_and_log_path_errors() {
+        assert_eq!(
+            combine_status_errors(
+                Some("daemon connection failed".into()),
+                Some("failed to resolve daemon log path: permission denied".into()),
+            )
+            .as_deref(),
+            Some("daemon connection failed; failed to resolve daemon log path: permission denied")
+        );
     }
 }

--- a/src/components/BackgroundSessionsSettings.test.tsx
+++ b/src/components/BackgroundSessionsSettings.test.tsx
@@ -104,4 +104,26 @@ describe("BackgroundSessionsSettings polling", () => {
 
     expect(apiMocks.daemonStatus).toHaveBeenCalledTimes(2);
   });
+
+  it("renders operational errors returned with the daemon status", async () => {
+    apiMocks.daemonStatus.mockResolvedValue({
+      enabled: true,
+      running: false,
+      daemon_version: null,
+      uptime_seconds: null,
+      session_count_total: null,
+      session_count_alive: null,
+      log_path: null,
+      last_error: "failed to resolve daemon log path: permission denied",
+    } satisfies DaemonStatus);
+
+    await act(async () => {
+      root.render(<BackgroundSessionsSettings />);
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain(
+      "failed to resolve daemon log path: permission denied",
+    );
+  });
 });

--- a/src/components/BackgroundSessionsSettings.tsx
+++ b/src/components/BackgroundSessionsSettings.tsx
@@ -59,7 +59,7 @@ export function BackgroundSessionsSettings() {
     try {
       const snap = await api.daemonStatus();
       setStatus(snap);
-      setStatusError(null);
+      setStatusError(snap.last_error);
       if (snap.running) {
         try {
           const list = await api.daemonListSessions();

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -804,6 +804,7 @@ interface DaemonSnapshot {
   running: boolean;
   enabled: boolean;
   sessions: number | null;
+  lastError: string | null;
 }
 
 type DotState = "ok" | "down" | "muted";
@@ -1308,9 +1309,15 @@ function ServicesStatusButton() {
         running: snap.running,
         enabled: snap.enabled,
         sessions: snap.session_count_alive,
+        lastError: snap.last_error,
       });
-    } catch {
-      setDaemon({ running: false, enabled: true, sessions: null });
+    } catch (err) {
+      setDaemon({
+        running: false,
+        enabled: true,
+        sessions: null,
+        lastError: err instanceof Error ? err.message : String(err),
+      });
     }
   }, []);
 
@@ -1647,7 +1654,7 @@ function ServicesDropdown({
             actionIcon={<Settings size={11} />}
             actionDisabled={false}
             onAction={onOpenDaemonSettings}
-            error={null}
+            error={daemon?.lastError ?? null}
           />
         </li>
       </ul>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1039,10 +1039,10 @@ export const api = {
   },
   /**
    * Probe the `acornd` daemon. Backs the StatusBar daemon indicator and
-   * the Settings → Background sessions panel. Always resolves — when no
-   * daemon is reachable, fields collapse to `null` and `running` is
-   * `false`; rejection only on serialization failure (which should never
-   * happen for this shape).
+   * the Settings → Background sessions panel. Always resolves — operational
+   * failures are returned in `last_error`, unavailable fields collapse to
+   * `null`, and `running` is `false`; rejection only on serialization failure
+   * (which should never happen for this shape).
    */
   daemonStatus(): Promise<DaemonStatus> {
     return invoke<DaemonStatus>("daemon_status");

--- a/tests/e2e/daemon-status-errors.spec.ts
+++ b/tests/e2e/daemon-status-errors.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "./support";
+
+test.describe("daemon status errors", () => {
+  test("surfaces status access failures in the status bar and settings", async ({
+    page,
+    tauri,
+  }) => {
+    const error = "failed to resolve daemon log path: permission denied";
+    await tauri.respond("get_acorn_ipc_status", {
+      bundled_path: "/tmp/acorn-ipc",
+      bundled_exists: true,
+      socket_path: "/tmp/acorn-dev/ipc.sock",
+      server_running: true,
+      shim_paths: [],
+    });
+    await tauri.respond("daemon_status", {
+      running: false,
+      enabled: true,
+      daemon_version: null,
+      uptime_seconds: null,
+      session_count_total: null,
+      session_count_alive: null,
+      log_path: null,
+      last_error: error,
+    });
+
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Service status" }).click();
+    const menu = page.getByRole("menu");
+    await expect(menu).toContainText(error);
+
+    await menu.getByRole("button", { name: "Settings" }).click();
+    const settings = page.getByRole("dialog", { name: "Settings" });
+    await expect(settings).toBeVisible();
+    await expect(settings.getByText(error, { exact: true })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Daemon status probes now preserve access failures through the existing status contract and surface them where users can act on them.

1. **Preserve backend diagnostics** — keep data-directory/log-path resolution failures in `DaemonStatus.last_error`, and retain both the bridge error and path error when they occur together.
2. **Render status failures** — pass `last_error` through the status-bar service menu and Background sessions settings instead of clearing or discarding it; unexpected invoke rejections also retain their actual message.
3. **Cover the user flow** — add Rust helper tests, a component regression test, and a Playwright path from the status-bar error to the Sessions settings panel.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Daemon data directory cannot be resolved | Log path silently becomes unavailable | The reason is returned in `last_error` |
| Bridge and log-path probes both fail | Only the bridge failure survives | Both diagnostics are retained |
| Status response contains an operational error | Status bar and settings discard it | Both surfaces render the actionable message |
| Status invoke unexpectedly rejects | Status bar only shows a generic down state | Status bar retains and renders the rejection message |

## Design notes

- `daemon_status` remains an always-resolving snapshot API. Operational failures continue to travel in `last_error`, so existing polling callers do not need a control-flow change.
- Log-path failure is orthogonal to daemon running/enabled state. The existing state fields stay authoritative while the diagnostic is shown alongside them.
- When multiple independent probes fail, their messages are combined rather than allowing one failure to hide the other.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib daemon_commands::tests -- --test-threads=1` — 2 passed
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace -- --test-threads=1 --skip top_level_wrappers_create_one_provider_independent_invocation_owner` — all workspace tests passed; app library 749 passed, 1 ignored, 1 filtered
- [x] `pnpm test` — 1,351 passed
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm exec playwright test tests/e2e/statusbar.spec.ts tests/e2e/background-sessions.spec.ts tests/e2e/daemon-status-errors.spec.ts` — 15 passed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets` — passed with existing warnings
- [x] `rustfmt --edition 2021 --check src-tauri/src/daemon_commands.rs`
- [x] `git diff --check`

## Notes

- The full Playwright run became resource-degraded: 304 tests passed, while 22 tests across unrelated suites failed or timed out after prolonged 15–31 minute stalls. The complete affected status-bar/background-session surface was then rerun in isolation and all 15 tests passed.
- Workspace-wide `cargo fmt --all -- --check` reports an unchanged formatting mismatch in `src-tauri/src/pty_env.rs` under the installed Rust formatter. The Rust file changed by this PR passes a direct formatter check.
