### PR TITLE
fix(files): surface desktop file-drop failures

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -36,6 +36,8 @@ const mocks = vi.hoisted(() => ({
   agentTranscriptSummary: vi.fn(),
   agentTranscriptSummaryAtPath: vi.fn(),
   ptyWrite: vi.fn(async () => undefined),
+  fsGrantExternalFile: vi.fn(async () => undefined),
+  showTranslatedErrorToast: vi.fn(),
 }));
 
 vi.mock("../lib/api", () => ({
@@ -60,7 +62,12 @@ vi.mock("../lib/api", () => ({
     agentTranscriptSummary: mocks.agentTranscriptSummary,
     agentTranscriptSummaryAtPath: mocks.agentTranscriptSummaryAtPath,
     ptyWrite: mocks.ptyWrite,
+    fsGrantExternalFile: mocks.fsGrantExternalFile,
   },
+}));
+
+vi.mock("../lib/operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -347,6 +354,7 @@ describe("Pane empty state", () => {
     });
     mocks.fsGitDiffStats.mockResolvedValue({});
     mocks.loadChatSessionState.mockResolvedValue(chatStateWithTokens(140));
+    mocks.fsGrantExternalFile.mockResolvedValue(undefined);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -1265,6 +1273,66 @@ describe("Pane empty state", () => {
     expect(mocks.ptyWrite).toHaveBeenCalledTimes(1);
     expect(mocks.ptyWrite).toHaveBeenCalledWith(second.id, "src/App.tsx ");
     expect(useAppStore.getState().focusedPaneId).toBe("pane-2");
+  });
+
+  it("surfaces terminal write failures from file drops", async () => {
+    const active = session("active-session");
+    const filePath = `${active.worktree_path}/src/App.tsx`;
+    seedActivePaneWithTab(active);
+    mocks.ptyWrite.mockRejectedValueOnce(new Error("PTY access denied"));
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const paneBody = container.querySelector('[data-pane-body="root"]');
+    expect(paneBody).not.toBeNull();
+    mockRect(paneBody!, { left: 0, top: 40, width: 360, height: 300 });
+
+    await act(async () => {
+      dropFilePayloadsAtPoint(
+        { x: 120, y: 120 },
+        [{ path: filePath, entryKind: "file", source: "explorer" }],
+      );
+      await Promise.resolve();
+    });
+
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.files.dropInputFailed",
+      expect.objectContaining({ message: "PTY access denied" }),
+    );
+  });
+
+  it("surfaces external file grant failures from desktop drops", async () => {
+    const active = session("active-session");
+    const filePath = "/Users/me/Desktop/private.txt";
+    seedActivePaneWithTab(active);
+    mocks.fsGrantExternalFile.mockRejectedValueOnce(
+      new Error("filesystem access denied"),
+    );
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+
+    const tabStrip = container.querySelector('[data-pane-tab-strip="root"]');
+    expect(tabStrip).not.toBeNull();
+    mockRect(tabStrip!, { left: 0, top: 0, width: 320, height: 36 });
+
+    await act(async () => {
+      dropFilePayloadsAtPoint(
+        { x: 12, y: 12 },
+        [{ path: filePath, entryKind: "file", source: "native" }],
+      );
+      await Promise.resolve();
+    });
+
+    expect(mocks.fsGrantExternalFile).toHaveBeenCalledWith(filePath);
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.files.dropOpenFailed",
+      expect.objectContaining({ message: "filesystem access denied" }),
+    );
+    expect(useAppStore.getState().panes.root.tabIds).toEqual([active.id]);
   });
 
   it("keeps the file mention prefix for Claude agent terminal drops", () => {

--- a/src/lib/fileDropTargets.ts
+++ b/src/lib/fileDropTargets.ts
@@ -3,6 +3,7 @@ import { resolveSessionAgentProvider } from "./agentProvider";
 import { formatTerminalFileMention } from "./fileMention";
 import type { PaneId } from "./layout";
 import { visibleMultiInputSessionIds } from "./multiInput";
+import { showTranslatedErrorToast } from "./operationToasts";
 import type { SessionAgentProvider } from "./types";
 import { useAppStore } from "../store";
 
@@ -127,11 +128,13 @@ function writePayloadsToTerminal(
     .join("");
   if (!data) return;
 
-  for (const sessionId of ptyWriteTargets(target.sessionId)) {
-    void api.ptyWrite(sessionId, data).catch((err: unknown) => {
-      console.error("[fileDropTargets] pty_write failed", err);
-    });
-  }
+  const writes = ptyWriteTargets(target.sessionId).map((sessionId) =>
+    api.ptyWrite(sessionId, data),
+  );
+  void Promise.all(writes).catch((err: unknown) => {
+    console.error("[fileDropTargets] pty_write failed", err);
+    showTranslatedErrorToast("toasts.files.dropInputFailed", err);
+  });
 }
 
 async function openPayloadsInPane(
@@ -247,6 +250,7 @@ export function applyFileDropTarget(
 
   void openPayloadsInPane(target.paneId, payloads).catch((err: unknown) => {
     console.error("[fileDropTargets] file open failed", err);
+    showTranslatedErrorToast("toasts.files.dropOpenFailed", err);
   });
 }
 

--- a/src/lib/nativeFileDrop.test.ts
+++ b/src/lib/nativeFileDrop.test.ts
@@ -1,5 +1,40 @@
-import { describe, expect, it } from "vitest";
-import { resolveNativeDropScaleFactor } from "./nativeFileDrop";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  onDragDropEvent: vi.fn(),
+  onScaleChanged: vi.fn(),
+  scaleFactor: vi.fn(),
+  showTranslatedErrorToast: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: mocks.onDragDropEvent,
+  }),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    onScaleChanged: mocks.onScaleChanged,
+    scaleFactor: mocks.scaleFactor,
+  }),
+}));
+
+vi.mock("./operationToasts", () => ({
+  showTranslatedErrorToast: mocks.showTranslatedErrorToast,
+}));
+
+import {
+  resolveNativeDropScaleFactor,
+  useNativeFileDropBridge,
+} from "./nativeFileDrop";
+
+function NativeDropBridgeHarness() {
+  useNativeFileDropBridge();
+  return null;
+}
 
 describe("resolveNativeDropScaleFactor", () => {
   it("accepts positive monitor scale changes", () => {
@@ -10,5 +45,45 @@ describe("resolveNativeDropScaleFactor", () => {
   it("retains the last usable scale for invalid events", () => {
     expect(resolveNativeDropScaleFactor(0, 1.5)).toBe(1.5);
     expect(resolveNativeDropScaleFactor(Number.NaN, 2)).toBe(2);
+  });
+});
+
+describe("useNativeFileDropBridge", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.scaleFactor.mockResolvedValue(1);
+    mocks.onScaleChanged.mockResolvedValue(() => {});
+    mocks.onDragDropEvent.mockResolvedValue(() => {});
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("surfaces failure to register the desktop drop listener", async () => {
+    const error = new Error("drag capability denied");
+    mocks.onDragDropEvent.mockRejectedValueOnce(error);
+
+    await act(async () => {
+      root.render(createElement(NativeDropBridgeHarness));
+      await Promise.resolve();
+    });
+
+    expect(mocks.showTranslatedErrorToast).toHaveBeenCalledWith(
+      "toasts.files.dropListenerFailed",
+      error,
+    );
   });
 });

--- a/src/lib/nativeFileDrop.ts
+++ b/src/lib/nativeFileDrop.ts
@@ -3,6 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useState } from "react";
 import { hasNativeFileDropData } from "./fileDrop";
 import { useFileExplorerDragSession } from "./fileExplorerDrag";
+import { showTranslatedErrorToast } from "./operationToasts";
 import {
   dropFilePayloadsAtPoint,
   resolveFileDropTargetAtPoint,
@@ -218,6 +219,7 @@ export function useNativeFileDropBridge(): NativeFileDropHoverTarget | null {
       })
       .catch((err: unknown) => {
         console.error("[nativeFileDrop] listener setup failed", err);
+        showTranslatedErrorToast("toasts.files.dropListenerFailed", err);
       });
 
     return () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,7 +61,10 @@
       "revealFailed": "Failed to reveal the path in the file manager:",
       "pathsCopied": "File paths copied.",
       "copyFailed": "Failed to copy file paths.",
-      "terminalLinkOpenFailed": "Failed to open terminal file link:"
+      "terminalLinkOpenFailed": "Failed to open terminal file link:",
+      "dropListenerFailed": "Desktop file drop is unavailable:",
+      "dropOpenFailed": "Failed to open dropped file:",
+      "dropInputFailed": "Failed to insert dropped file path into the terminal:"
     },
     "pullRequests": {
       "mergeFailed": "Failed to merge pull request:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -61,7 +61,10 @@
       "revealFailed": "ファイルマネージャーでパスを表示できませんでした:",
       "pathsCopied": "ファイルパスがコピーされました。",
       "copyFailed": "ファイルパスのコピーに失敗しました。",
-      "terminalLinkOpenFailed": "ターミナルのファイルリンクを開けませんでした:"
+      "terminalLinkOpenFailed": "ターミナルのファイルリンクを開けませんでした:",
+      "dropListenerFailed": "デスクトップからのファイルドロップを利用できません:",
+      "dropOpenFailed": "ドロップしたファイルを開けませんでした:",
+      "dropInputFailed": "ドロップしたファイルパスをターミナルに入力できませんでした:"
     },
     "pullRequests": {
       "mergeFailed": "プル リクエストのマージに失敗しました:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -61,7 +61,10 @@
       "revealFailed": "파일 관리자에서 경로를 표시하지 못했습니다:",
       "pathsCopied": "파일 경로를 복사했습니다.",
       "copyFailed": "파일 경로를 복사하지 못했습니다.",
-      "terminalLinkOpenFailed": "터미널 파일 링크를 열지 못했습니다:"
+      "terminalLinkOpenFailed": "터미널 파일 링크를 열지 못했습니다:",
+      "dropListenerFailed": "데스크톱 파일 드롭을 사용할 수 없습니다:",
+      "dropOpenFailed": "드롭한 파일을 열지 못했습니다:",
+      "dropInputFailed": "드롭한 파일 경로를 터미널에 입력하지 못했습니다:"
     },
     "pullRequests": {
       "mergeFailed": "Pull request를 병합하지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -61,7 +61,10 @@
       "revealFailed": "无法在文件管理器中显示该路径：",
       "pathsCopied": "已复制文件路径。",
       "copyFailed": "无法复制文件路径。",
-      "terminalLinkOpenFailed": "无法打开终端文件链接："
+      "terminalLinkOpenFailed": "无法打开终端文件链接：",
+      "dropListenerFailed": "桌面文件拖放不可用：",
+      "dropOpenFailed": "无法打开拖放的文件：",
+      "dropInputFailed": "无法将拖放的文件路径输入终端："
     },
     "pullRequests": {
       "mergeFailed": "无法合并拉取请求：",


### PR DESCRIPTION
## Summary

Desktop and explorer file-drop failures now remain visible instead of disappearing into the developer console.

1. **Listener capability feedback** — Surface failure to register Tauri's desktop drag/drop listener, while retaining silent fallback for optional scale-factor probes.
2. **External file authorization feedback** — Report canonicalization, missing-file, and access-denied failures from the native-file grant before a code tab is opened.
3. **Terminal input feedback** — Report PTY/daemon write failures when dropped paths cannot be inserted into the destination terminal.
4. **Single fan-out result** — Start every multi-input PTY write as before, but aggregate them behind one rejection boundary so one drop produces at most one failure toast.
5. **Regression coverage** — Cover listener registration rejection, external grant rejection, and terminal write rejection.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Desktop drop listener unavailable | Console-only setup error | Localized toast with the original capability error |
| Native file grant/access failure | Console-only; dropped file did not open | Localized toast; failed file remains unopened |
| Terminal/daemon write failure | Console-only; dropped path did not appear | Localized toast with the original PTY error |
| Multi-input write failure | One console error per failed target | One user-facing error per drop |
| Successful drops and scale fallback | Existing behavior | Unchanged |

## Design notes

- Tauri remains the authorization boundary: `fs_grant_external_file` still canonicalizes the path, rejects dangerous/non-file paths, and retains the grant only after success.
- The drop target resolver and pane focus behavior are unchanged.
- Coordinate and scale-factor probes remain best-effort because their existing fallbacks preserve drop functionality; only failure of the actual listener or requested drop action is surfaced.

## Follow-up (not in this PR)

- Terminal hyperlink file grants use the same backend boundary but are outside this drag/drop work unit.

## Test plan

- [x] `pnpm exec vitest run src/components/Pane.test.tsx src/lib/nativeFileDrop.test.ts src/lib/i18n.test.ts --maxWorkers=1` — 38 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,353 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `git diff --check` — passed

## Notes

- The build retains the repository's existing chunk-size and ineffective dynamic-import warnings.