### PR TITLE
fix(editor): surface configured launch failures

### DIFF
--- a/src/components/DiffSplitView.tsx
+++ b/src/components/DiffSplitView.tsx
@@ -4,7 +4,7 @@ import { PersistentGroup } from "./PersistentGroup";
 import { ExternalLink } from "lucide-react";
 import { cn } from "../lib/cn";
 import { countStats, parseDiff } from "../lib/diff";
-import { openFileInEditor } from "../lib/editor";
+import { openFileInEditorWithFeedback } from "../lib/editor";
 import type { DiffFile, DiffImageContext, DiffPayload } from "../lib/types";
 import { useDiffImages, type ResolvedDiffImage } from "../lib/useDiffImages";
 import { Tooltip } from "./Tooltip";
@@ -111,11 +111,7 @@ export function DiffSplitView({ payload, cwd, imageContext }: DiffSplitViewProps
   async function openInEditor(entry: FileEntry) {
     const rel = entry.file.new_path ?? entry.file.old_path;
     if (!rel || !cwd) return;
-    try {
-      await openFileInEditor(joinPath(cwd, rel));
-    } catch (err) {
-      console.error("[DiffSplitView] open in editor failed", err);
-    }
+    await openFileInEditorWithFeedback(joinPath(cwd, rel));
   }
 
   function selectEntry(entry: FileEntry) {

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -63,7 +63,7 @@ import {
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   hasConfiguredEditor,
-  openInConfiguredEditor,
+  openInConfiguredEditorWithFeedback,
 } from "../lib/editor";
 import {
   formatHotkey,
@@ -1357,11 +1357,7 @@ function TabItem({
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
-        void openInConfiguredEditor(tabPath).catch(
-          (err: unknown) => {
-            console.error("[Pane] open in editor failed", err);
-          },
-        );
+        void openInConfiguredEditorWithFeedback(tabPath);
       },
     },
     {
@@ -1882,10 +1878,8 @@ function buildPaneMenuItems({
           icon: <PencilLine size={12} />,
           disabled: !editorReady,
           onClick: () => {
-            void openInConfiguredEditor(activeSession.worktree_path).catch(
-              (err: unknown) => {
-                console.error("[Pane] open in editor failed", err);
-              },
+            void openInConfiguredEditorWithFeedback(
+              activeSession.worktree_path,
             );
           },
         },

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -92,7 +92,7 @@ import {
   revealInFileManagerText,
   revealPathWithFeedback,
 } from "../lib/fileManager";
-import { openInConfiguredEditor } from "../lib/editor";
+import { openInConfiguredEditorWithFeedback } from "../lib/editor";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
@@ -3576,11 +3576,7 @@ function SessionRow({
       icon: <PencilLine size={12} />,
       disabled: !editorConfigured,
       onClick: () => {
-        void openInConfiguredEditor(session.worktree_path).catch(
-          (err: unknown) => {
-            console.error("[Sidebar] open in editor failed", err);
-          },
-        );
+        void openInConfiguredEditorWithFeedback(session.worktree_path);
       },
     },
     {

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -55,7 +55,7 @@ import {
   revealInFileManagerText,
   revealPathWithFeedback,
 } from "../lib/fileManager";
-import { openInConfiguredEditor } from "../lib/editor";
+import { openInConfiguredEditorWithFeedback } from "../lib/editor";
 import { isInAcornFloatingLayer } from "../lib/floatingLayer";
 import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { LayoutNode } from "../lib/layout";
@@ -1444,11 +1444,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
         icon: <PencilLine size={12} />,
         disabled: !editorConfigured,
         onClick: () => {
-          void openInConfiguredEditor(session.worktree_path).catch(
-            (err: unknown) => {
-              console.error("[WorkspaceMain] open in editor failed", err);
-            },
-          );
+          void openInConfiguredEditorWithFeedback(session.worktree_path);
         },
       },
       {
@@ -2077,11 +2073,7 @@ function KanbanTerminalPopover({
         icon: <PencilLine size={12} />,
         disabled: !editorConfigured,
         onClick: () => {
-          void openInConfiguredEditor(session.worktree_path).catch(
-            (err: unknown) => {
-              console.error("[WorkspaceMain] open in editor failed", err);
-            },
-          );
+          void openInConfiguredEditorWithFeedback(session.worktree_path);
         },
       },
       {

--- a/src/lib/editor.test.ts
+++ b/src/lib/editor.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fsOpenDefault: vi.fn<(path: string) => Promise<void>>(),
+  openInEditor: vi.fn<
+    (command: string, args: string[], path: string) => Promise<void>
+  >(),
+  showTranslatedErrorToast: vi.fn(),
+}));
+
+vi.mock("./api", () => ({
+  api: {
+    fsOpenDefault: mocks.fsOpenDefault,
+    openInEditor: mocks.openInEditor,
+  },
+}));
+
+vi.mock("./operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
+}));
+
+import {
+  openFileInEditorWithFeedback,
+  openInConfiguredEditorWithFeedback,
+} from "./editor";
+import { DEFAULT_SETTINGS, useSettings } from "./settings";
+
+describe("editor launch feedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fsOpenDefault.mockResolvedValue(undefined);
+    mocks.openInEditor.mockResolvedValue(undefined);
+    useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
+  });
+
+  it("reports default-editor success without an error toast", async () => {
+    await expect(
+      openFileInEditorWithFeedback("/tmp/project/readme.md"),
+    ).resolves.toBe(true);
+
+    expect(mocks.fsOpenDefault).toHaveBeenCalledWith(
+      "/tmp/project/readme.md",
+    );
+    expect(mocks.showTranslatedErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("surfaces configured-editor launch failures", async () => {
+    useSettings.setState((state) => ({
+      settings: {
+        ...state.settings,
+        editor: { command: "code --wait" },
+      },
+    }));
+    const error = new Error("editor executable permission denied");
+    mocks.openInEditor.mockRejectedValueOnce(error);
+
+    await expect(
+      openInConfiguredEditorWithFeedback("/private/project"),
+    ).resolves.toBe(false);
+
+    expect(mocks.openInEditor).toHaveBeenCalledWith(
+      "code",
+      ["--wait"],
+      "/private/project",
+    );
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.files.editorOpenFailed",
+      error,
+    );
+  });
+
+  it("keeps a missing editor configuration as a non-error no-op", async () => {
+    await expect(
+      openInConfiguredEditorWithFeedback("/tmp/project"),
+    ).resolves.toBe(false);
+
+    expect(mocks.openInEditor).not.toHaveBeenCalled();
+    expect(mocks.showTranslatedErrorToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -1,4 +1,5 @@
 import { api } from "./api";
+import { showTranslatedErrorToast } from "./operationToasts";
 import { useSettings } from "./settings";
 
 /**
@@ -35,6 +36,32 @@ export async function openInConfiguredEditor(
   const args = parts.slice(1);
   await api.openInEditor(program, args, absolutePath);
   return true;
+}
+
+async function openEditorWithFeedback(
+  open: () => Promise<boolean | void>,
+): Promise<boolean> {
+  try {
+    const opened = await open();
+    return opened !== false;
+  } catch (error) {
+    showTranslatedErrorToast("toasts.files.editorOpenFailed", error);
+    return false;
+  }
+}
+
+/** Open through the configured/default editor and surface launch failures. */
+export function openFileInEditorWithFeedback(
+  absolutePath: string,
+): Promise<boolean> {
+  return openEditorWithFeedback(() => openFileInEditor(absolutePath));
+}
+
+/** Open only through the configured editor and surface launch failures. */
+export function openInConfiguredEditorWithFeedback(
+  absolutePath: string,
+): Promise<boolean> {
+  return openEditorWithFeedback(() => openInConfiguredEditor(absolutePath));
 }
 
 /** True when the user has configured an editor command in settings. */

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,6 +58,7 @@
       "renameFailed": "Failed to rename file:",
       "trashFailed": "Failed to move to trash:",
       "revealFailed": "Failed to reveal the path in the file manager:",
+      "editorOpenFailed": "Failed to open the path in the editor:",
       "pathsCopied": "File paths copied.",
       "copyFailed": "Failed to copy file paths.",
       "terminalLinkOpenFailed": "Failed to open terminal file link:"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -58,6 +58,7 @@
       "renameFailed": "ファイル名の変更に失敗しました:",
       "trashFailed": "ゴミ箱に移動できませんでした:",
       "revealFailed": "ファイルマネージャーでパスを表示できませんでした:",
+      "editorOpenFailed": "エディターでパスを開けませんでした:",
       "pathsCopied": "ファイルパスがコピーされました。",
       "copyFailed": "ファイルパスのコピーに失敗しました。",
       "terminalLinkOpenFailed": "ターミナルのファイルリンクを開けませんでした:"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -58,6 +58,7 @@
       "renameFailed": "파일 이름을 바꾸지 못했습니다:",
       "trashFailed": "휴지통으로 이동하지 못했습니다:",
       "revealFailed": "파일 관리자에서 경로를 표시하지 못했습니다:",
+      "editorOpenFailed": "편집기에서 경로를 열지 못했습니다:",
       "pathsCopied": "파일 경로를 복사했습니다.",
       "copyFailed": "파일 경로를 복사하지 못했습니다.",
       "terminalLinkOpenFailed": "터미널 파일 링크를 열지 못했습니다:"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -58,6 +58,7 @@
       "renameFailed": "无法重命名文件：",
       "trashFailed": "无法移至垃圾箱：",
       "revealFailed": "无法在文件管理器中显示该路径：",
+      "editorOpenFailed": "无法在编辑器中打开该路径：",
       "pathsCopied": "已复制文件路径。",
       "copyFailed": "无法复制文件路径。",
       "terminalLinkOpenFailed": "无法打开终端文件链接："

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -727,6 +727,67 @@ test.describe("sidebar: project lifecycle", () => {
       .toBe(transcriptPath);
   });
 
+  test("session context menu surfaces configured editor launch errors", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ editor: { command: "code --wait" } }),
+      );
+    });
+    await tauri.handle("open_in_editor", () =>
+      Promise.reject("editor executable permission denied"),
+    );
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "editor-session",
+        name: "editor-session",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "waiting_for_input",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        mode: "terminal",
+        owner: { kind: "user" },
+        position: 0,
+        in_worktree: false,
+        agent_provider: null,
+        agent_transcript_id: null,
+      },
+    ]);
+
+    await page.goto("/");
+    await page
+      .locator("aside")
+      .getByRole("button", { name: /editor-session/ })
+      .click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Open Worktree in Editor" })
+      .click();
+
+    await expect(
+      page.getByText(
+        "Failed to open the path in the editor: editor executable permission denied",
+      ),
+    ).toBeVisible();
+  });
+
   test("session rows surface open PR and active process context", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Editor authorization and process-launch failures now reach users from every context-menu surface that previously logged them only to the console.

1. **Checked UI wrappers** — Add feedback variants for default/configured editor launches while preserving the existing rejecting low-level functions for callers with inline error state.
2. **Missing caller coverage** — Route DiffSplitView, Pane, Sidebar, and Kanban/Workspace actions through the checked wrappers.
3. **Regression coverage** — Test success, configured-editor rejection, missing configuration, and a Tauri-mock launch failure from the session menu.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Configured editor spawn/permission failure | Pane, Sidebar, and Workspace logged only to the console | A localized toast includes the backend failure |
| Diff editor/default-app failure | Logged only to the console | A localized toast includes the failure |
| File Explorer and Staged views | Existing inline errors | Unchanged |
| Missing configured editor | Disabled/no-op strict action | Unchanged; no false error toast |

## Design notes

- The backend remains responsible for validating the configured command, canonicalizing the target, resolving Windows launchers, and preserving spawn errors.
- `openFileInEditor` and `openInConfiguredEditor` keep their rejection contracts so File Explorer and Staged callers can continue rendering local errors.
- The feedback wrappers return `boolean`, and only classify an absent strict-editor configuration as a quiet no-op.

## Follow-up (not in this PR)

- Editor command tokenization still follows the existing whitespace-split contract and is not changed here.

## Test plan

- [x] `pnpm exec vitest run src/lib/editor.test.ts src/lib/i18n.test.ts --maxWorkers=1` — 11 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,353 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "session context menu surfaces configured editor launch errors" --workers=1` — passed
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --workers=1` — 55 passed
- [x] `git diff --check` — passed

## Notes

- None.
