### PR TITLE
fix(opener): surface capability and launch failures

### DIFF
--- a/src/components/AuthorTag.tsx
+++ b/src/components/AuthorTag.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ExternalLink } from "lucide-react";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { AuthorAvatar } from "./AuthorAvatar";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { cn } from "../lib/cn";
@@ -51,7 +51,7 @@ export function buildProfileMenuItems(
     {
       label,
       icon: <ExternalLink size={12} />,
-      onClick: () => void openSafeUrl(`https://github.com/${slug}`),
+      onClick: () => void openExternalUrlWithFeedback(`https://github.com/${slug}`),
     },
   ];
 }

--- a/src/components/ImageLightbox.tsx
+++ b/src/components/ImageLightbox.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
 import { ExternalLink, X } from "lucide-react";
-import { isSafeOpenUrl, openSafeUrl } from "../lib/safeOpenUrl";
+import { isSafeOpenUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { useTranslation } from "../lib/useTranslation";
 import { Tooltip } from "./Tooltip";
 
@@ -69,7 +70,7 @@ export function ImageLightbox({ image, onClose }: ImageLightboxProps) {
               aria-label={t("imageLightbox.openInBrowser")}
               onClick={(e) => {
                 e.stopPropagation();
-                void openSafeUrl(image.src);
+                void openExternalUrlWithFeedback(image.src);
               }}
               className="rounded p-1.5 text-white/70 transition hover:bg-white/10 hover:text-white"
             >

--- a/src/components/IssueDetailModal.tsx
+++ b/src/components/IssueDetailModal.tsx
@@ -19,7 +19,7 @@ import type {
   IssueDetail,
   IssueDetailListing,
 } from "../lib/types";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag } from "./AuthorTag";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
@@ -393,7 +393,7 @@ function IssueDetailBody({
           >
             <button
               type="button"
-              onClick={() => void openSafeUrl(detail.url)}
+              onClick={() => void openExternalUrlWithFeedback(detail.url)}
               className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
             >
               <ExternalLink size={14} />
@@ -591,7 +591,7 @@ function IssueCommentBlock({
             >
               <button
                 type="button"
-                onClick={() => void openSafeUrl(comment.url ?? "")}
+                onClick={() => void openExternalUrlWithFeedback(comment.url ?? "")}
                 className="rounded p-1 text-fg-muted transition hover:bg-bg hover:text-fg"
               >
                 <ExternalLink size={12} />

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -30,7 +30,7 @@ import { cn } from "../lib/cn";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { emitPullRequestMutation } from "../lib/pullRequestEvents";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { useSettings } from "../lib/settings";
 import { useToasts } from "../lib/toasts";
 import { ResizeHandle } from "./ResizeHandle";
@@ -830,7 +830,7 @@ function DetailBody({
           <Tooltip label={dt(t, "dialogs.pullRequestDetail.openOnGithub")} side="bottom">
             <button
               type="button"
-              onClick={() => void openSafeUrl(detail.url)}
+              onClick={() => void openExternalUrlWithFeedback(detail.url)}
               className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
             >
               <ExternalLink size={14} />
@@ -1509,7 +1509,7 @@ function CommentBlock({
               <button
                 type="button"
                 onClick={() => {
-                  if (comment.url) void openSafeUrl(comment.url);
+                  if (comment.url) void openExternalUrlWithFeedback(comment.url);
                 }}
                 className="rounded p-1 text-fg-muted transition hover:bg-bg hover:text-fg"
               >
@@ -1751,7 +1751,7 @@ function CommitListItem({
           {
             label: dt(t, "dialogs.pullRequestDetail.viewOnGithub"),
             icon: <ExternalLink size={12} />,
-            onClick: () => void openSafeUrl(commitUrl),
+            onClick: () => void openExternalUrlWithFeedback(commitUrl),
           },
         ]
       : []),
@@ -1941,7 +1941,7 @@ function CommitDetailView({
         >
           <button
             type="button"
-            onClick={() => void openSafeUrl(commitUrl)}
+            onClick={() => void openExternalUrlWithFeedback(commitUrl)}
             className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >
             <ExternalLink size={12} />
@@ -2071,7 +2071,7 @@ function CheckRow({
           <button
             type="button"
             onClick={() => {
-              if (check.url) void openSafeUrl(check.url);
+              if (check.url) void openExternalUrlWithFeedback(check.url);
             }}
             className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
           >

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -60,6 +60,7 @@ import { joinPath } from "../lib/paths";
 import { trimTrailingPathSeparators } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { findSessionsForPullRequest } from "../lib/sessionContext";
 import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
 import {
@@ -2079,7 +2080,7 @@ function CommitsTab({
           <Tooltip label={rt(t, "rightPanel.tooltips.openOnGitHub")} side="bottom">
             <button
               type="button"
-              onClick={() => void openSafeUrl(webUrl)}
+              onClick={() => void openExternalUrlWithFeedback(webUrl)}
               className="shrink-0 rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
             >
               <ExternalLink size={12} />
@@ -4173,7 +4174,7 @@ function WorkflowRunDetailModal({
                 >
                   <button
                     type="button"
-                    onClick={() => void openSafeUrl(detail.url)}
+                    onClick={() => void openExternalUrlWithFeedback(detail.url)}
                     className="rounded p-1 text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
                   >
                     <ExternalLink size={14} />
@@ -4448,13 +4449,13 @@ function WorkflowJobRow({ job, nowUnix }: { job: WorkflowJob; nowUnix: number })
               tabIndex={0}
               onClick={(e) => {
                 e.stopPropagation();
-                void openSafeUrl(job.url);
+                void openExternalUrlWithFeedback(job.url);
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
                   e.stopPropagation();
-                  void openSafeUrl(job.url);
+                  void openExternalUrlWithFeedback(job.url);
                 }
               }}
               className="shrink-0 cursor-pointer rounded p-0.5 text-fg-muted transition hover:bg-bg-sidebar hover:text-fg"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -64,7 +64,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useAppStore, type WorkspaceViewMode } from "../store";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import {
   AgentProviderIcon,
   buildAgentForkCommand,
@@ -3847,9 +3847,7 @@ function SessionRowLabel({
               onKeyUp={(e) => e.stopPropagation()}
               onClick={(e) => {
                 e.stopPropagation();
-                void openSafeUrl(currentPullRequest.url).catch((err: unknown) => {
-                  console.error("[Sidebar] open PR URL failed", err);
-                });
+                void openExternalUrlWithFeedback(currentPullRequest.url);
               }}
               className={cn(
                 "inline-flex shrink-0 items-center gap-0.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -26,7 +26,7 @@ import {
 } from "../lib/fileDrop";
 import { formatTerminalFileMention } from "../lib/fileMention";
 import { writeClipboardText } from "../lib/clipboardText";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import {
   AGENT_PROVIDER_ORDER,
   providerSupportsImagePasteFallback,
@@ -873,9 +873,7 @@ export function Terminal({
         return;
       }
       if (/^file:/iu.test(uri)) return;
-      void openSafeUrl(uri).catch((err: unknown) => {
-        console.error("failed to open terminal link", uri, err);
-      });
+      void openExternalUrlWithFeedback(uri);
     };
     const hoverExternalLink = (uri: string, range: IViewportRange) => {
       if (linkActivation !== "modifier-click") return;

--- a/src/components/WhatsNewModal.tsx
+++ b/src/components/WhatsNewModal.tsx
@@ -1,7 +1,8 @@
 import { ExternalLink, Sparkles } from "lucide-react";
 import type { ReactElement } from "react";
 import type { TranslationKey, Translator } from "../lib/i18n";
-import { isSafeOpenUrl, openSafeUrl } from "../lib/safeOpenUrl";
+import { isSafeOpenUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { useTranslation } from "../lib/useTranslation";
 import {
   Button,
@@ -154,7 +155,7 @@ export function WhatsNewModal({
       <ModalFooter>
         {htmlUrl && isSafeOpenUrl(htmlUrl) ? (
           <Button
-            onClick={() => void openSafeUrl(htmlUrl)}
+            onClick={() => void openExternalUrlWithFeedback(htmlUrl)}
           >
             <ExternalLink size={12} />
             {dt(t, "dialogs.whatsNew.viewOnGithub")}

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -61,7 +61,7 @@ import { formatHotkey, matchesHotkeyEvent } from "../lib/hotkeys";
 import type { LayoutNode } from "../lib/layout";
 import { basename } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
-import { openSafeUrl } from "../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import {
   PROJECT_SESSION_CREATE_MENU,
@@ -1682,14 +1682,7 @@ const KanbanSessionCard = memo(function KanbanSessionCard({
                   onKeyUp={(event) => event.stopPropagation()}
                   onClick={(event) => {
                     event.stopPropagation();
-                    void openSafeUrl(currentPullRequest.url).catch(
-                      (err: unknown) => {
-                        console.error(
-                          "[WorkspaceMain] open PR URL failed",
-                          err,
-                        );
-                      },
-                    );
+                    void openExternalUrlWithFeedback(currentPullRequest.url);
                   }}
                   className={cn(
                     "inline-flex min-w-0 shrink-0 items-center gap-0.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",
@@ -2671,9 +2664,7 @@ function KanbanTerminalPopoverPullRequestMetaItem({
         onKeyUp={(event) => event.stopPropagation()}
         onClick={(event) => {
           event.stopPropagation();
-          void openSafeUrl(pullRequest.url).catch((err: unknown) => {
-            console.error("[WorkspaceMain] open PR URL failed", err);
-          });
+          void openExternalUrlWithFeedback(pullRequest.url);
         }}
         className={cn(
           "inline-flex min-w-0 max-w-[18rem] shrink items-center gap-1.5 rounded-sm underline-offset-2 transition hover:text-fg hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/60",

--- a/src/components/chat/ChatMessageBody.tsx
+++ b/src/components/chat/ChatMessageBody.tsx
@@ -2,7 +2,8 @@ import { Children, isValidElement, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "../../lib/cn";
-import { isSafeOpenUrl, openSafeUrl } from "../../lib/safeOpenUrl";
+import { isSafeOpenUrl } from "../../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../../lib/externalOpener";
 import {
   markdownImageUrlTransform,
   RemoteImage,
@@ -55,7 +56,7 @@ export function ChatMessageBody({
       return (
         <button
           type="button"
-          onClick={() => void openSafeUrl(safeHref)}
+          onClick={() => void openExternalUrlWithFeedback(safeHref)}
           className="inline cursor-pointer bg-transparent p-0 text-accent underline-offset-2 hover:underline"
         >
           {children}

--- a/src/components/ui/Markdown.tsx
+++ b/src/components/ui/Markdown.tsx
@@ -4,7 +4,8 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { cn } from "../../lib/cn";
-import { isSafeOpenUrl, openSafeUrl } from "../../lib/safeOpenUrl";
+import { isSafeOpenUrl } from "../../lib/safeOpenUrl";
+import { openExternalUrlWithFeedback } from "../../lib/externalOpener";
 import { ImageLightbox } from "../ImageLightbox";
 import { Tooltip } from "../Tooltip";
 import { markdownImageUrlTransform, RemoteImage } from "./RemoteImage";
@@ -139,7 +140,7 @@ const baseComponents: Components = {
     const link = (
       <button
         type="button"
-        onClick={() => void openSafeUrl(safeHref)}
+        onClick={() => void openExternalUrlWithFeedback(safeHref)}
         className="inline cursor-pointer bg-transparent p-0 text-accent underline-offset-2 hover:underline"
       >
         {children}

--- a/src/lib/externalOpener.test.ts
+++ b/src/lib/externalOpener.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openExternalUrl: vi.fn<(url: string) => Promise<boolean>>(),
+  showTranslatedErrorToast: vi.fn(),
+  showTranslatedToast: vi.fn(),
+}));
+
+vi.mock("./api", () => ({
+  api: { openExternalUrl: mocks.openExternalUrl },
+}));
+
+vi.mock("./operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
+  showTranslatedToast: mocks.showTranslatedToast,
+}));
+
+import { openExternalUrlWithFeedback } from "./externalOpener";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.openExternalUrl.mockResolvedValue(true);
+});
+
+describe("openExternalUrlWithFeedback", () => {
+  it("opens a safe URL without a toast", async () => {
+    await expect(
+      openExternalUrlWithFeedback("https://example.com/acorn"),
+    ).resolves.toBe(true);
+
+    expect(mocks.openExternalUrl).toHaveBeenCalledWith(
+      "https://example.com/acorn",
+    );
+    expect(mocks.showTranslatedToast).not.toHaveBeenCalled();
+    expect(mocks.showTranslatedErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("surfaces launcher failures", async () => {
+    const error = new Error("no application registered for https");
+    mocks.openExternalUrl.mockRejectedValueOnce(error);
+
+    await expect(
+      openExternalUrlWithFeedback("https://example.com/acorn"),
+    ).resolves.toBe(false);
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.opener.urlFailed",
+      error,
+    );
+  });
+
+  it("keeps the URL policy gate and never reaches the opener for unsafe input", async () => {
+    await expect(
+      openExternalUrlWithFeedback("javascript:alert(1)"),
+    ).resolves.toBe(false);
+
+    expect(mocks.openExternalUrl).not.toHaveBeenCalled();
+    expect(mocks.showTranslatedToast).toHaveBeenCalledWith(
+      "toasts.opener.urlBlocked",
+    );
+  });
+
+  it("reports a refusal from the backend policy check", async () => {
+    mocks.openExternalUrl.mockResolvedValueOnce(false);
+
+    await expect(
+      openExternalUrlWithFeedback("https://example.com/acorn"),
+    ).resolves.toBe(false);
+    expect(mocks.showTranslatedToast).toHaveBeenCalledWith(
+      "toasts.opener.urlBlocked",
+    );
+  });
+});

--- a/src/lib/externalOpener.ts
+++ b/src/lib/externalOpener.ts
@@ -1,0 +1,24 @@
+import { openSafeUrl } from "./safeOpenUrl";
+import { showTranslatedErrorToast, showTranslatedToast } from "./operationToasts";
+
+/**
+ * Open an external link through the URL policy gate and keep failures visible.
+ *
+ * This wraps `openSafeUrl` rather than the opener plugin directly so the policy
+ * check — and the matching one the Rust command applies — stays on the path.
+ * Callers that already surface the outcome themselves (the updater's canonical
+ * release page, the commit view's inline error) should keep calling
+ * `openSafeUrl` so a failure is not reported twice.
+ */
+export async function openExternalUrlWithFeedback(url: string): Promise<boolean> {
+  try {
+    const opened = await openSafeUrl(url);
+    if (!opened) {
+      showTranslatedToast("toasts.opener.urlBlocked");
+    }
+    return opened;
+  } catch (error) {
+    showTranslatedErrorToast("toasts.opener.urlFailed", error);
+    return false;
+  }
+}

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -10,7 +10,7 @@ import {
 } from "@tauri-apps/plugin-fs";
 import { create } from "zustand";
 import { ensureRealDirectory } from "./safeAppLocalFs";
-import { openSafeUrl } from "./safeOpenUrl";
+import { openExternalUrlWithFeedback } from "./externalOpener";
 
 import acornDarkCss from "../assets/themes/acorn-dark.css?raw";
 import acornLightCss from "../assets/themes/acorn-light.css?raw";
@@ -724,7 +724,7 @@ export async function revealThemesFolder(): Promise<void> {
 }
 
 export async function openThemePreview(): Promise<void> {
-  await openSafeUrl(THEME_PREVIEW_URL);
+  await openExternalUrlWithFeedback(THEME_PREVIEW_URL);
 }
 
 export function mergeThemes(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -70,6 +70,10 @@
       "dropOpenFailed": "Failed to open dropped file:",
       "dropInputFailed": "Failed to insert dropped file path into the terminal:"
     },
+    "opener": {
+      "urlFailed": "Failed to open the external link:",
+      "urlBlocked": "That link was blocked because it is not a safe external URL."
+    },
     "pullRequests": {
       "mergeFailed": "Failed to merge pull request:",
       "closeFailed": "Failed to close pull request:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -70,6 +70,10 @@
       "dropOpenFailed": "ドロップしたファイルを開けませんでした:",
       "dropInputFailed": "ドロップしたファイルパスをターミナルに入力できませんでした:"
     },
+    "opener": {
+      "urlFailed": "外部リンクを開けませんでした:",
+      "urlBlocked": "安全な外部 URL ではないため、このリンクはブロックされました。"
+    },
     "pullRequests": {
       "mergeFailed": "プル リクエストのマージに失敗しました:",
       "closeFailed": "プルリクエストをクローズできませんでした:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -70,6 +70,10 @@
       "dropOpenFailed": "드롭한 파일을 열지 못했습니다:",
       "dropInputFailed": "드롭한 파일 경로를 터미널에 입력하지 못했습니다:"
     },
+    "opener": {
+      "urlFailed": "외부 링크를 열지 못했습니다:",
+      "urlBlocked": "안전한 외부 URL이 아니어서 링크를 차단했습니다."
+    },
     "pullRequests": {
       "mergeFailed": "Pull request를 병합하지 못했습니다:",
       "closeFailed": "Pull request를 닫지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -70,6 +70,10 @@
       "dropOpenFailed": "无法打开拖放的文件：",
       "dropInputFailed": "无法将拖放的文件路径输入终端："
     },
+    "opener": {
+      "urlFailed": "无法打开外部链接：",
+      "urlBlocked": "该链接不是安全的外部 URL，已被阻止。"
+    },
     "pullRequests": {
       "mergeFailed": "无法合并拉取请求：",
       "closeFailed": "无法关闭拉取请求：",


### PR DESCRIPTION
## Summary

Every external-link click routed through `openSafeUrl` and then dropped the result. A rejected promise became an unhandled rejection or a bare `console.error`, and a `false` return — the URL policy refusing the link — was invisible. Either way the user saw a click that did nothing.

`openExternalUrlWithFeedback` delegates to `openSafeUrl` and reports both outcomes as toasts:

- launcher/IPC rejection → `toasts.opener.urlFailed` with the underlying message
- policy refusal (`false`) → `toasts.opener.urlBlocked`

Call sites that already surface the outcome themselves keep calling `openSafeUrl` directly, so nothing is reported twice: `updater.ts` (throws its own error for the canonical release page) and the commit / PR / issue "open in browser" handlers in `RightPanel.tsx` (inline `setError`).

## Note on the previous revision

This branch originally added an `externalOpener` that called `openUrl`/`openPath` from `@tauri-apps/plugin-opener` directly, and removed the `isSafeOpenUrl(image.src)` guard in `ImageLightbox.tsx`.

`main` has since routed all external opens through `openSafeUrl` → `api.openExternalUrl`, which applies a URL policy in the renderer and independently again in Rust. Landing the original revision would have bypassed both layers and dropped a safety gate, so the branch was re-authored to add the feedback on top of the policy gate rather than around it. All four `isSafeOpenUrl` gates (`Markdown`, `ChatMessageBody`, `WhatsNewModal`, `ImageLightbox`) are untouched.

`openExternalPathWithFeedback` was dropped: `main` no longer has any `openPath` call site for it to serve.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 1439 passed (122 files), including 4 new `externalOpener` cases
- [x] `pnpm exec vitest run src/lib/externalOpener.test.ts` — 4 passed
- [x] `grep -rn "isSafeOpenUrl" src` — all four call-site gates still present
