### PR TITLE
fix(terminal): retain failed queued commands

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2640,16 +2640,38 @@ export function Terminal({
         // Cleanup can run between consume and write under StrictMode's
         // mount/cleanup/mount sequence. Re-check `disposed` so we do not
         // pty_write into a session whose PTY has already been killed.
-        if (queued && !disposed) {
+        if (queued) {
+          if (disposed) {
+            useAppStore
+              .getState()
+              .restorePendingTerminalInput(sessionId, queued);
+            return;
+          }
+          const payload = encodeStringToBase64(queued.command + "\r");
+          try {
+            await invoke("pty_write", { sessionId, data: payload });
+          } catch (err) {
+            const restored = useAppStore
+              .getState()
+              .restorePendingTerminalInput(sessionId, queued);
+            console.error("[Terminal] pending pty_write failed", err);
+            if (!disposed) {
+              const retryDetail = restored
+                ? " The command remains queued for the next terminal attach."
+                : " A newer command is already queued for this session.";
+              term.write(
+                `\r\n${ANSI_RED}[acorn] Failed to run queued command: ${formatError(err)}${retryDetail}${ANSI_RESET}\r\n`,
+              );
+              showTranslatedErrorToast(
+                "toasts.session.pendingCommandFailed",
+                err,
+              );
+            }
+            return;
+          }
           if (queued.adoptWorktreeOnExit) {
             worktreeAdoptionIntent = { kind: "after-exit" };
           }
-          const payload = encodeStringToBase64(queued.command + "\r");
-          invoke("pty_write", { sessionId, data: payload }).catch(
-            (err: unknown) => {
-              console.error("[Terminal] pending pty_write failed", err);
-            },
-          );
         }
       } catch (err) {
         if (!disposed) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,6 +19,7 @@
       "titleRegenerateSkipped": "Session name was not regenerated.",
       "worktreeAdopted": "Worktree adopted: {name}",
       "worktreeAdoptFailed": "Failed to adopt worktree:",
+      "pendingCommandFailed": "Failed to run queued terminal command:",
       "worktreeMissing": "Worktree folder no longer exists on disk."
     },
     "autonomousGoal": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -19,6 +19,7 @@
       "titleRegenerateSkipped": "セッション名は再生成されませんでした。",
       "worktreeAdopted": "採用されたワークツリー: {name}",
       "worktreeAdoptFailed": "ワークツリーの採用に失敗しました:",
+      "pendingCommandFailed": "予約されたターミナルコマンドを実行できませんでした:",
       "worktreeMissing": "Worktree フォルダーはディスク上に存在しません。"
     },
     "autonomousGoal": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -19,6 +19,7 @@
       "titleRegenerateSkipped": "세션 이름을 다시 생성하지 않았습니다.",
       "worktreeAdopted": "새 워크트리를 가져왔습니다: {name}",
       "worktreeAdoptFailed": "워크트리를 가져오지 못했습니다:",
+      "pendingCommandFailed": "예약된 터미널 명령을 실행하지 못했습니다:",
       "worktreeMissing": "워크트리 폴더가 디스크에 더 이상 존재하지 않습니다."
     },
     "autonomousGoal": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -19,6 +19,7 @@
       "titleRegenerateSkipped": "会话名称未重新生成。",
       "worktreeAdopted": "已采用工作树：{name}",
       "worktreeAdoptFailed": "未能采用工作树：",
+      "pendingCommandFailed": "无法运行已排队的终端命令：",
       "worktreeMissing": "工作树文件夹磁盘上不再存在。"
     },
     "autonomousGoal": {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -4043,6 +4043,44 @@ describe("pendingTerminalInput", () => {
       agentProvider: "codex",
     });
   });
+
+  it("restores a consumed command when no newer command is queued", () => {
+    const store = useAppStore.getState();
+    store.setPendingTerminalInput("sess-1", "claude --worktree", {
+      agentProvider: "claude",
+    });
+    const consumed = store.consumePendingTerminalInput("sess-1");
+
+    expect(consumed).not.toBeNull();
+    expect(
+      useAppStore
+        .getState()
+        .restorePendingTerminalInput("sess-1", consumed!),
+    ).toBe(true);
+    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toEqual({
+      command: "claude --worktree",
+      adoptWorktreeOnExit: true,
+      agentProvider: "claude",
+    });
+  });
+
+  it("does not replace a newer command while restoring a failed claim", () => {
+    const store = useAppStore.getState();
+    store.setPendingTerminalInput("sess-1", "first");
+    const consumed = store.consumePendingTerminalInput("sess-1");
+    store.setPendingTerminalInput("sess-1", "newer");
+
+    expect(consumed).not.toBeNull();
+    expect(
+      useAppStore
+        .getState()
+        .restorePendingTerminalInput("sess-1", consumed!),
+    ).toBe(false);
+    expect(useAppStore.getState().pendingTerminalInput["sess-1"]).toEqual({
+      command: "newer",
+      adoptWorktreeOnExit: false,
+    });
+  });
 });
 
 describe("createSession returns the created session", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -602,6 +602,11 @@ interface AppStateModel {
   ) => void;
   /** Atomically read and remove the queued command for `sessionId`. */
   consumePendingTerminalInput: (sessionId: string) => PendingTerminalInput | null;
+  /** Restore a failed claim without replacing a command queued in the meantime. */
+  restorePendingTerminalInput: (
+    sessionId: string,
+    input: PendingTerminalInput,
+  ) => boolean;
   addSessionNotification: (notification: SessionNotification) => void;
   markSessionNotificationRead: (id: string) => void;
   markSessionNotificationsReadForSession: (sessionId: string) => void;
@@ -3899,6 +3904,21 @@ export const useAppStore = create<AppStateModel>()(
       return { pendingTerminalInput: rest };
     });
     return consumed;
