### PR TITLE
fix(files): surface file-manager reveal failures

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -56,7 +56,10 @@ import {
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { requestNewGraphSession } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
-import { revealInFileManagerText } from "../lib/fileManager";
+import {
+  revealInFileManagerText,
+  revealPathWithFeedback,
+} from "../lib/fileManager";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   hasConfiguredEditor,
@@ -1361,9 +1364,7 @@ function TabItem({
       label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
-        void api.fsReveal(tabPath).catch((err: unknown) => {
-          console.error("[Pane] reveal in finder failed", err);
-        });
+        void revealPathWithFeedback(tabPath);
       },
     },
     paneContextMenuGroupTitle(t, "copy"),
@@ -1888,11 +1889,7 @@ function buildPaneMenuItems({
           label: revealInFileManagerText(t),
           icon: <FolderOpen size={12} />,
           onClick: () => {
-            void api.fsReveal(activeSession.worktree_path).catch(
-              (err: unknown) => {
-                console.error("[Pane] reveal failed", err);
-              },
-            );
+            void revealPathWithFeedback(activeSession.worktree_path);
           },
         },
         { type: "separator" },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -88,7 +88,10 @@ import {
   type NewGraphSessionEventDetail,
 } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
-import { revealInFileManagerText } from "../lib/fileManager";
+import {
+  revealInFileManagerText,
+  revealPathWithFeedback,
+} from "../lib/fileManager";
 import { openInConfiguredEditor } from "../lib/editor";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { TranslationKey, Translator } from "../lib/i18n";
@@ -2336,11 +2339,7 @@ function ProjectGroupView({
   }
 
   async function openInFinder(path: string) {
-    try {
-      await api.fsReveal(path);
-    } catch {
-      // ignore
-    }
+    await revealPathWithFeedback(path);
   }
 
   const projectActionMenuItems: ContextMenuItem[] = [
@@ -3180,7 +3179,7 @@ function ProjectFolderView({
             label: revealInFileManagerText(t),
             icon: <FolderOpen size={12} />,
             onClick: () => {
-              void api.fsReveal(folder.cwdPath);
+              void revealPathWithFeedback(folder.cwdPath);
             },
           },
           {
@@ -3571,9 +3570,7 @@ function SessionRow({
       label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
-        void api.fsReveal(session.worktree_path).catch((err: unknown) => {
-          console.error("[Sidebar] reveal failed", err);
-        });
+        void revealPathWithFeedback(session.worktree_path);
       },
     },
     contextMenuGroupTitle(t, "copy"),
@@ -4615,7 +4612,7 @@ function LocalWorkspaceView({
       label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
-        void api.fsReveal(folder.cwdPath);
+        void revealPathWithFeedback(folder.cwdPath);
       },
     },
     {
@@ -4950,9 +4947,7 @@ function LocalSessionRow({
       label: revealInFileManagerText(t),
       icon: <FolderOpen size={12} />,
       onClick: () => {
-        void api.fsReveal(session.worktree_path).catch((err: unknown) => {
-          console.error("[Sidebar] reveal failed", err);
-        });
+        void revealPathWithFeedback(session.worktree_path);
       },
     },
     {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -48,12 +48,14 @@ import {
   X,
   XCircle,
 } from "lucide-react";
-import { api } from "../lib/api";
 import { writeClipboardText } from "../lib/clipboardText";
 import { requestNewAutonomousGoalSession } from "../lib/autonomousGoal";
 import { requestNewGraphSession } from "../lib/graphSessionEvents";
 import { cn } from "../lib/cn";
-import { revealInFileManagerText } from "../lib/fileManager";
+import {
+  revealInFileManagerText,
+  revealPathWithFeedback,
+} from "../lib/fileManager";
 import { openInConfiguredEditor } from "../lib/editor";
 import { isInAcornFloatingLayer } from "../lib/floatingLayer";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
@@ -1453,9 +1455,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         label: revealInFileManagerText(t),
         icon: <FolderOpen size={12} />,
         onClick: () => {
-          void api.fsReveal(session.worktree_path).catch((err: unknown) => {
-            console.error("[WorkspaceMain] reveal failed", err);
-          });
+          void revealPathWithFeedback(session.worktree_path);
         },
       },
       { type: "separator" },
@@ -2088,9 +2088,7 @@ function KanbanTerminalPopover({
         label: revealInFileManagerText(t),
         icon: <FolderOpen size={12} />,
         onClick: () => {
-          void api.fsReveal(session.worktree_path).catch((err: unknown) => {
-            console.error("[WorkspaceMain] reveal failed", err);
-          });
+          void revealPathWithFeedback(session.worktree_path);
         },
       },
       workspaceContextMenuGroupTitle(t, "copy"),

--- a/src/lib/fileManager.test.ts
+++ b/src/lib/fileManager.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, it } from "vitest";
-import { revealInFileManagerText } from "./fileManager";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fsReveal: vi.fn<(path: string) => Promise<void>>(),
+  showTranslatedErrorToast: vi.fn(),
+}));
+
+vi.mock("./api", () => ({
+  api: { fsReveal: mocks.fsReveal },
+}));
+
+vi.mock("./operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
+}));
+
+import {
+  revealInFileManagerText,
+  revealPathWithFeedback,
+} from "./fileManager";
 import { createTranslator } from "./i18n";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fsReveal.mockResolvedValue(undefined);
+});
 
 describe("revealInFileManagerText", () => {
   const t = createTranslator("en");
@@ -15,6 +37,28 @@ describe("revealInFileManagerText", () => {
     );
     expect(revealInFileManagerText(t, "Linux x86_64")).toBe(
       "Reveal in File Manager",
+    );
+  });
+});
+
+describe("revealPathWithFeedback", () => {
+  it("reports success without an error toast", async () => {
+    await expect(revealPathWithFeedback("/tmp/project")).resolves.toBe(true);
+
+    expect(mocks.fsReveal).toHaveBeenCalledWith("/tmp/project");
+    expect(mocks.showTranslatedErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("surfaces authorization and launcher failures", async () => {
+    const error = new Error("permission denied");
+    mocks.fsReveal.mockRejectedValueOnce(error);
+
+    await expect(revealPathWithFeedback("/private/project")).resolves.toBe(
+      false,
+    );
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.files.revealFailed",
+      error,
     );
   });
 });

--- a/src/lib/fileManager.ts
+++ b/src/lib/fileManager.ts
@@ -1,4 +1,6 @@
+import { api } from "./api";
 import type { Translator } from "./i18n";
+import { showTranslatedErrorToast } from "./operationToasts";
 
 export function revealInFileManagerText(
   t: Translator,
@@ -7,4 +9,15 @@ export function revealInFileManagerText(
   return platform.startsWith("Mac")
     ? t("ui.revealInFinder")
     : t("ui.revealInFileManager");
+}
+
+/** Reveal a user-selected path and keep launcher/access failures visible. */
+export async function revealPathWithFeedback(path: string): Promise<boolean> {
+  try {
+    await api.fsReveal(path);
+    return true;
+  } catch (error) {
+    showTranslatedErrorToast("toasts.files.revealFailed", error);
+    return false;
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,7 @@
     "files": {
       "renameFailed": "Failed to rename file:",
       "trashFailed": "Failed to move to trash:",
+      "revealFailed": "Failed to reveal the path in the file manager:",
       "pathsCopied": "File paths copied.",
       "copyFailed": "Failed to copy file paths."
     },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -47,6 +47,7 @@
     "files": {
       "renameFailed": "ファイル名の変更に失敗しました:",
       "trashFailed": "ゴミ箱に移動できませんでした:",
+      "revealFailed": "ファイルマネージャーでパスを表示できませんでした:",
       "pathsCopied": "ファイルパスがコピーされました。",
       "copyFailed": "ファイルパスのコピーに失敗しました。"
     },

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -47,6 +47,7 @@
     "files": {
       "renameFailed": "파일 이름을 바꾸지 못했습니다:",
       "trashFailed": "휴지통으로 이동하지 못했습니다:",
+      "revealFailed": "파일 관리자에서 경로를 표시하지 못했습니다:",
       "pathsCopied": "파일 경로를 복사했습니다.",
       "copyFailed": "파일 경로를 복사하지 못했습니다."
     },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -47,6 +47,7 @@
     "files": {
       "renameFailed": "无法重命名文件：",
       "trashFailed": "无法移至垃圾箱：",
+      "revealFailed": "无法在文件管理器中显示该路径：",
       "pathsCopied": "已复制文件路径。",
       "copyFailed": "无法复制文件路径。"
     },

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -4610,10 +4610,13 @@ test.describe("sidebar: project lifecycle", () => {
     ).toContainText("demo-api");
   });
 
-  test("a multi-root project header keeps only project management actions", async ({
+  test("a multi-root project header keeps project actions and surfaces reveal errors", async ({
     page,
     tauri,
   }) => {
+    await tauri.handle("fs_reveal", () =>
+      Promise.reject("reveal permission denied"),
+    );
     await tauri.respond("list_projects", [
       {
         repo_path: "/tmp/demo",
@@ -4661,6 +4664,13 @@ test.describe("sidebar: project lifecycle", () => {
     await page.keyboard.press("Escape");
     await projectRow.click({ button: "right" });
     await expect(page.getByRole("menuitem")).toHaveText(expectedProjectActions);
+    await page.getByRole("menuitem", { name: revealLabel }).click();
+
+    await expect(
+      page.getByText(
+        "Failed to reveal the path in the file manager: reveal permission denied",
+      ),
+    ).toBeVisible();
   });
 
   test("primary and source root headers create worktree sessions in their repositories", async ({


### PR DESCRIPTION
## Summary

File-manager reveal failures now remain visible across every context-menu surface that previously ignored or only logged them.

1. **Shared reveal feedback** — Add `revealPathWithFeedback` beside the platform-specific label helper so authorization, missing-path, and OS launcher errors produce a localized toast.
2. **Caller alignment** — Route Pane, Sidebar, project/source/local workspace, and Kanban reveal actions through the checked helper. File Explorer keeps its existing inline error state.
3. **Regression coverage** — Cover helper success/failure and verify a rejected Tauri `fs_reveal` command reaches the user from the project menu.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Project/workspace/session reveal | Permission or launcher failures were ignored, logged only, or left as rejected promises | A localized toast includes the backend failure |
| Successful reveal | OS file manager opens/selects the path | Unchanged |
| File Explorer reveal | Inline component error | Unchanged |

## Design notes

- The Rust command already preserves `FsScope::authorize_existing`, missing-path, and platform launcher failures as `AppResult` errors; this PR changes only the renderer-side presentation.
- A single helper prevents sibling context menus from drifting back to different failure semantics.
- The helper returns a boolean for callers that may later want success-only UI without re-catching the same error.

## Follow-up (not in this PR)

- Editor-launch feedback is a separate action and remains outside this work unit.

## Test plan

- [x] `pnpm exec vitest run src/lib/fileManager.test.ts src/lib/i18n.test.ts --maxWorkers=1` — 12 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,352 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "multi-root project header keeps project actions and surfaces reveal errors" --workers=1` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --workers=1` — 54 passed
- [x] `git diff --check` — passed

## Notes

- None.
