### PR TITLE
fix(terminal): surface file-link authorization failures

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -857,7 +857,7 @@ export function Terminal({
             useAppStore.getState().openCodeViewerTab(filePath, cwd);
           })
           .catch((err: unknown) => {
-            console.error("failed to open terminal file link", uri, err);
+            showTranslatedErrorToast("toasts.files.terminalLinkOpenFailed", err);
           });
         return;
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -48,7 +48,8 @@
       "renameFailed": "Failed to rename file:",
       "trashFailed": "Failed to move to trash:",
       "pathsCopied": "File paths copied.",
-      "copyFailed": "Failed to copy file paths."
+      "copyFailed": "Failed to copy file paths.",
+      "terminalLinkOpenFailed": "Failed to open terminal file link:"
     },
     "pullRequests": {
       "mergeFailed": "Failed to merge pull request:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -48,7 +48,8 @@
       "renameFailed": "ファイル名の変更に失敗しました:",
       "trashFailed": "ゴミ箱に移動できませんでした:",
       "pathsCopied": "ファイルパスがコピーされました。",
-      "copyFailed": "ファイルパスのコピーに失敗しました。"
+      "copyFailed": "ファイルパスのコピーに失敗しました。",
+      "terminalLinkOpenFailed": "ターミナルのファイルリンクを開けませんでした:"
     },
     "pullRequests": {
       "mergeFailed": "プル リクエストのマージに失敗しました:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -48,7 +48,8 @@
       "renameFailed": "파일 이름을 바꾸지 못했습니다:",
       "trashFailed": "휴지통으로 이동하지 못했습니다:",
       "pathsCopied": "파일 경로를 복사했습니다.",
-      "copyFailed": "파일 경로를 복사하지 못했습니다."
+      "copyFailed": "파일 경로를 복사하지 못했습니다.",
+      "terminalLinkOpenFailed": "터미널 파일 링크를 열지 못했습니다:"
     },
     "pullRequests": {
       "mergeFailed": "Pull request를 병합하지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -48,7 +48,8 @@
       "renameFailed": "无法重命名文件：",
       "trashFailed": "无法移至垃圾箱：",
       "pathsCopied": "已复制文件路径。",
-      "copyFailed": "无法复制文件路径。"
+      "copyFailed": "无法复制文件路径。",
+      "terminalLinkOpenFailed": "无法打开终端文件链接："
     },
     "pullRequests": {
       "mergeFailed": "无法合并拉取请求：",

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -2896,6 +2896,84 @@ test.describe("terminal: spawn", () => {
     await expect(page.locator('img[alt="preview image (1).png"]')).toBeVisible();
   });
 
+  test("surfaces terminal file URL grant failures", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __deniedFileUrlLinkChannelId?: number;
+      };
+      w.__deniedFileUrlLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_grant_external_file", () => {
+      throw new Error("filesystem access denied");
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __deniedFileUrlLinkChannelId?: number;
+              }
+            ).__deniedFileUrlLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const uri = "file:///Users/tester/Desktop/private.txt";
+    await emitSubscribedPtyOutput(
+      page,
+      "__deniedFileUrlLinkChannelId",
+      `Saved to: ${uri}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(uri);
+
+    const textRect = await terminalTextRect(page, uri);
+    expect(textRect).not.toBeNull();
+    await page.mouse.click(
+      textRect!.left + Math.min(12, textRect!.width / 2),
+      (textRect!.top + textRect!.bottom) / 2,
+    );
+
+    await expect(
+      page.getByRole("status").filter({
+        hasText: "Failed to open terminal file link: filesystem access denied",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /private\.txt Close tab/ }),
+    ).toHaveCount(0);
+  });
+
   test("keeps modifier-click link tooltip mounted while output streams", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Terminal `file://` link authorization failures now stay visible and leave the workspace unchanged.

1. **Access feedback** — Surface the original `fs_grant_external_file` rejection in a localized toast when a clicked terminal file URL cannot be authorized.
2. **Scope preservation** — Keep the existing click-only grant boundary; terminal output and hover still cannot expand the viewer's filesystem scope.
3. **No partial open** — Continue opening the code/media tab only after the backend canonicalizes and grants the external file.
4. **Browser regression coverage** — Exercise a real Tauri-mock access denial and verify both the toast and absence of a new tab.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Terminal file URL access denial | Console-only failure; no tab opened | Localized toast includes the backend error; no tab opens |
| Successful terminal file URL | Grant, then open code/media viewer | Unchanged |
| Link hover/output | No filesystem grant | Unchanged |
| Non-file terminal links | OS opener path | Unchanged |

## Design notes

- `fs_grant_external_file` remains the authority: it rejects dangerous paths, canonicalization/access failures, missing files, and non-file targets before adding the canonical path to the scoped grants.
- The catch now has a user-visible owner, so it no longer emits a duplicate expected console error.
- This PR is intentionally separate from desktop drag/drop, which reaches the same backend grant through a different interaction boundary.

## Follow-up (not in this PR)

- None for this work unit.

## Test plan

- [x] `pnpm exec vitest run src/lib/i18n.test.ts --maxWorkers=1` — 8 passed
- [x] `pnpm exec vitest run --maxWorkers=1` — 1,350 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm run build` — passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts --grep "surfaces terminal file URL grant failures" --workers=1` — passed
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts --workers=1` — 43 passed; one unrelated fixture-setup timeout
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts --grep "shows stable hover underline for OSC URI terminal links" --workers=1` — isolated rerun passed
- [x] `git diff --check` — passed

## Notes

- The full terminal E2E run timed out once while setting up the Playwright `page` fixture for the pre-existing OSC URI hover test, before that test reached application actions. Its isolated rerun passed in 0.7s.
- The build retains the repository's existing chunk-size and ineffective dynamic-import warnings.