### PR TITLE
fix(github): fail cleanly on gh stdin errors

### DIFF
--- a/src-tauri/crates/acorn-platform/src/process.rs
+++ b/src-tauri/crates/acorn-platform/src/process.rs
@@ -180,9 +180,22 @@ pub fn run_bounded(
         std::thread::sleep(Duration::from_millis(5));
     };
 
-    if let Some(writer) = stdin_writer {
-        let _ = writer.join();
-    }
+    let stdin_error = stdin_writer.and_then(|writer| match writer.join() {
+        Ok(Ok(())) => None,
+        // The child stopped reading before the payload was fully written. That
+        // is the normal shape for a command that already decided its answer
+        // (`gh pr merge` skipping its confirmation prompt), so the child's own
+        // exit status stays the authority.
+        Ok(Err(error)) if error.kind() == io::ErrorKind::BrokenPipe => None,
+        // Any other write failure means the child ran on a payload we know is
+        // incomplete. Surface it instead of trusting output produced from a
+        // truncated request body.
+        Ok(Err(error)) => Some(io::Error::new(
+            error.kind(),
+            format!("failed writing child stdin: {error}"),
+        )),
+        Err(_) => Some(io::Error::other("bounded child stdin writer panicked")),
+    });
     let stdout = stdout_reader
         .join()
         .map_err(|_| io::Error::other("bounded stdout reader panicked"))??;
@@ -191,6 +204,9 @@ pub fn run_bounded(
         .map_err(|_| io::Error::other("bounded stderr reader panicked"))??;
     let (status, terminal_error) = wait_result?;
     if let Some(error) = terminal_error {
+        return Err(error);
+    }
+    if let Some(error) = stdin_error {
         return Err(error);
     }
     if stdout_overflow.load(Ordering::Acquire) || stderr_overflow.load(Ordering::Acquire) {
@@ -481,6 +497,39 @@ mod tests {
         .unwrap();
         assert_eq!(output.stdout, b"done");
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_runner_tolerates_a_child_that_never_reads_stdin() {
+        let limits = BoundedOutputLimits {
+            timeout: Duration::from_secs(5),
+            stdin_bytes: 512 * 1024,
+            stdout_bytes: 1024,
+            stderr_bytes: 1024,
+        };
+
+        // `gh pr merge` skips its confirmation prompt when it already knows the
+        // answer, closing stdin before the payload lands. That broken pipe must
+        // not turn a successful command into an error. The payload is larger
+        // than any pipe buffer so the write cannot quietly succeed instead.
+        let output = run_bounded(
+            Command::new("/bin/sh").args(["-c", "exec 0<&-; printf merged"]),
+            Some(&vec![b'y'; 256 * 1024]),
+            limits,
+        )
+        .expect("a child that ignores stdin still succeeds");
+        assert_eq!(output.stdout, b"merged");
+        assert!(output.status.success());
+
+        // A child that does consume stdin still sees the whole payload.
+        let output = run_bounded(
+            Command::new("/bin/sh").args(["-c", "cat"]),
+            Some(b"confirm\n"),
+            limits,
+        )
+        .expect("piped stdin is delivered");
+        assert_eq!(output.stdout, b"confirm\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`acorn_platform::process::run_bounded` spawned a thread to write the child's stdin payload and then discarded its result (`let _ = writer.join()`). A payload that never reached the child was therefore indistinguishable from one that did, so every caller piping a request body through `cli_resolver::run_with_input` could act on output produced from a truncated request.

Affected call sites: `gh pr edit --body-file -`, `gh api -X PATCH --input -` (comment update), `gh issue/pr comment --body-file -`, and the `gh pr merge` confirmation.

The fix propagates the write error from the single shared chokepoint instead of re-implementing stdin plumbing at each call site.

`BrokenPipe` stays tolerated: a child that stops reading before the payload lands — `gh pr merge` skipping its confirmation prompt when it already knows the answer — is the normal shape, and the child's own exit status remains the authority. Any other write failure now fails the call.

## Note on the previous revision

This branch originally hand-rolled `spawn` + stdin handling at four `pull_requests.rs` call sites. `main` has since centralised those through `cli_resolver::run_with_input` → `run_bounded`, so that approach would have undone the centralisation and duplicated the logic four times. The branch was re-authored against current `main` to fix the same defect at the shared chokepoint.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-platform` — 9 passed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn-platform --all-targets` — no issues
- [x] Negative control: removing the `BrokenPipe` arm makes `bounded_runner_tolerates_a_child_that_never_reads_stdin` fail, confirming the new test guards the behaviour rather than passing vacuously.

The new test pipes 256 KiB — larger than any pipe buffer — at a child that closes stdin immediately, so the write is guaranteed to hit `EPIPE` rather than quietly succeeding into the buffer.
