### PR TITLE
fix(sessions): isolate control-guide storage failures

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1897,7 +1897,14 @@ function App() {
         onClose={(dontShowAgain) => {
           setControlGuideOpen(false);
           if (dontShowAgain && typeof window !== "undefined") {
-            window.localStorage.setItem(CONTROL_GUIDE_DISMISSED_KEY, "1");
+            try {
+              window.localStorage.setItem(CONTROL_GUIDE_DISMISSED_KEY, "1");
+            } catch (error) {
+              console.warn("[App] control guide preference write failed", error);
+              showToast(
+                appText(t, "app.toast.controlGuidePreferenceSaveFailed"),
+              );
+            }
           }
         }}
       />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -922,7 +922,8 @@
       "multiInputOff": "Multi-input disabled.",
       "shellEnvironmentReloaded": "Shell environment reloaded. Open a new session to apply.",
       "shellEnvironmentReloadFailed": "Failed to reload shell environment.",
-      "preventSleepSyncFailedPrefix": "Could not apply the keep-awake setting:"
+      "preventSleepSyncFailedPrefix": "Could not apply the keep-awake setting:",
+      "controlGuidePreferenceSaveFailed": "Couldn't save the control-session guide preference."
     }
   },
   "statusBar": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -922,7 +922,8 @@
       "multiInputOff": "マルチ入力が無効になっています。",
       "shellEnvironmentReloaded": "シェル環境がリロードされました。新しいセッションを開いて適用します。",
       "shellEnvironmentReloadFailed": "シェル環境のリロードに失敗しました。",
-      "preventSleepSyncFailedPrefix": "スリープ防止設定を適用できませんでした:"
+      "preventSleepSyncFailedPrefix": "スリープ防止設定を適用できませんでした:",
+      "controlGuidePreferenceSaveFailed": "コントロールセッションガイドの設定を保存できませんでした。"
     }
   },
   "statusBar": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -922,7 +922,8 @@
       "multiInputOff": "다중 입력을 껐습니다.",
       "shellEnvironmentReloaded": "셸 환경을 다시 불러왔습니다. 적용하려면 새 세션을 여세요.",
       "shellEnvironmentReloadFailed": "셸 환경을 다시 불러오지 못했습니다.",
-      "preventSleepSyncFailedPrefix": "잠자기 방지 설정을 적용하지 못했습니다:"
+      "preventSleepSyncFailedPrefix": "잠자기 방지 설정을 적용하지 못했습니다:",
+      "controlGuidePreferenceSaveFailed": "제어 세션 안내 설정을 저장하지 못했습니다."
     }
   },
   "statusBar": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -922,7 +922,8 @@
       "multiInputOff": "禁用多输入。",
       "shellEnvironmentReloaded": "shell 环境已重新加载。请打开新会话以应用更改。",
       "shellEnvironmentReloadFailed": "无法重新加载 shell 环境。",
-      "preventSleepSyncFailedPrefix": "无法应用防止睡眠设置："
+      "preventSleepSyncFailedPrefix": "无法应用防止睡眠设置：",
+      "controlGuidePreferenceSaveFailed": "无法保存控制会话指南偏好设置。"
     }
   },
   "statusBar": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -3805,6 +3805,42 @@ describe("createSession", () => {
     }
   });
 
