### PR TITLE
fix(power): surface keep-awake application failures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -850,8 +850,11 @@ function App() {
     void api.setPreventSleep(preventSleep).catch((err) => {
       lastPreventSleepSync = null;
       console.warn("[App] prevent-sleep sync failed", err);
+      showToast(
+        `${appText(t, "app.toast.preventSleepSyncFailedPrefix")} ${err instanceof Error ? err.message : String(err)}`,
+      );
     });
-  }, [preventSleep]);
+  }, [preventSleep, showToast, t]);
 
   // Auto-update: check once on startup, then every 24h. Both calls are
   // best-effort and non-blocking — surfaced via the App-level

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -908,7 +908,8 @@
       "multiInputOn": "Multi-input enabled.",
       "multiInputOff": "Multi-input disabled.",
       "shellEnvironmentReloaded": "Shell environment reloaded. Open a new session to apply.",
-      "shellEnvironmentReloadFailed": "Failed to reload shell environment."
+      "shellEnvironmentReloadFailed": "Failed to reload shell environment.",
+      "preventSleepSyncFailedPrefix": "Could not apply the keep-awake setting:"
     }
   },
   "statusBar": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -908,7 +908,8 @@
       "multiInputOn": "複数入力が可能です。",
       "multiInputOff": "マルチ入力が無効になっています。",
       "shellEnvironmentReloaded": "シェル環境がリロードされました。新しいセッションを開いて適用します。",
-      "shellEnvironmentReloadFailed": "シェル環境のリロードに失敗しました。"
+      "shellEnvironmentReloadFailed": "シェル環境のリロードに失敗しました。",
+      "preventSleepSyncFailedPrefix": "スリープ防止設定を適用できませんでした:"
     }
   },
   "statusBar": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -908,7 +908,8 @@
       "multiInputOn": "다중 입력을 켰습니다.",
       "multiInputOff": "다중 입력을 껐습니다.",
       "shellEnvironmentReloaded": "셸 환경을 다시 불러왔습니다. 적용하려면 새 세션을 여세요.",
-      "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다."
+      "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다.",
+      "preventSleepSyncFailedPrefix": "잠자기 방지 설정을 적용하지 못했습니다:"
     }
   },
   "statusBar": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -908,7 +908,8 @@
       "multiInputOn": "启用多输入。",
       "multiInputOff": "禁用多输入。",
       "shellEnvironmentReloaded": "shell 环境已重新加载。请打开新会话以应用更改。",
-      "shellEnvironmentReloadFailed": "无法重新加载 shell 环境。"
+      "shellEnvironmentReloadFailed": "无法重新加载 shell 环境。",
+      "preventSleepSyncFailedPrefix": "无法应用防止睡眠设置："
     }
   },
   "statusBar": {

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -651,6 +651,54 @@ test.describe("settings modal", () => {
       .toBe(false);
   });
 
+  test("surfaces keep-awake backend failures while retaining the preference", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "platform", {
+        get: () => "MacIntel",
+        configurable: true,
+      });
+    });
+    await tauri.handle("set_prevent_sleep", (args) => {
+      const enabled =
+        !!args &&
+        typeof args === "object" &&
+        "enabled" in args &&
+        !!args.enabled;
+      if (enabled) throw new Error("permission denied");
+      return { supported: true, enabled: false };
+    });
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "," });
+    const modal = page.getByRole("dialog", { name: SETTINGS_DIALOG_NAME });
+    await modal.getByRole("button", { name: /^(Sessions|세션)$/ }).click();
+
+    const checkbox = modal.getByRole("checkbox", {
+      name: /Keep this Mac awake|이 Mac 잠자기 방지/,
+    });
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.click();
+
+    await expect(
+      page.getByRole("status").filter({
+        hasText:
+          /Could not apply the keep-awake setting:.*permission denied|잠자기 방지 설정을 적용하지 못했습니다:.*permission denied/,
+      }),
+    ).toBeVisible();
+    await expect(checkbox).toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const raw = window.localStorage.getItem("acorn:settings:v1");
+          return raw ? JSON.parse(raw).power?.preventSleep : null;
+        }),
+      )
+      .toBe(true);
+  });
+
   test("toggles the working-session close warning from Sessions settings", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

The macOS keep-awake preference could be saved even when creating the OS power assertion failed, leaving the user-visible toggle enabled while the failure was only written to the developer console.

1. **Visible failure feedback** — show a localized toast with the backend error when `set_prevent_sleep` rejects.
2. **Preference semantics** — retain the user's requested preference so Acorn can retry applying it on a later launch, while making the current runtime failure explicit.
3. **Regression coverage** — exercise a rejected Tauri command and verify both the toast and persisted preference.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Keep-awake assertion succeeds | Preference and runtime state synchronize | Unchanged |
| OS/Tauri rejects the assertion | Toggle stays enabled; failure appears only in the console | Localized toast includes the failure reason; requested preference remains saved for a later retry |

## Design notes

The persisted value represents the user's desired setting, while the backend owns the current OS assertion. A transient permission or platform failure should not erase that preference; the UI now reports the mismatch immediately and the existing sync guard remains eligible to retry after a failure.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/settings.spec.ts --grep "keep-awake"` — 2 passed
- [x] `pnpm test -- src/lib/i18n.test.ts` — 8 passed
- [x] `pnpm typecheck`
- [x] `pnpm test` — 112 files / 1,350 tests passed
- [x] `pnpm build`
