### PR TITLE
fix(pull-requests): surface merge settings access failures

### DIFF
--- a/src/components/MergePullRequestDialog.tsx
+++ b/src/components/MergePullRequestDialog.tsx
@@ -73,6 +73,11 @@ function defaultPromptForMethod(method: MergeMethod): string {
   }
 }
 
+function projectSettingsLoadError(t: Translator, error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return `${dt(t, "dialogs.mergePullRequest.projectSettingsLoadFailed")} ${message}`;
+}
+
 function projectNameFromRepoPath(repoPath: string): string {
   const trimmed = repoPath.replace(/[\\/]+$/, "");
   return trimmed.split(/[\\/]/).pop() || repoPath;
@@ -168,6 +173,7 @@ export function MergePullRequestDialog({
   const [submitting, setSubmitting] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   const [adminMerge, setAdminMerge] = useState(false);
 
   const checksBlock = useMemo<ChecksBlock>(
@@ -196,6 +202,7 @@ export function MergePullRequestDialog({
     setPrompt(defaultPromptForMethod(nextMethod));
     setProjectSettingsOpen(false);
     setError(null);
+    setSettingsError(null);
     setSubmitting(false);
     setGenerating(false);
     setAdminMerge(false);
@@ -208,13 +215,14 @@ export function MergePullRequestDialog({
           setPrompt(savedPrompt);
         }
       })
-      .catch(() => {
-        // Project settings are optional; generation still works with defaults.
+      .catch((loadError) => {
+        if (cancelled) return;
+        setSettingsError(projectSettingsLoadError(t, loadError));
       });
     return () => {
       cancelled = true;
     };
-  }, [open, detail, repoPath]);
+  }, [open, detail, repoPath, t]);
 
   // Close also bumps the epoch — a generate kicked off right before the
   // user dismissed the dialog must be invalidated even if they never
@@ -317,8 +325,9 @@ export function MergePullRequestDialog({
         record.settings.pull_requests.generation_prompt ??
           defaultPromptForMethod(method),
       );
-    } catch {
-      // Project settings are optional; keep the current prompt fallback.
+      setSettingsError(null);
+    } catch (loadError) {
+      setSettingsError(projectSettingsLoadError(t, loadError));
     }
   }
 
@@ -511,6 +520,12 @@ export function MergePullRequestDialog({
                     </span>
                   </label>
                 </div>
+              </Notice>
+            ) : null}
+
+            {settingsError ? (
+              <Notice tone="danger" density="compact">
+                {settingsError}
               </Notice>
             ) : null}
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2404,6 +2404,7 @@
       "generateVia": "Generate via",
       "generateWithAi": "Generate with AI",
       "goToProjectSettings": "Go to project settings",
+      "projectSettingsLoadFailed": "Failed to load project settings:",
       "subjectPlaceholder": "Subject",
       "bodyPlaceholder": "Body (optional)",
       "rebaseMessageLocked": "Rebase replays the original commits onto the base branch - the commit messages are not customizable here.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2404,6 +2404,7 @@
       "generateVia": "経由で生成",
       "generateWithAi": "AIで生成",
       "goToProjectSettings": "プロジェクト設定に移動します",
+      "projectSettingsLoadFailed": "プロジェクト設定の読み込みに失敗しました:",
       "subjectPlaceholder": "件名",
       "bodyPlaceholder": "本体（オプション）",
       "rebaseMessageLocked": "Rebase は元のコミットをベース ブランチに再実行します。ここではコミット メッセージをカスタマイズできません。",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2404,6 +2404,7 @@
       "generateVia": "다음으로 생성:",
       "generateWithAi": "AI로 생성",
       "goToProjectSettings": "프로젝트 설정으로 이동",
+      "projectSettingsLoadFailed": "프로젝트 설정을 불러오지 못했습니다:",
       "subjectPlaceholder": "제목",
       "bodyPlaceholder": "본문(선택 사항)",
       "rebaseMessageLocked": "Rebase는 원래 커밋을 기본 브랜치 위에 다시 적용하므로 여기서 커밋 메시지를 변경할 수 없습니다.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2404,6 +2404,7 @@
       "generateVia": "生成方式",
       "generateWithAi": "使用 AI 生成",
       "goToProjectSettings": "转到项目设置",
+      "projectSettingsLoadFailed": "无法加载项目设置：",
       "subjectPlaceholder": "主题",
       "bodyPlaceholder": "正文（可选）",
       "rebaseMessageLocked": "Rebase 会将原始提交变基到基础分支，因此无法在此自定义提交消息。",

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1518,6 +1518,108 @@ test.describe("right panel: tab switching", () => {
     ).toHaveCount(0);
   });
 
+  test("surfaces project settings access errors without blocking the merge dialog", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 19,
+          title: "Settings access PR",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "fix/settings-access",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/19",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.respond("get_pull_request_detail", {
+      kind: "ok",
+      account: "test-account",
+      detail: {
+        number: 19,
+        title: "Settings access PR",
+        body: "Merge body",
+        state: "OPEN",
+        is_draft: false,
+        author: "im-ian",
+        head_branch: "fix/settings-access",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/19",
+        created_at: "2026-05-18T00:00:00Z",
+        updated_at: "2026-05-19T00:00:00Z",
+        merged_at: null,
+        additions: 4,
+        deletions: 1,
+        changed_files: 2,
+        mergeable: "MERGEABLE",
+        labels: [],
+        comments: [],
+        reviews: [],
+        checks: [],
+        commits: [],
+      },
+    });
+    await tauri.handle("get_project_settings", () => {
+      const w = window as unknown as { __projectSettingsCalls?: number };
+      w.__projectSettingsCalls = (w.__projectSettingsCalls ?? 0) + 1;
+      if (w.__projectSettingsCalls === 1) {
+        throw new Error("permission denied reading project-settings.json");
+      }
+      if (w.__projectSettingsCalls === 2) {
+        return {
+          key: "path:/tmp/demo",
+          settings: {
+            remember_after_close: true,
+            pull_requests: { generation_prompt: null },
+            worktrees: { base_branch: null },
+          },
+        };
+      }
+      throw new Error("permission denied reloading project-settings.json");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await expect(page.getByText("Settings access PR")).toBeVisible();
+    await page.getByText("Settings access PR").click({ button: "right" });
+    await page.getByRole("menuitem", { name: /^Merge…$/ }).click();
+
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Merge #19" }),
+    });
+    await expect(dialog.locator("input")).toHaveValue("Settings access PR");
+    await expect(dialog).toContainText("Failed to load project settings:");
+    await expect(dialog).toContainText(
+      "permission denied reading project-settings.json",
+    );
+    await expect(
+      dialog.getByRole("button", { name: "Merge", exact: true }),
+    ).toBeEnabled();
+
+    await dialog
+      .getByRole("button", { name: "Go to project settings" })
+      .click();
+    const projectSettings = page.getByRole("dialog", {
+      name: "Project Settings",
+    });
+    await expect(projectSettings).toBeVisible();
+    await projectSettings.getByRole("button", { name: "Close" }).click();
+    await expect(projectSettings).toHaveCount(0);
+    await expect(dialog).toContainText(
+      "permission denied reloading project-settings.json",
+    );
+  });
+
   test("opening PR close from the context menu shows a skeleton before details load", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

The pull-request merge dialog now reports project-settings access failures while preserving its safe default-prompt fallback and merge controls.

1. **Surface both read paths** — preserve failures from the initial project-settings load and the reload after closing Project Settings instead of silently discarding them.
2. **Keep fallback behavior usable** — hold settings failures separately from merge/generation failures, so the dialog continues with the standard prompt and does not disable merging.
3. **Localize the diagnostic** — add the settings-load label in all four supported languages.
4. **Cover the full UI flow** — exercise the PR context menu, initial access failure, enabled Merge action, Project Settings round trip, and reload failure.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Project settings file is inaccessible when opening Merge | Failure is silently treated like no custom prompt | Dialog shows the access error and uses the standard prompt |
| Settings reload fails after editing Project Settings | Failure is silently ignored | Dialog shows the reload error |
| Settings read fails but PR is otherwise mergeable | Merge remains possible without explaining the fallback | Merge remains possible and the fallback is explicit |

## Design notes

- Project settings are optional for the merge operation, so a read failure remains non-blocking. The new `settingsError` state is intentionally independent of destructive-action and AI-generation errors.
- The existing cancellation guard is retained for the asynchronous initial read, preventing a late failure from leaking into a closed or different dialog.
- A later successful settings reload clears the diagnostic and applies the saved prompt normally.

## Test plan

- [x] `pnpm exec vitest run --maxWorkers=1` — 112 files, 1,350 tests passed
- [x] `pnpm exec playwright test tests/e2e/right-panel.spec.ts --workers=1` — 38 passed
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `git diff --check`

## Notes

- The default parallel Vitest run hit local worker-start timeouts after 1,279 tests passed. Re-running the complete suite with one worker passed all 1,350 tests; no test assertion failed.
- An initial parallel Right Panel run similarly exhausted browser workers late in unrelated History cases. The complete file passed with one worker.