+  it("keeps a created control session when the guide preference is inaccessible", async () => {
+    const events: Event[] = [];
+    const listener = (event: Event) => events.push(event);
+    const originalGetItem = Storage.prototype.getItem;
+    const storageError = new DOMException("storage blocked", "SecurityError");
+    const getItem = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(function (this: Storage, key: string) {
+        if (key === guideKey) throw storageError;
+        return originalGetItem.call(this, key);
+      });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    window.addEventListener("acorn:show-control-guide", listener);
+    try {
+      mockApi.createSession.mockResolvedValueOnce(
+        session("ctl", REPO_A, { kind: "control" }),
+      );
+
+      const created = await useAppStore
+        .getState()
+        .createSession("ctl", REPO_A, false, "control");
+
+      expect(created?.id).toBe("ctl");
+      expect(useAppStore.getState().error).toBeNull();
+      expect(events).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(
+        "[store] control guide preference read failed",
+        storageError,
+      );
+    } finally {
+      window.removeEventListener("acorn:show-control-guide", listener);
+      getItem.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it("suppresses the guide event when the dismissed flag is set", async () => {
     window.localStorage.setItem(guideKey, "1");
     const events: Event[] = [];

--- a/src/store.ts
+++ b/src/store.ts
@@ -112,6 +112,16 @@ let activeStatusPollIds = new Set<string>();
 let refreshSessionsSeq = 0;
 let sessionPlacementSeq = 0;
 
+function shouldShowControlSessionGuide(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return !window.localStorage.getItem(CONTROL_GUIDE_DISMISSED_KEY);
+  } catch (error) {
+    console.warn("[store] control guide preference read failed", error);
+    return true;
+  }
+}
+
 function sessionProcessSummariesEqual(
   a: readonly SessionProcessSummary[],
   b: readonly SessionProcessSummary[],
@@ -3109,11 +3119,7 @@ export const useAppStore = create<AppStateModel>()(
       }
       // First-run guidance for control sessions. Gated on a localStorage
       // flag so power users only see it once. App.tsx hosts the modal.
-      if (
-        kind === "control" &&
-        typeof window !== "undefined" &&
-        !window.localStorage.getItem(CONTROL_GUIDE_DISMISSED_KEY)
-      ) {
+      if (kind === "control" && shouldShowControlSessionGuide()) {
         window.dispatchEvent(new CustomEvent("acorn:show-control-guide"));
       }
       return created;

--- a/tests/e2e/control-session.spec.ts
+++ b/tests/e2e/control-session.spec.ts
@@ -91,6 +91,40 @@ test.describe("control session: creation flow", () => {
     expect(dismissed).toBe("1");
   });
 
+  test("reports when the control-session guide preference cannot be saved", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(() => {
+      const originalSetItem = Storage.prototype.setItem;
+      Storage.prototype.setItem = function (key: string, value: string) {
+        if (key === "acorn:control-guide-dismissed-v1") {
+          throw new DOMException("storage blocked", "SecurityError");
+        }
+        return originalSetItem.call(this, key, value);
+      };
+      window.dispatchEvent(new CustomEvent("acorn:show-control-guide"));
+    });
+
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeVisible();
+    await page
+      .getByRole("checkbox", { name: /Don't show this again/i })
+      .check();
+    await page.getByRole("button", { name: "Got it" }).click();
+
+    await expect(
+      page.getByText(
+        "Couldn't save the control-session guide preference.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Control session" }),
+    ).toBeHidden();
+  });
+
   test("command palette exposes a 'New control session' entry", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Control-session creation now stays successful when the optional onboarding preference is inaccessible, while an explicit “don't show again” write failure remains visible to the user.

1. **Creation isolation** — read the guide dismissal flag behind a guarded optional boundary so a `localStorage` permission error cannot turn an already-created backend session into a reported failure.
2. **Safe fallback** — show the informational guide when its dismissal state cannot be read instead of encouraging the user to retry session creation.
3. **Write feedback** — close the guide normally but show a localized toast when the browser refuses to persist “don't show again.”
4. **Regression coverage** — verify the store returns the created session and emits the guide event after a storage `SecurityError`, and verify the rendered save-failure toast.

## Expected impact

| Scenario | Before | After | Expected impact |
| --- | --- | --- | --- |
| Guide preference read is denied after backend session creation | `createSession` returns `null` and reports the whole creation as failed | The created session is returned and the guide opens | Prevents duplicate control sessions when a user retries an operation that already succeeded |
| “Don't show again” write is denied | The modal closes with no indication that the preference was lost | The modal closes and a localized failure toast appears | The user knows the guide may appear again |
| Storage is available | The guide is shown once and dismissal persists | Unchanged | No change to the normal onboarding flow |

## Design notes

- The guide preference is optional metadata and runs after the authoritative backend session create/refresh path. Its read therefore fails open to showing the guide and cannot alter the creation result.
- The write remains a user-triggered preference change, so failure is surfaced at the action site in all four supported locales.
- This PR intentionally scopes the change to the control-session guide boundary; a shared checked browser-storage facade for persistent application state remains a separate structural decision.

## Test plan

- [x] `pnpm exec vitest run src/store.test.ts -t "guide preference"` — 1 passed
- [x] `pnpm exec playwright test tests/e2e/control-session.spec.ts --workers=1` — 3 passed
- [x] `pnpm run typecheck` — passed
- [x] `pnpm test` — 1,351 passed
- [x] `pnpm run build` — passed
- [x] `git diff --check`

## Notes

- The production build retains the pre-existing dynamic-import and chunk-size warnings; this PR does not change bundling.
- The control-session E2E retains the pre-existing Radix dialog accessibility warning in the command-palette case; it is not caused by this PR.
- The repository does not include a Prettier dependency or formatting script, so formatting verification used TypeScript compilation and the repository's test/build gates.