+  },
+
+  restorePendingTerminalInput(sessionId, input) {
+    let restored = false;
+    set((s) => {
+      if (s.pendingTerminalInput[sessionId]) return s;
+      restored = true;
+      return {
+        pendingTerminalInput: {
+          ...s.pendingTerminalInput,
+          [sessionId]: input,
+        },
+      };
+    });
+    return restored;
   },
 
   addSessionNotification(notification) {

--- a/tests/e2e/command-hint.spec.ts
+++ b/tests/e2e/command-hint.spec.ts
@@ -76,4 +76,75 @@ test.describe("CommandHint via NoAccessBanner", () => {
 
     await expect(page.getByText(/Run this command\?/i)).toHaveCount(0);
   });
+
+  test("a queued command write failure is visible to the user", async ({
+    page,
+    tauri,
+    errorTracker,
+  }) => {
+    await seedNoAccess(tauri);
+    errorTracker.allow(/\[Terminal\] pending pty_write failed/);
+
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __commandRunSessions?: Array<Record<string, unknown>>;
+      };
+      w.__commandRunSessions ??= [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      return w.__commandRunSessions;
+    });
+    await tauri.handle("create_session", (args: unknown) => {
+      const w = window as unknown as {
+        __commandRunSessions?: Array<Record<string, unknown>>;
+      };
+      const request = args as { name: string; repoPath: string };
+      const created = {
+        id: "s-command",
+        name: request.name,
+        repo_path: request.repoPath,
+        worktree_path: request.repoPath,
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:01:00Z",
+        updated_at: "2026-01-01T00:01:00Z",
+        last_message: null,
+      };
+      w.__commandRunSessions = [...(w.__commandRunSessions ?? []), created];
+      return created;
+    });
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_write", () => {
+      throw new Error("Permission denied");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+    await page.getByRole("button", { name: /gh auth login/ }).click();
+    await page.getByRole("button", { name: /^Run$/ }).click();
+
+    await expect(
+      page.getByText(
+        "Failed to run queued terminal command: Permission denied",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.locator(".xterm").filter({
+        hasText: "Failed to run queued command: Permission denied",
+      }),
+    ).toHaveCount(1);
+  });
 });


### PR DESCRIPTION
## Summary

This prevents one-shot commands from disappearing when a newly spawned terminal cannot accept the queued PTY write.

1. **Atomic command recovery** — restore a claimed command when StrictMode cleanup wins the spawn race or `pty_write` fails, without replacing a newer queued command.
2. **Accurate worktree adoption** — arm post-exit adoption only after the worktree command reaches the PTY successfully.
3. **Visible failure feedback** — report the preserved backend error in both the terminal and a localized toast.
4. **Regression coverage** — cover restore/no-overwrite state transitions and the user-visible permission-denied flow.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Queued commands | A failed `pty_write` permanently consumed the command | The command remains queued for the next terminal attach |
| Concurrent queue updates | Recovery had no contract | A newer command always wins and is never overwritten |
| Worktree adoption | Failed delivery could leave a false adoption intent | Adoption intent is set only after successful delivery |
| Error visibility | Failure was written only to the developer console | The terminal and localized toast show the original error |

## Design notes

- The store exposes a compare-before-restore operation because the terminal must recover its claimed value without racing a command queued by another caller.
- Delivery stays at the existing post-`pty_spawn` call site, so command producers and PTY creation contracts remain unchanged.
- The pending input remains in memory only, matching the existing one-shot queue lifetime.

## Follow-up (not in this PR)

- A broader PTY startup transaction could unify spawn, initial writes, attachment ownership, and rollback, but that changes multiple lifecycle contracts and is intentionally kept separate.

## Test plan

- [x] `pnpm typecheck` — passed.
- [x] `pnpm test -- src/store.test.ts src/lib/i18n.test.ts` — 181 tests passed.
- [x] `pnpm exec playwright test tests/e2e/command-hint.spec.ts --workers=1` — 3 tests passed.
- [x] `pnpm test` — 1,352 tests passed.
- [x] `pnpm build` — production build passed.
- [x] `git diff --check` — passed.

## Notes

- The production build still reports the existing large-chunk and ineffective-dynamic-import warnings; this PR does not introduce them.
