### PR TITLE
fix(ipc): fail closed on stale endpoint access

### DIFF
--- a/src-tauri/crates/acorn-local-ipc/src/lib.rs
+++ b/src-tauri/crates/acorn-local-ipc/src/lib.rs
@@ -77,17 +77,13 @@ fn bind_platform(endpoint: &Path) -> io::Result<Listener> {
     if let Some(parent) = endpoint.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    if endpoint.exists() {
-        let _ = std::fs::remove_file(endpoint);
-    }
+    remove_stale_endpoint(endpoint)?;
 
     // Keep the staging name deterministic and shorter than the canonical
     // socket. The listener's reclaim guard is disabled because the bound
     // pathname is renamed before the listener is dropped.
     let staging = endpoint.with_extension("tmp");
-    if staging.exists() {
-        let _ = std::fs::remove_file(&staging);
-    }
+    remove_stale_endpoint(&staging)?;
     let name = endpoint_name(&staging)?;
     let listener = ListenerOptions::new()
         .name(name)
@@ -104,6 +100,50 @@ fn bind_platform(endpoint: &Path) -> io::Result<Listener> {
         return Err(err);
     }
     Ok(listener)
+}
+
+#[cfg(unix)]
+fn remove_stale_endpoint(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::FileTypeExt;
+
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(endpoint_inspection_error(path, error)),
+    };
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || (!file_type.is_file() && !file_type.is_socket()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "local IPC endpoint is not a regular file or Unix socket: {}",
+                path.display()
+            ),
+        ));
+    }
+    std::fs::remove_file(path).map_err(|error| endpoint_removal_error(path, error))
+}
+
+#[cfg(unix)]
+fn endpoint_inspection_error(path: &Path, error: io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!(
+            "failed to inspect stale local IPC endpoint {}: {error}",
+            path.display()
+        ),
+    )
+}
+
+#[cfg(unix)]
+fn endpoint_removal_error(path: &Path, error: io::Error) -> io::Error {
+    io::Error::new(
+        error.kind(),
+        format!(
+            "failed to remove stale local IPC endpoint {}: {error}",
+            path.display()
+        ),
+    )
 }
 
 #[cfg(windows)]
@@ -310,6 +350,102 @@ mod tests {
         drop((server, listener));
         cleanup(&endpoint);
         assert!(!endpoint.exists());
+        let _ = std::fs::remove_dir_all(scratch);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_rejects_symlinked_canonical_endpoint_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let scratch = tempfile_dir();
+        let target = scratch.join("keep.txt");
+        let endpoint = scratch.join("linked.sock");
+        std::fs::write(&target, b"keep").expect("write target");
+        symlink(&target, &endpoint).expect("create endpoint symlink");
+
+        let error = bind(&endpoint).expect_err("a linked endpoint must not be reclaimed");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(std::fs::read(&target).unwrap(), b"keep");
+        assert!(std::fs::symlink_metadata(&endpoint)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let _ = std::fs::remove_dir_all(scratch);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_rejects_symlinked_staging_endpoint_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let scratch = tempfile_dir();
+        let target = scratch.join("keep.txt");
+        let endpoint = scratch.join("canonical.sock");
+        let staging = endpoint.with_extension("tmp");
+        std::fs::write(&target, b"keep").expect("write target");
+        symlink(&target, &staging).expect("create staging symlink");
+
+        let error = bind(&endpoint).expect_err("a linked staging endpoint must not be reclaimed");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(std::fs::read(&target).unwrap(), b"keep");
+        assert!(std::fs::symlink_metadata(&staging)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let _ = std::fs::remove_dir_all(scratch);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_endpoint_probe_preserves_parent_access_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let scratch = tempfile_dir();
+        let blocked = scratch.join("blocked");
+        let endpoint = blocked.join("endpoint.sock");
+        std::fs::create_dir(&blocked).expect("create blocked parent");
+        let original = std::fs::metadata(&blocked).unwrap().permissions();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000))
+            .expect("deny parent access");
+
+        let result = remove_stale_endpoint(&endpoint);
+        let permission_denied = matches!(
+            std::fs::symlink_metadata(&endpoint),
+            Err(ref error) if error.kind() == io::ErrorKind::PermissionDenied
+        );
+
+        std::fs::set_permissions(&blocked, original).expect("restore parent access");
+        if permission_denied {
+            let error = result.expect_err("access failure must remain an error");
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(error.to_string().contains(&endpoint.display().to_string()));
+        }
+        let _ = std::fs::remove_dir_all(scratch);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stale_endpoint_removal_preserves_permission_errors() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let scratch = tempfile_dir();
+        let endpoint = scratch.join("endpoint.sock");
+        std::fs::write(&endpoint, b"stale").expect("write stale marker");
+        let original = std::fs::metadata(&scratch).unwrap().permissions();
+        std::fs::set_permissions(&scratch, std::fs::Permissions::from_mode(0o500))
+            .expect("deny marker removal");
+
+        let result = remove_stale_endpoint(&endpoint);
+
+        std::fs::set_permissions(&scratch, original).expect("restore parent access");
+        if endpoint.exists() {
+            let error = result.expect_err("removal failure must remain an error");
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            assert!(error.to_string().contains(&endpoint.display().to_string()));
+        }
         let _ = std::fs::remove_dir_all(scratch);
     }
 


