### PR TITLE
fix(notifications): keep permission and click failures actionable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1072,7 +1072,16 @@ function App() {
   useEffect(() => {
     let dispose: (() => void) | null = null;
     let cancelled = false;
-    void startNotificationClickHandler().then((d) => {
+    void startNotificationClickHandler((stage, error) => {
+      if (cancelled) return;
+      const prefix =
+        stage === "registration"
+          ? appText(t, "app.toast.notificationClickRegistrationFailedPrefix")
+          : appText(t, "app.toast.notificationClickActivationFailedPrefix");
+      showToast(
+        `${prefix} ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }).then((d) => {
       if (cancelled) {
         d();
         return;
@@ -1083,7 +1092,7 @@ function App() {
       cancelled = true;
       dispose?.();
     };
-  }, []);
+  }, [showToast, t]);
 
   // Probe session status adaptively: active tabs stay fresh, volatile sessions
   // get a moderate cadence, and stable sessions fall back to a slow safety

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -28,6 +28,7 @@ vi.mock("@tauri-apps/api/window", () => ({
 
 import {
   resetNotificationsForTests,
+  sendTestNotification,
   startFocusedSessionNotificationReadWatcher,
   startNotificationClickHandler,
   startSessionActivityInboxWatcher,
@@ -119,6 +120,66 @@ describe("notifications", () => {
       }),
     );
     dispose();
+  });
+
+  it("retries a transient permission probe failure on the next transition", async () => {
+    mocks.isPermissionGranted.mockRejectedValueOnce(
+      new Error("notification capability unavailable"),
+    );
+    const dispose = startSessionNotificationWatcher();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "waiting_for_input",
+          updated_at: "2026-01-01T00:01:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(mocks.isPermissionGranted).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
+
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "working",
+          updated_at: "2026-01-01T00:02:00Z",
+        }),
+      ],
+    });
+    useAppStore.setState({
+      sessions: [
+        session({
+          status: "errored",
+          updated_at: "2026-01-01T00:03:00Z",
+        }),
+      ],
+    });
+    await flushPromises();
+
+    expect(mocks.isPermissionGranted).toHaveBeenCalledTimes(2);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("reports a permission probe failure as an error instead of a denial", async () => {
+    mocks.isPermissionGranted.mockRejectedValueOnce(
+      new Error("notification capability unavailable"),
+    );
+
+    await expect(sendTestNotification()).resolves.toBe("error");
+    expect(mocks.requestPermission).not.toHaveBeenCalled();
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("keeps an explicit permission denial distinct from probe errors", async () => {
+    mocks.isPermissionGranted.mockResolvedValueOnce(false);
+    mocks.requestPermission.mockResolvedValueOnce("denied");
+
+    await expect(sendTestNotification()).resolves.toBe("denied");
+    expect(mocks.sendNotification).not.toHaveBeenCalled();
   });
 
   it("opens the destination session surface when a system notification is clicked", async () => {

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -72,6 +72,9 @@ describe("notifications", () => {
     vi.clearAllMocks();
     mocks.isPermissionGranted.mockResolvedValue(true);
     mocks.requestPermission.mockResolvedValue("granted");
+    mocks.show.mockResolvedValue(undefined);
+    mocks.unminimize.mockResolvedValue(undefined);
+    mocks.setFocus.mockResolvedValue(undefined);
     Object.defineProperty(document, "hasFocus", {
       configurable: true,
       value: () => true,
@@ -186,7 +189,22 @@ describe("notifications", () => {
     const unregister = vi.fn();
     mocks.onAction.mockResolvedValue({ unregister });
     const openSessionSurface = vi.fn(() => true);
-    useAppStore.setState({ openSessionSurface });
+    useAppStore.setState({
+      openSessionSurface,
+      sessionNotifications: [
+        {
+          id: "notification-1",
+          sessionId: "session-1",
+          kind: "waiting_for_input",
+          status: "waiting_for_input",
+          previousStatus: "working",
+          sessionName: "Agent",
+          projectName: "acorn",
+          repoPath: "/repo/acorn",
+          createdAt: "2026-01-01T00:01:00Z",
+        },
+      ],
+    });
 
     const dispose = await startNotificationClickHandler();
     const handleAction = mocks.onAction.mock.calls[0]?.[0] as
@@ -196,6 +214,7 @@ describe("notifications", () => {
     if (!handleAction) throw new Error("notification action handler missing");
 
     handleAction({ extra: { sessionId: "session-1" } });
+    await flushPromises();
 
     expect(openSessionSurface).toHaveBeenCalledWith("session-1", {
       centerInCanvas: true,
@@ -203,9 +222,67 @@ describe("notifications", () => {
     expect(mocks.show).toHaveBeenCalled();
     expect(mocks.unminimize).toHaveBeenCalled();
     expect(mocks.setFocus).toHaveBeenCalled();
+    expect(useAppStore.getState().sessionNotifications).toEqual([]);
 
     dispose();
     expect(unregister).toHaveBeenCalled();
+  });
+
+  it("reports click-listener registration failures without rejecting", async () => {
+    mocks.onAction.mockRejectedValueOnce(new Error("listener denied"));
+    const onFailure = vi.fn();
+
+    const dispose = await startNotificationClickHandler(onFailure);
+
+    expect(onFailure).toHaveBeenCalledWith(
+      "registration",
+      expect.objectContaining({ message: "listener denied" }),
+    );
+    expect(() => dispose()).not.toThrow();
+  });
+
+  it("keeps activity unread when the clicked notification cannot activate the window", async () => {
+    mocks.onAction.mockResolvedValue({ unregister: vi.fn() });
+    mocks.show.mockRejectedValueOnce(new Error("window access denied"));
+    const onFailure = vi.fn();
+    const openSessionSurface = vi.fn(() => true);
+    useAppStore.setState({
+      openSessionSurface,
+      sessionNotifications: [
+        {
+          id: "notification-1",
+          sessionId: "session-1",
+          kind: "waiting_for_input",
+          status: "waiting_for_input",
+          previousStatus: "working",
+          sessionName: "Agent",
+          projectName: "acorn",
+          repoPath: "/repo/acorn",
+          createdAt: "2026-01-01T00:01:00Z",
+        },
+      ],
+    });
+    const dispose = await startNotificationClickHandler(onFailure);
+    const handleAction = mocks.onAction.mock.calls[0]?.[0] as
+      | ((notification: { extra?: Record<string, unknown> }) => void)
+      | undefined;
+    if (!handleAction) throw new Error("notification action handler missing");
+
+    handleAction({ extra: { sessionId: "session-1" } });
+    await flushPromises();
+
+    expect(openSessionSurface).toHaveBeenCalledWith("session-1", {
+      centerInCanvas: true,
+    });
+    expect(mocks.show).toHaveBeenCalled();
+    expect(mocks.unminimize).toHaveBeenCalled();
+    expect(mocks.setFocus).toHaveBeenCalled();
+    expect(onFailure).toHaveBeenCalledWith(
+      "activation",
+      expect.objectContaining({ message: "window access denied" }),
+    );
+    expect(useAppStore.getState().sessionNotifications).toHaveLength(1);
+    dispose();
   });
 
   it("marks a focused session transition read instead of sending a system notification", async () => {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -36,26 +36,32 @@ let cachedPermission: boolean | null = null;
 let inboxNotificationCounter = 0;
 
 async function checkPermission(): Promise<boolean> {
+  let granted = await isPermissionGranted();
+  if (!granted) {
+    const result = await requestPermission();
+    granted = result === "granted";
+  }
+  return granted;
+}
+
+async function ensurePermission(): Promise<boolean> {
+  if (cachedPermission !== null) return cachedPermission;
   try {
-    let granted = await isPermissionGranted();
-    if (!granted) {
-      const result = await requestPermission();
-      granted = result === "granted";
-    }
-    return granted;
+    cachedPermission = await checkPermission();
+    return cachedPermission;
   } catch (err) {
+    // A probe failure is not a permission denial. Leave the cache empty so a
+    // later transition can retry after a transient plugin/IPC failure.
     console.error("[notifications] permission check failed", err);
     return false;
   }
 }
 
-async function ensurePermission(): Promise<boolean> {
-  if (cachedPermission !== null) return cachedPermission;
-  cachedPermission = await checkPermission();
-  return cachedPermission;
-}
-
 async function refreshPermission(): Promise<boolean> {
+  // The explicit test action must not fall back to a previously cached result.
+  // Clearing first also lets normal notifications retry if this fresh probe
+  // fails instead of retaining stale permission state.
+  cachedPermission = null;
   cachedPermission = await checkPermission();
   return cachedPermission;
 }
@@ -311,19 +317,19 @@ export async function startNotificationClickHandler(): Promise<() => void> {
  *
  * - `"sent"`  — fire-and-forget succeeded
  * - `"denied"` — the OS rejected (or the user dismissed) the permission prompt
- * - `"error"` — `sendNotification` threw; details are logged to the console
+ * - `"error"` — the permission probe or notification send failed
  */
 export async function sendTestNotification(): Promise<"sent" | "denied" | "error"> {
-  const ok = await refreshPermission();
-  if (!ok) return "denied";
   try {
+    const ok = await refreshPermission();
+    if (!ok) return "denied";
     sendNotification({
       title: "Acorn — test notification",
       body: "If you can see this, system notifications are working.",
     });
     return "sent";
   } catch (err) {
-    console.error("[notifications] test sendNotification failed", err);
+    console.error("[notifications] test notification failed", err);
     return "error";
   }
 }

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -274,6 +274,13 @@ async function fire(
   }
 }
 
+export type NotificationClickFailureStage = "registration" | "activation";
+
+type NotificationClickFailureHandler = (
+  stage: NotificationClickFailureStage,
+  error: unknown,
+) => void;
+
 /**
  * Registers a listener that fires when the user clicks a session-status
  * notification we sent. Each notification carries the originating session id
@@ -284,25 +291,74 @@ async function fire(
  * Returns a cleanup function. Designed to run once at app boot. The Tauri
  * plugin only delivers click events while a listener is attached, so the
  * caller must keep this registration alive for the lifetime of the app.
+ * Registration and window-activation failures are reported through
+ * `onFailure`; activation failures intentionally leave inbox activity unread.
  */
-export async function startNotificationClickHandler(): Promise<() => void> {
+export async function startNotificationClickHandler(
+  onFailure?: NotificationClickFailureHandler,
+): Promise<() => void> {
   let disposed = false;
-  const listener = await onAction((notification) => {
-    if (disposed) return;
-    const sessionId =
-      typeof notification.extra?.sessionId === "string"
-        ? notification.extra.sessionId
-        : null;
-    if (!sessionId) return;
-    const win = getCurrentWindow();
-    void win.show();
-    void win.unminimize();
-    void win.setFocus();
-    useAppStore
-      .getState()
-      .openSessionSurface(sessionId, { centerInCanvas: true });
-    markSessionNotificationsRead(sessionId);
-  });
+  const reportFailure = (
+    stage: NotificationClickFailureStage,
+    error: unknown,
+  ) => {
+    console.error(`[notifications] click ${stage} failed`, error);
+    try {
+      onFailure?.(stage, error);
+    } catch (callbackError) {
+      console.error(
+        "[notifications] click failure callback failed",
+        callbackError,
+      );
+    }
+  };
+
+  let listener: Awaited<ReturnType<typeof onAction>>;
+  try {
+    listener = await onAction((notification) => {
+      if (disposed) return;
+      const sessionId =
+        typeof notification.extra?.sessionId === "string"
+          ? notification.extra.sessionId
+          : null;
+      if (!sessionId) return;
+
+      void (async () => {
+        try {
+          const opened = useAppStore
+            .getState()
+            .openSessionSurface(sessionId, { centerInCanvas: true });
+          const win = getCurrentWindow();
+          const restoreAttempts = [
+            () => win.show(),
+            () => win.unminimize(),
+            () => win.setFocus(),
+          ];
+          const restoreFailures: unknown[] = [];
+          for (const run of restoreAttempts) {
+            try {
+              await run();
+            } catch (error) {
+              restoreFailures.push(error);
+            }
+          }
+          if (disposed) return;
+          if (restoreFailures.length > 0) {
+            reportFailure("activation", restoreFailures[0]);
+            return;
+          }
+          if (opened) markSessionNotificationsRead(sessionId);
+        } catch (error) {
+          reportFailure("activation", error);
+        }
+      })();
+    });
+  } catch (error) {
+    reportFailure("registration", error);
+    return () => {
+      disposed = true;
+    };
+  }
   return () => {
     disposed = true;
     listener.unregister();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -930,7 +930,9 @@
       "shellEnvironmentReloaded": "Shell environment reloaded. Open a new session to apply.",
       "shellEnvironmentReloadFailed": "Failed to reload shell environment.",
       "preventSleepSyncFailedPrefix": "Could not apply the keep-awake setting:",
-      "controlGuidePreferenceSaveFailed": "Couldn't save the control-session guide preference."
+      "controlGuidePreferenceSaveFailed": "Couldn't save the control-session guide preference.",
+      "notificationClickRegistrationFailedPrefix": "Could not enable notification click handling:",
+      "notificationClickActivationFailedPrefix": "Could not bring Acorn to the clicked notification:"
     }
   },
   "statusBar": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -930,7 +930,9 @@
       "shellEnvironmentReloaded": "シェル環境がリロードされました。新しいセッションを開いて適用します。",
       "shellEnvironmentReloadFailed": "シェル環境のリロードに失敗しました。",
       "preventSleepSyncFailedPrefix": "スリープ防止設定を適用できませんでした:",
-      "controlGuidePreferenceSaveFailed": "コントロールセッションガイドの設定を保存できませんでした。"
+      "controlGuidePreferenceSaveFailed": "コントロールセッションガイドの設定を保存できませんでした。",
+      "notificationClickRegistrationFailedPrefix": "通知クリック処理を有効にできませんでした:",
+      "notificationClickActivationFailedPrefix": "クリックした通知から Acorn を開けませんでした:"
     }
   },
   "statusBar": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -930,7 +930,9 @@
       "shellEnvironmentReloaded": "셸 환경을 다시 불러왔습니다. 적용하려면 새 세션을 여세요.",
       "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다.",
       "preventSleepSyncFailedPrefix": "잠자기 방지 설정을 적용하지 못했습니다:",
-      "controlGuidePreferenceSaveFailed": "제어 세션 안내 설정을 저장하지 못했습니다."
+      "controlGuidePreferenceSaveFailed": "제어 세션 안내 설정을 저장하지 못했습니다.",
+      "notificationClickRegistrationFailedPrefix": "알림 클릭 처리를 활성화하지 못했습니다:",
+      "notificationClickActivationFailedPrefix": "클릭한 알림으로 Acorn을 열지 못했습니다:"
     }
   },
   "statusBar": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -930,7 +930,9 @@
       "shellEnvironmentReloaded": "shell 环境已重新加载。请打开新会话以应用更改。",
       "shellEnvironmentReloadFailed": "无法重新加载 shell 环境。",
       "preventSleepSyncFailedPrefix": "无法应用防止睡眠设置：",
-      "controlGuidePreferenceSaveFailed": "无法保存控制会话指南偏好设置。"
+      "controlGuidePreferenceSaveFailed": "无法保存控制会话指南偏好设置。",
+      "notificationClickRegistrationFailedPrefix": "无法启用通知点击处理：",
+      "notificationClickActivationFailedPrefix": "无法从点击的通知打开 Acorn："
     }
   },
   "statusBar": {


### PR DESCRIPTION
## Summary

Notification capability and activation failures no longer masquerade as durable denial, disappear as unhandled promises, or consume activity the user could not reach.

1. **Retryable permission checks** — Cache only successful permission results, leaving transient plugin/IPC failures retryable on the next qualifying session transition.
2. **Accurate test feedback** — Keep explicit OS denial separate from capability/probe errors in the Settings test-notification result.
3. **Fresh explicit probes** — Clear cached permission before the user-triggered test so stale state cannot hide a changed OS setting.
4. **Safe click registration** — Convert notification action-listener registration rejection into localized user feedback instead of an unhandled promise.
5. **Actionable activation failures** — Attempt `show`, `unminimize`, and `setFocus` in order; report any failure and retain the related inbox activity as unread.
6. **Regression coverage** — Cover transient probe retry, probe error versus denial, listener registration failure, successful click routing, and window activation failure.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Transient permission probe failure | Cached as `false`; notifications stayed off until app restart | Not cached; the next transition retries |
| Settings test after probe failure | Reported as permission denied | Reported as a notification error |
| Explicit OS permission denial | Reported as denied | Unchanged |
| Click-listener registration failure | Unhandled rejected promise | Localized toast with the failure reason |
| Window restoration after a notification click | Failures were detached and the activity was marked read immediately | Every restoration step is attempted; failures are surfaced and activity stays unread |
| Successful notification click | Opens the destination session | Opens the destination session and marks its activity read after activation succeeds |

## Design notes

- The steady-state watcher remains best-effort and logs a failed probe, but it does not convert transport/capability failure into permission state.
- The public `sendTestNotification` result union is unchanged; its existing `error` member now also represents permission-probe failures as documented.
- A real `false`/denied result is still cached because that is authoritative OS state until the explicit test action refreshes it.
- Notification click routing still selects the requested session immediately. Inbox activity is consumed only after the window restoration calls settle successfully, preserving a recovery path when OS window access fails.
- Listener setup failures resolve to a safe no-op cleanup function after reporting the failure, so App teardown remains uniform and does not create a second error path.

## Follow-up (not in this PR)

- None for this work unit.

## Test plan

- [x] `pnpm exec vitest run src/lib/notifications.test.ts src/lib/i18n.test.ts --maxWorkers=1` — 2 files / 25 tests passed
- [x] `pnpm typecheck`
- [x] `pnpm test` — 112 files / 1,355 tests passed
- [x] `pnpm build`
- [x] `git diff --check`

## Notes

- The build retains the repository's existing chunk-size and ineffective dynamic-import warnings.
