### PR TITLE
fix(clipboard): surface copy permission failures

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -39,7 +39,7 @@ import { createPortal } from "react-dom";
 import { selectSessionsById, useAppStore } from "../store";
 import { FileViewer } from "./FileViewer";
 import { mediaKindFromPath } from "../lib/mediaFiles";
-import { writeClipboardText } from "../lib/clipboardText";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import { ChatPane } from "./ChatPane";
 import { WorkSummaryView } from "./WorkSummaryView";
 import { api } from "../lib/api";
@@ -1385,7 +1385,7 @@ function TabItem({
               : paneT(t, "pane.menu.worktreePath"),
           icon: <Copy size={12} />,
           onClick: () => {
-            void copyToClipboard(tabPath);
+            void copyTextWithFeedback(tabPath);
           },
         },
         {
@@ -1396,7 +1396,7 @@ function TabItem({
               : paneT(t, "pane.menu.worktreeName"),
           icon: <Copy size={12} />,
           onClick: () => {
-            void copyToClipboard(basename(tabPath));
+            void copyTextWithFeedback(basename(tabPath));
           },
         },
         ...(session
@@ -1405,7 +1405,7 @@ function TabItem({
                 label: paneT(t, "pane.menu.branchName"),
                 icon: <Copy size={12} />,
                 onClick: () => {
-                  void copyToClipboard(session.branch);
+                  void copyTextWithFeedback(session.branch);
                 },
                 disabled: !session.branch,
               },
@@ -1413,7 +1413,7 @@ function TabItem({
                 label: paneT(t, "pane.menu.sessionId"),
                 icon: <Copy size={12} />,
                 onClick: () => {
-                  void copyToClipboard(session.id);
+                  void copyTextWithFeedback(session.id);
                 },
               },
             ]
@@ -1900,13 +1900,14 @@ function buildPaneMenuItems({
         {
           label: paneT(t, "pane.menu.copyWorktreePath"),
           icon: <Copy size={12} />,
-          onClick: () => void copyToClipboard(activeSession.worktree_path),
+          onClick: () =>
+            void copyTextWithFeedback(activeSession.worktree_path),
         },
         {
           label: paneT(t, "pane.menu.copyWorktreeName"),
           icon: <Copy size={12} />,
           onClick: () =>
-            void copyToClipboard(basename(activeSession.worktree_path)),
+            void copyTextWithFeedback(basename(activeSession.worktree_path)),
         },
       ]
     : [];
@@ -1969,12 +1970,4 @@ function buildPaneMenuItems({
       disabled: totalPanes <= 1,
     },
   ];
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await writeClipboardText(text);
-  } catch (err) {
-    console.warn("[Pane] clipboard write failed", err);
-  }
 }

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -25,7 +25,7 @@ import {
 import { Panel } from "react-resizable-panels";
 import { PersistentGroup } from "./PersistentGroup";
 import { api } from "../lib/api";
-import { writeClipboardText } from "../lib/clipboardText";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -1762,7 +1762,7 @@ function CommitListItem({
     {
       label: dt(t, "dialogs.pullRequestDetail.copySha"),
       icon: <Copy size={12} />,
-      onClick: () => void writeClipboardText(commit.oid),
+      onClick: () => void copyTextWithFeedback(commit.oid),
     },
   ];
 
@@ -1927,7 +1927,7 @@ function CommitDetailView({
         <button
           type="button"
           onClick={() => {
-            void writeClipboardText(commit.oid);
+            void copyTextWithFeedback(commit.oid);
           }}
           className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
         >

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -47,6 +47,7 @@ import { Panel } from "react-resizable-panels";
 import { PersistentGroup } from "./PersistentGroup";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { api, FS_CHANGED_EVENT, type FsChangePayload } from "../lib/api";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import { writeClipboardText } from "../lib/clipboardText";
 import { cn } from "../lib/cn";
 import { openFileInEditor } from "../lib/editor";
@@ -2068,7 +2069,7 @@ function CommitsTab({
         <Tooltip label={rt(t, "rightPanel.tooltips.copySha")} side="bottom">
           <button
             type="button"
-            onClick={() => void writeClipboardText(c.sha)}
+            onClick={() => void copyTextWithFeedback(c.sha)}
             className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[10.5px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
             {c.short_sha}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -76,7 +76,7 @@ import {
   createEmptySessionAgentDetection,
 } from "../lib/agentContextMenu";
 import { api, type SessionRemoval } from "../lib/api";
-import { writeClipboardText } from "../lib/clipboardText";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import {
   EDIT_AUTONOMOUS_GOAL_SESSION_EVENT,
   NEW_AUTONOMOUS_GOAL_SESSION_EVENT,
@@ -2344,11 +2344,7 @@ function ProjectGroupView({
   }
 
   async function copyText(text: string) {
-    try {
-      await writeClipboardText(text);
-    } catch {
-      // ignore
-    }
+    await copyTextWithFeedback(text);
   }
 
   async function openInFinder(path: string) {
@@ -3199,7 +3195,7 @@ function ProjectFolderView({
             label: sidebarText(t, "sidebar.actions.copyPath"),
             icon: <Copy size={12} />,
             onClick: () => {
-              void copyToClipboard(folder.cwdPath);
+              void copyTextWithFeedback(folder.cwdPath);
             },
           },
           contextMenuGroupTitle(t, "danger"),
@@ -3599,32 +3595,33 @@ function SessionRow({
         {
           label: sidebarText(t, "sidebar.actions.worktreePath"),
           icon: <Copy size={12} />,
-          onClick: () => void copyToClipboard(session.worktree_path),
+          onClick: () => void copyTextWithFeedback(session.worktree_path),
         },
         ...(transcriptPath
           ? [
               {
                 label: sidebarText(t, "sidebar.actions.transcriptPath"),
                 icon: <Copy size={12} />,
-                onClick: () => void copyToClipboard(transcriptPath),
+                onClick: () => void copyTextWithFeedback(transcriptPath),
               } satisfies ContextMenuItem,
             ]
           : []),
         {
           label: sidebarText(t, "sidebar.actions.worktreeName"),
           icon: <Copy size={12} />,
-          onClick: () => void copyToClipboard(basename(session.worktree_path)),
+          onClick: () =>
+            void copyTextWithFeedback(basename(session.worktree_path)),
         },
         {
           label: sidebarText(t, "sidebar.actions.branchName"),
           icon: <Copy size={12} />,
-          onClick: () => void copyToClipboard(session.branch),
+          onClick: () => void copyTextWithFeedback(session.branch),
           disabled: !session.branch,
         },
         {
           label: sidebarText(t, "sidebar.actions.sessionId"),
           icon: <Copy size={12} />,
-          onClick: () => void copyToClipboard(session.id),
+          onClick: () => void copyTextWithFeedback(session.id),
         },
       ],
     },
@@ -3934,14 +3931,6 @@ function SessionStatusMarker({
       )}
     </span>
   );
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await writeClipboardText(text);
-  } catch (err) {
-    console.warn("[Sidebar] clipboard write failed", err);
-  }
 }
 
 interface RenameInputProps {
@@ -4636,7 +4625,7 @@ function LocalWorkspaceView({
       label: sidebarText(t, "sidebar.actions.copyPath"),
       icon: <Copy size={12} />,
       onClick: () => {
-        void copyToClipboard(folder.cwdPath);
+        void copyTextWithFeedback(folder.cwdPath);
       },
     },
     contextMenuGroupTitle(t, "danger"),
@@ -4970,14 +4959,14 @@ function LocalSessionRow({
     {
       label: sidebarText(t, "sidebar.actions.copyWorktreePath"),
       icon: <Copy size={12} />,
-      onClick: () => void copyToClipboard(session.worktree_path),
+      onClick: () => void copyTextWithFeedback(session.worktree_path),
     },
     ...(transcriptPath
       ? [
           {
             label: sidebarText(t, "sidebar.actions.copyTranscriptPath"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(transcriptPath),
+            onClick: () => void copyTextWithFeedback(transcriptPath),
           } satisfies ContextMenuItem,
         ]
       : []),

--- a/src/components/WorkSummaryView.test.tsx
+++ b/src/components/WorkSummaryView.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useToasts } from "../lib/toasts";
 import type { ChatSessionState, Session } from "../lib/types";
 import { makeWorkSummaryWorkspaceTab } from "../lib/workspaceTabs";
 
@@ -231,6 +232,7 @@ describe("WorkSummaryView", () => {
     root = createRoot(container);
     eventMocks.listeners.clear();
     eventMocks.listen.mockClear();
+    useToasts.getState().hide(undefined, { skipDismiss: true });
     mocks.fsGitStatus.mockResolvedValue({
       statuses: {
         [`${REPO}/src/App.tsx`]: {
@@ -261,6 +263,7 @@ describe("WorkSummaryView", () => {
     container.remove();
     restoreClipboard?.();
     restoreClipboard = null;
+    useToasts.getState().hide(undefined, { skipDismiss: true });
     vi.useRealTimers();
     vi.clearAllMocks();
   });
@@ -864,7 +867,6 @@ describe("WorkSummaryView", () => {
       )?.textContent,
     ).toContain("/Users/me/.codex/sessions/transcript-1.jsonl");
 
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     clipboardWriteText.mockRejectedValueOnce(new Error("denied"));
     await act(async () => {
       container
@@ -874,12 +876,8 @@ describe("WorkSummaryView", () => {
         .click();
       await Promise.resolve();
     });
-    expect(warn).toHaveBeenCalledWith(
-      "[WorkSummaryView] clipboard write failed",
-      expect.any(Error),
-    );
-    expect(container.textContent).not.toContain("denied");
-    warn.mockRestore();
+    const toasts = useToasts.getState().toasts;
+    expect(toasts[toasts.length - 1]?.message).toContain("denied");
 
     const copyButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Copy transcript path"]',

--- a/src/components/WorkSummaryView.tsx
+++ b/src/components/WorkSummaryView.tsx
@@ -25,7 +25,7 @@ import {
   type FsGitDiffStatsRequest,
   type FsGitStatus,
 } from "../lib/api";
-import { writeClipboardText } from "../lib/clipboardText";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import { cn } from "../lib/cn";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { fsChangeTouchesRoot } from "../lib/workSummaryInvalidation";
@@ -265,11 +265,7 @@ export function WorkSummaryView({
   }, [conversationIdentity]);
 
   const copyText = useCallback(async (text: string) => {
-    try {
-      await writeClipboardText(text);
-    } catch (err) {
-      console.warn("[WorkSummaryView] clipboard write failed", err);
-    }
+    await copyTextWithFeedback(text);
   }, []);
 
   const load = useCallback(async () => {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -47,7 +47,7 @@ import {
   X,
   XCircle,
 } from "lucide-react";
-import { writeClipboardText } from "../lib/clipboardText";
+import { copyTextWithFeedback } from "../lib/clipboardActions";
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { requestNewGraphSession } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
@@ -1468,32 +1468,32 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
           {
             label: sidebarText(t, "sidebar.actions.worktreePath"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.worktree_path),
+            onClick: () => void copyTextWithFeedback(session.worktree_path),
           },
           ...(transcriptPath
             ? [
                 {
                   label: sidebarText(t, "sidebar.actions.transcriptPath"),
                   icon: <Copy size={12} />,
-                  onClick: () => void copyToClipboard(transcriptPath),
+                  onClick: () => void copyTextWithFeedback(transcriptPath),
                 } satisfies ContextMenuItem,
               ]
             : []),
           {
             label: sidebarText(t, "sidebar.actions.worktreeName"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(worktreeName),
+            onClick: () => void copyTextWithFeedback(worktreeName),
           },
           {
             label: sidebarText(t, "sidebar.actions.branchName"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.branch),
+            onClick: () => void copyTextWithFeedback(session.branch),
             disabled: !session.branch,
           },
           {
             label: sidebarText(t, "sidebar.actions.sessionId"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.id),
+            onClick: () => void copyTextWithFeedback(session.id),
           },
         ],
       },
@@ -2100,32 +2100,32 @@ function KanbanTerminalPopover({
           {
             label: sidebarText(t, "sidebar.actions.worktreePath"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.worktree_path),
+            onClick: () => void copyTextWithFeedback(session.worktree_path),
           },
           ...(transcriptPath
             ? [
                 {
                   label: sidebarText(t, "sidebar.actions.transcriptPath"),
                   icon: <Copy size={12} />,
-                  onClick: () => void copyToClipboard(transcriptPath),
+                  onClick: () => void copyTextWithFeedback(transcriptPath),
                 } satisfies ContextMenuItem,
               ]
             : []),
           {
             label: sidebarText(t, "sidebar.actions.worktreeName"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(worktreeName),
+            onClick: () => void copyTextWithFeedback(worktreeName),
           },
           {
             label: sidebarText(t, "sidebar.actions.branchName"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.branch),
+            onClick: () => void copyTextWithFeedback(session.branch),
             disabled: !session.branch,
           },
           {
             label: sidebarText(t, "sidebar.actions.sessionId"),
             icon: <Copy size={12} />,
-            onClick: () => void copyToClipboard(session.id),
+            onClick: () => void copyTextWithFeedback(session.id),
           },
         ],
       },
@@ -3095,12 +3095,4 @@ function cssAttributeEscape(value: string): string {
     return CSS.escape(value);
   }
   return value.replace(/(["\\\]\[])/g, "\\$1");
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await writeClipboardText(text);
-  } catch (err) {
-    console.warn("[WorkspaceMain] clipboard write failed", err);
-  }
 }

--- a/src/components/chat/ChatCodeBlock.tsx
+++ b/src/components/chat/ChatCodeBlock.tsx
@@ -1,7 +1,7 @@
 import { Check, ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { copyTextWithFeedback } from "../../lib/clipboardActions";
 import { cn } from "../../lib/cn";
-import { writeClipboardText } from "../../lib/clipboardText";
 import { diffGutterWidth, parseDiff, type ParsedLine } from "../../lib/diff";
 import { highlightCode, langFromPath } from "../../lib/highlight";
 import { useSettings } from "../../lib/settings";
@@ -133,7 +133,8 @@ export function ChatCodeBlock({
   }, [isDiff, label, normalizedCode, sourceLines.length, themeMode]);
 
   async function copyCode() {
-    await writeClipboardText(normalizedCode);
+    const copied = await copyTextWithFeedback(normalizedCode);
+    if (!copied) return;
     setCopied(true);
     if (copyResetTimer.current !== null) {
       window.clearTimeout(copyResetTimer.current);

--- a/src/components/chat/ChatMessageBody.test.tsx
+++ b/src/components/chat/ChatMessageBody.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useToasts } from "../../lib/toasts";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(true),
@@ -25,6 +26,7 @@ describe("ChatMessageBody", () => {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    useToasts.getState().hide(undefined, { skipDismiss: true });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -33,6 +35,7 @@ describe("ChatMessageBody", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    useToasts.getState().hide(undefined, { skipDismiss: true });
   });
 
   it("preserves paragraph and fenced code block order", async () => {
@@ -101,6 +104,37 @@ describe("ChatMessageBody", () => {
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       "const copied = true;",
+    );
+  });
+
+  it("surfaces clipboard permission failures from fenced code copy", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi
+          .fn()
+          .mockRejectedValue(new Error("clipboard permission denied")),
+      },
+    });
+    await act(async () => {
+      root.render(
+        <ChatMessageBody content={"```ts\nconst blocked = true;\n```"} />,
+      );
+    });
+    await settle();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Copy code block"]',
+        )!
+        .click();
+      await Promise.resolve();
+    });
+
+    const toasts = useToasts.getState().toasts;
+    expect(toasts[toasts.length - 1]?.message).toContain(
+      "clipboard permission denied",
     );
   });
 

--- a/src/lib/clipboardActions.test.ts
+++ b/src/lib/clipboardActions.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  writeClipboardText: vi.fn<(text: string) => Promise<void>>(),
+  showTranslatedErrorToast: vi.fn(),
+}));
+
+vi.mock("./clipboardText", () => ({
+  writeClipboardText: mocks.writeClipboardText,
+}));
+
+vi.mock("./operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
+}));
+
+import { copyTextWithFeedback } from "./clipboardActions";
+
+describe("copyTextWithFeedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.writeClipboardText.mockResolvedValue(undefined);
+  });
+
+  it("reports success without showing an error toast", async () => {
+    await expect(copyTextWithFeedback("copied text")).resolves.toBe(true);
+
+    expect(mocks.writeClipboardText).toHaveBeenCalledWith("copied text");
+    expect(mocks.showTranslatedErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("surfaces clipboard permission failures and reports failure", async () => {
+    const error = new Error("clipboard permission denied");
+    mocks.writeClipboardText.mockRejectedValueOnce(error);
+
+    await expect(copyTextWithFeedback("blocked text")).resolves.toBe(false);
+
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.clipboard.writeFailed",
+      error,
+    );
+  });
+});

--- a/src/lib/clipboardActions.ts
+++ b/src/lib/clipboardActions.ts
@@ -1,0 +1,20 @@
+import { writeClipboardText } from "./clipboardText";
+import { showTranslatedErrorToast } from "./operationToasts";
+
+/**
+ * Copy user-requested text and surface native/browser clipboard failures.
+ *
+ * Callers with operation-specific error UI should keep using
+ * `writeClipboardText` directly. This helper is for fire-and-forget copy
+ * actions that would otherwise turn a permission denial into an unhandled or
+ * console-only rejection.
+ */
+export async function copyTextWithFeedback(text: string): Promise<boolean> {
+  try {
+    await writeClipboardText(text);
+    return true;
+  } catch (error) {
+    showTranslatedErrorToast("toasts.clipboard.writeFailed", error);
+    return false;
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,6 +54,9 @@
       "restarted": "IPC server restarted.",
       "restartFailed": "Failed to restart IPC server:"
     },
+    "clipboard": {
+      "writeFailed": "Failed to write to the clipboard:"
+    },
     "files": {
       "renameFailed": "Failed to rename file:",
       "trashFailed": "Failed to move to trash:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -54,6 +54,9 @@
       "restarted": "IPCサーバーが再起動されました。",
       "restartFailed": "IPC サーバーの再起動に失敗しました:"
     },
+    "clipboard": {
+      "writeFailed": "クリップボードに書き込めませんでした:"
+    },
     "files": {
       "renameFailed": "ファイル名の変更に失敗しました:",
       "trashFailed": "ゴミ箱に移動できませんでした:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -54,6 +54,9 @@
       "restarted": "IPC 서버를 다시 시작했습니다.",
       "restartFailed": "IPC 서버를 다시 시작하지 못했습니다:"
     },
+    "clipboard": {
+      "writeFailed": "클립보드에 쓰지 못했습니다:"
+    },
     "files": {
       "renameFailed": "파일 이름을 바꾸지 못했습니다:",
       "trashFailed": "휴지통으로 이동하지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -54,6 +54,9 @@
       "restarted": "IPC 服务器已重新启动。",
       "restartFailed": "无法重新启动 IPC 服务器："
     },
+    "clipboard": {
+      "writeFailed": "无法写入剪贴板："
+    },
     "files": {
       "renameFailed": "无法重命名文件：",
       "trashFailed": "无法移至垃圾箱：",

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -666,7 +666,7 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(tooltip.locator("svg")).toHaveCount(6);
   });
 
-  test("session context menu copies the paired transcript path", async ({
+  test("session context menu copies transcript paths and surfaces clipboard denial", async ({
     page,
     tauri,
   }) => {
@@ -725,6 +725,23 @@ test.describe("sidebar: project lifecycle", () => {
         ),
       )
       .toBe(transcriptPath);
+
+    await page.evaluate(() => {
+      window.__ACORN_MOCK_HANDLERS__["plugin:clipboard-manager|write_text"] =
+        () => Promise.reject("clipboard permission denied");
+    });
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /copyable-session/ })
+      .click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Copy" }).hover();
+    await page.getByRole("menuitem", { name: "Transcript Path" }).click();
+
+    await expect(
+      page.getByText(
+        "Failed to write to the clipboard: clipboard permission denied",
+      ),
+    ).toBeVisible();
   });
 
   test("session rows surface open PR and active process context", async ({


### PR DESCRIPTION
## Summary

Clipboard permission failures now reach the user instead of becoming unhandled promises or console-only warnings.

1. **Shared copy feedback** — Add a small `copyTextWithFeedback` action that preserves the existing native/browser clipboard contract and emits a localized error toast when the write is denied.
2. **Missing caller coverage** — Route PR commit SHA, right-panel commit SHA, chat code block, workspace/kanban, sidebar, pane, project-folder, and work-summary copy actions through the checked path. Existing surfaces with operation-specific inline errors continue using their own handlers.
3. **Regression coverage** — Cover helper success/failure, code-block copy denial, work-summary denial, and a real Tauri-mock sidebar clipboard rejection.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Denied clipboard writes | Several copy actions failed silently, logged only to the console, or leaked a rejected promise | The user sees a localized toast containing the native/browser failure |
| Code-block copied state | A rejected copy could escape the click handler | The checkmark is set only after a successful write |
| Existing specialized copy flows | Inline or operation-specific errors | Unchanged |

## Design notes

- The low-level `writeClipboardText` function remains the transport boundary and still uses the native plugin in Tauri plus `navigator.clipboard` in browser development.
- The new helper is intentionally limited to fire-and-forget UI actions. Callers that already own an error state or operation-specific copy message retain their existing direct handling.
- Error text retains the underlying clipboard rejection so permission and platform failures stay diagnosable.

## Follow-up (not in this PR)

- None for this work unit.

## Test plan

- [x] `pnpm exec vitest run src/lib/clipboardActions.test.ts src/components/chat/ChatMessageBody.test.tsx src/components/WorkSummaryView.test.tsx --maxWorkers=1` — 24 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,353 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "session context menu copies transcript paths and surfaces clipboard denial" --workers=1` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts tests/e2e/right-panel.spec.ts --workers=1` — 90 passed; one unrelated drag-order timing failure
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "priority sorting preserves drag order within each status group" --workers=1` — passed on isolated rerun
- [x] `git diff --check` — passed

## Notes

- The combined sidebar/right-panel E2E run had one transient failure in the pre-existing priority drag-order test. It passed immediately in isolation; the clipboard denial regression and all other tests in that run passed.