### PR DESCRIPTION
## Summary

Local IPC listeners now surface stale-endpoint access failures and refuse to delete unexpected filesystem objects before binding.

1. **Checked stale-endpoint inspection** — replace `Path::exists` plus ignored deletion results with a fallible inspection/removal path for both canonical and staging endpoints.
2. **Constrained reclamation** — reclaim only Unix sockets and legacy regular-file placeholders; reject symlinks, directories, FIFOs, and other special files without touching them.
3. **Diagnostic preservation** — retain the original `io::ErrorKind` for inspection and removal failures while adding the affected endpoint path.
4. **Regression coverage** — cover canonical and staging symlinks, access-denied inspection/removal, existing round trips, and the macOS socket-path boundary.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Permission failures | Could be treated as absence or ignored before bind | Fail immediately with the original error kind and endpoint path |
| Unexpected endpoint objects | Could be unlinked blindly | Are rejected without deletion |
| Legacy stale placeholders | Reclaimed | Still reclaimed for backward compatibility |
| App and daemon listeners | Shared the unchecked helper | Share the checked reclamation contract |

## Design notes

- The app IPC server and daemon control/stream servers all bind through `acorn-local-ipc`, so the policy is enforced once at their shared boundary.
- Regular files remain reclaimable because older lifecycle paths and daemon regression fixtures use them as stale endpoint placeholders.
- Windows named-pipe behavior is unchanged.

## Follow-up (not in this PR)

- Post-bind endpoint ownership and cleanup races require a separate lifecycle contract; this PR is limited to safe pre-bind stale reclamation.

## Test plan

- [x] `cargo test -p acorn-local-ipc -- --test-threads=1` — 6 tests passed.
- [x] `cargo test -p acorn-daemon socket::tests -- --test-threads=1` — 2 tests passed, including legacy regular-file reclamation.
- [x] `cargo test -p acorn --lib ipc::server::tests -- --test-threads=1` — 14 tests passed.
- [x] `cargo check --workspace` — passed with 5 pre-existing app warnings.
- [x] `cargo clippy -p acorn-local-ipc --all-targets -- -D warnings` — passed.
- [x] `rustfmt --edition 2021 --check src-tauri/crates/acorn-local-ipc/src/lib.rs` — passed.
- [x] `git diff --check` — passed.

## Notes

- The permission tests restore directory modes before cleanup and tolerate elevated environments where Unix permission denial cannot be reproduced.