### PR TITLE
fix(daemon): keep staged-restart failures actionable

### DIFF
--- a/src/components/StagedRevMismatchModal.test.tsx
+++ b/src/components/StagedRevMismatchModal.test.tsx
@@ -1,0 +1,116 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  daemonShutdown: vi.fn<() => Promise<void>>(),
+  acknowledgeStagedRevMismatch: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    daemonShutdown: mocks.daemonShutdown,
+    acknowledgeStagedRevMismatch: mocks.acknowledgeStagedRevMismatch,
+  },
+}));
+
+import { useSettings } from "../lib/settings";
+import { StagedRevMismatchModal } from "./StagedRevMismatchModal";
+
+describe("StagedRevMismatchModal", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mocks.daemonShutdown.mockResolvedValue();
+    mocks.acknowledgeStagedRevMismatch.mockResolvedValue();
+    useSettings.getState().reset();
+    useSettings.getState().patchLanguage("en");
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function renderModal() {
+    const onDismiss = vi.fn();
+    act(() => {
+      root.render(
+        <StagedRevMismatchModal
+          mismatch={{ current_rev: "new-rev", stale_session_count: 2 }}
+          onDismiss={onDismiss}
+        />,
+      );
+    });
+    return onDismiss;
+  }
+
+  async function clickButton(label: string) {
+    const button = Array.from(document.querySelectorAll("button")).find(
+      (candidate) => candidate.textContent?.includes(label),
+    );
+    if (!button) throw new Error(`button "${label}" not found`);
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+    });
+  }
+
+  it("keeps the prompt open when daemon shutdown fails", async () => {
+    mocks.daemonShutdown.mockRejectedValueOnce(new Error("access denied"));
+    const onDismiss = renderModal();
+
+    await clickButton("Restart sessions");
+
+    expect(mocks.acknowledgeStagedRevMismatch).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Couldn't restart background sessions: access denied",
+    );
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it("does not continue after acknowledgement fails", async () => {
+    mocks.acknowledgeStagedRevMismatch.mockRejectedValueOnce(
+      new Error("IPC unavailable"),
+    );
+    const onDismiss = renderModal();
+
+    await clickButton("Restart sessions");
+
+    expect(mocks.daemonShutdown).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Couldn't restart background sessions: IPC unavailable",
+    );
+  });
+
+  it("keeps the prompt open when dismiss acknowledgement fails", async () => {
+    mocks.acknowledgeStagedRevMismatch.mockRejectedValueOnce(
+      new Error("IPC unavailable"),
+    );
+    const onDismiss = renderModal();
+
+    await clickButton("Later");
+
+    expect(mocks.daemonShutdown).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Couldn't dismiss this reminder: IPC unavailable",
+    );
+  });
+
+  it("dismisses only after acknowledgement succeeds", async () => {
+    const onDismiss = renderModal();
+
+    await clickButton("Later");
+
+    expect(mocks.acknowledgeStagedRevMismatch).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/StagedRevMismatchModal.tsx
+++ b/src/components/StagedRevMismatchModal.tsx
@@ -3,12 +3,16 @@ import { RefreshCw, Terminal } from "lucide-react";
 import { api, type StagedRevMismatch } from "../lib/api";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useTranslation } from "../lib/useTranslation";
-import { Button, Modal, ModalFooter, ModalHeader } from "./ui";
+import { Button, Modal, ModalFooter, ModalHeader, Notice } from "./ui";
 
 type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
 function dt(t: Translator, key: DialogTranslationKey): string {
   return t(key);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 interface StagedRevMismatchModalProps {
@@ -29,32 +33,37 @@ export function StagedRevMismatchModal({
 }: StagedRevMismatchModalProps): ReactElement | null {
   const t = useTranslation();
   const [restarting, setRestarting] = useState(false);
+  const [dismissing, setDismissing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (!mismatch) return null;
 
   async function handleRestart() {
+    if (restarting || dismissing) return;
     setRestarting(true);
+    setError(null);
     try {
       await api.daemonShutdown();
-    } catch (err) {
-      console.error("[StagedRevMismatchModal] daemon_shutdown failed", err);
-    }
-    try {
       await api.acknowledgeStagedRevMismatch();
+      // Webview reload re-runs the app setup. The daemon boot thread
+      // will spawn a fresh `acornd` process whose registry is empty, so
+      // the next reconcile finds nothing stale and the prompt does not
+      // reappear.
+      window.location.reload();
     } catch (err) {
-      console.error(
-        "[StagedRevMismatchModal] acknowledge_staged_rev_mismatch failed",
-        err,
+      console.error("[StagedRevMismatchModal] restart failed", err);
+      setError(
+        `${dt(t, "dialogs.stagedRevMismatch.restartFailed")} ${errorMessage(err)}`,
       );
+      setRestarting(false);
+      return;
     }
-    // Webview reload re-runs the app setup. The daemon boot thread
-    // will spawn a fresh `acornd` process whose registry is empty, so
-    // the next reconcile finds nothing stale and the prompt does not
-    // reappear.
-    window.location.reload();
   }
 
   async function handleLater() {
+    if (restarting || dismissing) return;
+    setDismissing(true);
+    setError(null);
     try {
       await api.acknowledgeStagedRevMismatch();
     } catch (err) {
@@ -62,9 +71,16 @@ export function StagedRevMismatchModal({
         "[StagedRevMismatchModal] acknowledge_staged_rev_mismatch failed",
         err,
       );
+      setError(
+        `${dt(t, "dialogs.stagedRevMismatch.dismissFailed")} ${errorMessage(err)}`,
+      );
+      setDismissing(false);
+      return;
     }
     onDismiss();
   }
+
+  const busy = restarting || dismissing;
 
   const sessionWord =
     mismatch.stale_session_count === 1
@@ -94,18 +110,23 @@ export function StagedRevMismatchModal({
         <p>
           {dt(t, "dialogs.stagedRevMismatch.bodyRestart")}
         </p>
+        {error ? (
+          <Notice tone="danger" role="alert">
+            {error}
+          </Notice>
+        ) : null}
       </div>
       <ModalFooter>
         <Button
           onClick={handleLater}
-          disabled={restarting}
+          disabled={busy}
           className="disabled:opacity-50"
         >
           {dt(t, "dialogs.stagedRevMismatch.later")}
         </Button>
         <Button
           onClick={handleRestart}
-          disabled={restarting}
+          disabled={busy}
           variant="primary"
           className="disabled:opacity-50"
         >

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2425,7 +2425,9 @@
       "bodyRestart": "Restart now to apply the new environment. Open agent conversations (Claude / Codex) will pick up where they left off on next focus.",
       "later": "Later",
       "restarting": "Restarting...",
-      "restartSessions": "Restart sessions"
+      "restartSessions": "Restart sessions",
+      "restartFailed": "Couldn't restart background sessions:",
+      "dismissFailed": "Couldn't dismiss this reminder:"
     },
     "memoryBreakdown": {
       "title": "Memory breakdown",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2425,7 +2425,9 @@
       "bodyRestart": "今すぐ再起動して新しい環境を適用します。オープン エージェントの会話 (クロード / コーデックス) は、次のフォーカスで中断したところから再開されます。",
       "later": "後で",
       "restarting": "再起動中...",
-      "restartSessions": "セッションを再開する"
+      "restartSessions": "セッションを再開する",
+      "restartFailed": "バックグラウンドセッションを再起動できませんでした:",
+      "dismissFailed": "この通知を閉じることができませんでした:"
     },
     "memoryBreakdown": {
       "title": "記憶力の低下",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2425,7 +2425,9 @@
       "bodyRestart": "새 환경을 적용하려면 지금 재시작하세요. 열린 에이전트 대화(Claude / Codex)는 다음 포커스 시점에 이어서 진행됩니다.",
       "later": "나중에",
       "restarting": "재시작 중...",
-      "restartSessions": "세션 재시작"
+      "restartSessions": "세션 재시작",
+      "restartFailed": "백그라운드 세션을 재시작하지 못했습니다:",
+      "dismissFailed": "이 알림을 닫지 못했습니다:"
     },
     "memoryBreakdown": {
       "title": "메모리 세부 정보",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -2425,7 +2425,9 @@
       "bodyRestart": "立即重启以应用新环境。打开的智能体对话（Claude / Codex）会在下次聚焦时从中断处继续。",
       "later": "稍后",
       "restarting": "正在重新启动...",
-      "restartSessions": "重新启动会话"
+      "restartSessions": "重新启动会话",
+      "restartFailed": "无法重启后台会话：",
+      "dismissFailed": "无法关闭此提醒："
     },
     "memoryBreakdown": {
       "title": "内存细分",


### PR DESCRIPTION
## Summary

The shell-environment mismatch prompt now stays actionable when daemon shutdown, acknowledgement, or reload fails.

1. **Ordered restart transaction** — Stop the restart flow at the first failed step instead of acknowledging and reloading after a daemon shutdown failure.
2. **Durable prompt state** — Dismiss only after the idempotent backend acknowledgement succeeds; failed acknowledgement leaves the modal open.
3. **Visible diagnostics** — Render the original failure inline with localized restart/dismiss context and re-enable actions for retry.
4. **Regression coverage** — Cover shutdown failure, restart acknowledgement failure, dismiss acknowledgement failure, and successful dismissal.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Daemon shutdown failure | Logged; acknowledgement and page reload still continued | Prompt stays open with the failure; acknowledgement is not attempted |
| Acknowledgement/IPC failure | Logged; prompt closed or page reloaded anyway | Prompt stays open and can be retried |
| Concurrent modal actions | Restart button alone was guarded | Both actions are disabled while either operation is active |
| Successful restart/dismiss | Reload or close | Unchanged |

## Design notes

- The backend shutdown contract returns only after the daemon ACK and clears the cached bridge connection; the frontend now preserves that ordering as a single fail-fast flow.
- `acknowledge_staged_rev_mismatch` is an idempotent in-memory clear, so retaining the modal after transport failure is safe and retryable.
- No daemon lifecycle or staged-revision backend contract changed in this work unit.

## Follow-up (not in this PR)

- None for this work unit.

## Test plan

- [x] `pnpm exec vitest run src/components/StagedRevMismatchModal.test.tsx src/lib/i18n.test.ts --maxWorkers=1` — 12 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,354 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `git diff --check` — passed

## Notes

- The build retains the repository's existing chunk-size and ineffective dynamic-import warnings.