### PR TITLE
fix(removals): report partial outcomes + retry failed steps

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -83,6 +83,35 @@ impl SessionRemoval {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovalIssue {
+    pub kind: String,
+    pub target: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemovalOutcome<T> {
+    pub result: T,
+    pub removed_session_ids: Vec<String>,
+    pub issues: Vec<RemovalIssue>,
+    pub retry_token: Option<String>,
+}
+
+impl<T> RemovalOutcome<T> {
+    fn complete(result: T, removed_session_ids: Vec<String>) -> Self {
+        Self {
+            result,
+            removed_session_ids,
+            issues: Vec::new(),
+            retry_token: None,
+        }
+    }
+}
+
 async fn run_blocking<T, F>(label: &'static str, f: F) -> AppResult<T>
 where
     T: Send + 'static,
@@ -7095,12 +7124,13 @@ pub async fn remove_project(
     remove_sessions: Option<bool>,
     remove_worktrees: Option<bool>,
     remove_settings: Option<bool>,
-) -> AppResult<Vec<worktree::RemovedWorktree>> {
+) -> AppResult<RemovalOutcome<Vec<worktree::RemovedWorktree>>> {
     let app_state = state.inner().clone();
     let path = PathBuf::from(&repo_path);
     let cascade = remove_sessions.unwrap_or(true);
     let drop_worktrees = remove_worktrees.unwrap_or(false);
     let mut removed_worktrees = Vec::new();
+    let mut removed_session_ids = Vec::new();
     let mut staged_worktree_paths = HashSet::new();
     // Closing a project closes every root it spans, not just the primary one.
     let roots = app_state
@@ -7119,6 +7149,7 @@ pub async fn remove_project(
             terminate_session_runtime_blocking(app_state.clone(), session.id).await?;
         }
         for session in sessions_to_remove {
+            removed_session_ids.push(session.id.to_string());
             if drop_worktrees && staged_worktree_paths.insert(session.worktree_path.clone()) {
                 if worktree_path_used_outside_project(&app_state, &path, &session.worktree_path) {
                     tracing::warn!(
@@ -7165,7 +7196,10 @@ pub async fn remove_project(
         }
     }
     persist(&app_state);
-    Ok(removed_worktrees)
+    Ok(RemovalOutcome::complete(
+        removed_worktrees,
+        removed_session_ids,
+    ))
 }
 
 #[tauri::command]
@@ -7173,11 +7207,15 @@ pub async fn remove_session(
     state: State<'_, AppState>,
     id: String,
     remove_worktree: Option<bool>,
-) -> AppResult<Option<SessionRemoval>> {
+) -> AppResult<RemovalOutcome<Option<SessionRemoval>>> {
     let app_state = state.inner().clone();
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = app_state.sessions.get(&id)?;
     let sessions_to_remove = session_removal_cascade(&app_state, &session);
+    let removed_session_ids = sessions_to_remove
+        .iter()
+        .map(|session| session.id.to_string())
+        .collect::<Vec<_>>();
     let removal_ids: HashSet<_> = sessions_to_remove
         .iter()
         .map(|session| session.id)
@@ -7230,7 +7268,7 @@ pub async fn remove_session(
                 scrollback::delete(&dir, &session.id.to_string()).ok();
             }
         }
-        return Ok(None);
+        return Ok(RemovalOutcome::complete(None, removed_session_ids));
     };
     let removal = SessionRemoval::new(&removed_worktree, &sessions_to_remove);
     app_state.pending_session_removals.lock().insert(
@@ -7240,7 +7278,7 @@ pub async fn remove_session(
             sessions: sessions_to_remove,
         },
     );
-    Ok(Some(removal))
+    Ok(RemovalOutcome::complete(Some(removal), removed_session_ids))
 }
 
 #[tauri::command]
@@ -8046,7 +8084,7 @@ pub async fn remove_worktree(
     repo_path: String,
     worktree_path: String,
     remove_sessions: Option<bool>,
-) -> AppResult<Option<worktree::RemovedWorktree>> {
+) -> AppResult<RemovalOutcome<Option<worktree::RemovedWorktree>>> {
     let app_state = state.inner().clone();
     let repo_path = PathBuf::from(repo_path);
     let worktree_path = PathBuf::from(worktree_path);
@@ -8062,15 +8100,18 @@ pub async fn remove_worktree(
                 WORKTREE_IN_USE_BY_OTHER_SESSIONS.to_string(),
             ));
         }
-        return stage_remove_linked_worktree_and_sessions_blocking(
-            app_state,
-            repo_path,
-            worktree_path,
-        )
-        .await;
+        let removed_session_ids = matching_sessions
+            .iter()
+            .map(|session| session.id.to_string())
+            .collect();
+        let removed =
+            stage_remove_linked_worktree_and_sessions_blocking(app_state, repo_path, worktree_path)
+                .await?;
+        return Ok(RemovalOutcome::complete(removed, removed_session_ids));
     }
     ensure_no_sessions_using_worktree_path_except(&app_state, &worktree_path, None)?;
-    stage_remove_linked_worktree_blocking(repo_path, worktree_path).await
+    let removed = stage_remove_linked_worktree_blocking(repo_path, worktree_path).await?;
+    Ok(RemovalOutcome::complete(removed, Vec::new()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,7 +19,7 @@ use crate::pull_requests::{
     PrStateFilter, PullRequestDetailListing, PullRequestDiffListing, PullRequestListing,
     PullRequestStateChange, WorkflowRunDetailListing, WorkflowRunsListing,
 };
-use crate::state::{AppState, PendingSessionRemoval};
+use crate::state::{AppState, PendingRemovalStep, PendingSessionRemoval};
 use crate::todos::{self, TodoItem};
 use crate::work_graph::{self, GraphPromptPlan};
 use crate::worktree;
@@ -112,6 +112,192 @@ impl<T> RemovalOutcome<T> {
     }
 }
 
+#[derive(Default)]
+struct RemovalProgress {
+    issues: Vec<RemovalIssue>,
+    retry_steps: Vec<PendingRemovalStep>,
+}
+
+impl RemovalProgress {
+    fn record_failure(&mut self, step: PendingRemovalStep, error: impl std::fmt::Display) {
+        let (kind, target) = removal_step_context(&step);
+        self.issues.push(RemovalIssue {
+            kind: kind.to_string(),
+            target,
+            message: error.to_string(),
+            retryable: true,
+        });
+        self.retry_steps.push(step);
+    }
+
+    fn into_outcome<T>(
+        self,
+        state: &AppState,
+        result: T,
+        removed_session_ids: Vec<String>,
+        preferred_retry_token: Option<String>,
+    ) -> RemovalOutcome<T> {
+        let retry_token = register_removal_retries(state, self.retry_steps, preferred_retry_token);
+        RemovalOutcome {
+            result,
+            removed_session_ids,
+            issues: self.issues,
+            retry_token,
+        }
+    }
+}
+
+fn removal_step_context(step: &PendingRemovalStep) -> (&'static str, String) {
+    match step {
+        PendingRemovalStep::DeleteScrollbacks { session_ids } => (
+            "scrollback",
+            if session_ids.len() == 1 {
+                session_ids[0].clone()
+            } else {
+                format!("{} sessions", session_ids.len())
+            },
+        ),
+        PendingRemovalStep::StageWorktree { worktree_path, .. } => {
+            ("worktree", worktree_path.display().to_string())
+        }
+        PendingRemovalStep::RemoveProjectSettings { repo_path, .. } => {
+            ("settings", repo_path.display().to_string())
+        }
+        PendingRemovalStep::PersistSessions => ("persistence", "sessions".to_string()),
+        PendingRemovalStep::PersistProjects => ("persistence", "projects".to_string()),
+    }
+}
+
+fn register_removal_retries(
+    state: &AppState,
+    retry_steps: Vec<PendingRemovalStep>,
+    preferred_token: Option<String>,
+) -> Option<String> {
+    if retry_steps.is_empty() {
+        return None;
+    }
+    let token = preferred_token.unwrap_or_else(|| Uuid::new_v4().to_string());
+    state
+        .pending_removal_retries
+        .lock()
+        .insert(token.clone(), retry_steps);
+    Some(token)
+}
+
+fn cleanup_removed_scrollbacks(session_ids: &[String], progress: &mut RemovalProgress) {
+    match persistence::data_dir() {
+        Ok(data_dir) => cleanup_removed_scrollbacks_from_dir(&data_dir, session_ids, progress),
+        Err(error) => progress.record_failure(
+            PendingRemovalStep::DeleteScrollbacks {
+                session_ids: session_ids.to_vec(),
+            },
+            error,
+        ),
+    }
+}
+
+fn cleanup_removed_scrollbacks_from_dir(
+    data_dir: &Path,
+    session_ids: &[String],
+    progress: &mut RemovalProgress,
+) {
+    for session_id in session_ids {
+        if let Err(error) = scrollback::delete(data_dir, session_id) {
+            progress.record_failure(
+                PendingRemovalStep::DeleteScrollbacks {
+                    session_ids: vec![session_id.clone()],
+                },
+                error,
+            );
+        }
+    }
+}
+
+fn persist_removal_state(state: &AppState, progress: &mut RemovalProgress) {
+    if let Err(error) = persistence::save_sessions(&state.sessions) {
+        progress.record_failure(PendingRemovalStep::PersistSessions, error);
+    }
+    if let Err(error) = persistence::save_projects(&state.projects.list()) {
+        progress.record_failure(PendingRemovalStep::PersistProjects, error);
+    }
+}
+
+fn remove_project_settings_step(repo_path: &Path, respect_preference: bool) -> AppResult<()> {
+    if respect_preference && !project_settings::should_remove_on_project_close(repo_path)? {
+        return Ok(());
+    }
+    project_settings::remove(repo_path)
+}
+
+fn retry_removal_cleanup_inner(
+    state: &AppState,
+    retry_token: &str,
+) -> AppResult<RemovalOutcome<Vec<worktree::RemovedWorktree>>> {
+    let steps = state
+        .pending_removal_retries
+        .lock()
+        .remove(retry_token)
+        .ok_or_else(|| AppError::Other("removal cleanup retry is not available".to_string()))?;
+    let mut progress = RemovalProgress::default();
+    let mut removed_worktrees = Vec::new();
+
+    for step in steps {
+        match step {
+            PendingRemovalStep::DeleteScrollbacks { session_ids } => {
+                cleanup_removed_scrollbacks(&session_ids, &mut progress);
+            }
+            PendingRemovalStep::StageWorktree {
+                repo_path,
+                worktree_path,
+            } => {
+                let retry_step = PendingRemovalStep::StageWorktree {
+                    repo_path: repo_path.clone(),
+                    worktree_path: worktree_path.clone(),
+                };
+                let result =
+                    ensure_no_sessions_using_worktree_path_except(state, &worktree_path, None)
+                        .and_then(|()| {
+                            stage_remove_linked_worktree_at_path(&repo_path, &worktree_path)
+                        });
+                match result {
+                    Ok(Some(removed)) => removed_worktrees.push(removed),
+                    Ok(None) => {}
+                    Err(error) => progress.record_failure(retry_step, error),
+                }
+            }
+            PendingRemovalStep::RemoveProjectSettings {
+                repo_path,
+                respect_preference,
+            } => {
+                let retry_step = PendingRemovalStep::RemoveProjectSettings {
+                    repo_path: repo_path.clone(),
+                    respect_preference,
+                };
+                if let Err(error) = remove_project_settings_step(&repo_path, respect_preference) {
+                    progress.record_failure(retry_step, error);
+                }
+            }
+            PendingRemovalStep::PersistSessions => {
+                if let Err(error) = persistence::save_sessions(&state.sessions) {
+                    progress.record_failure(PendingRemovalStep::PersistSessions, error);
+                }
+            }
+            PendingRemovalStep::PersistProjects => {
+                if let Err(error) = persistence::save_projects(&state.projects.list()) {
+                    progress.record_failure(PendingRemovalStep::PersistProjects, error);
+                }
+            }
+        }
+    }
+
+    Ok(progress.into_outcome(
+        state,
+        removed_worktrees,
+        Vec::new(),
+        Some(retry_token.to_string()),
+    ))
+}
+
 async fn run_blocking<T, F>(label: &'static str, f: F) -> AppResult<T>
 where
     T: Send + 'static,
@@ -136,7 +322,7 @@ async fn stage_remove_linked_worktree_and_sessions_blocking(
     state: AppState,
     repo_path: PathBuf,
     worktree_path: PathBuf,
-) -> AppResult<Option<worktree::RemovedWorktree>> {
+) -> AppResult<RemovalOutcome<Option<worktree::RemovedWorktree>>> {
     run_blocking("stage linked worktree removal with sessions", move || {
         stage_remove_linked_worktree_at_path_and_sessions(&state, &repo_path, &worktree_path)
     })
@@ -7131,6 +7317,7 @@ pub async fn remove_project(
     let drop_worktrees = remove_worktrees.unwrap_or(false);
     let mut removed_worktrees = Vec::new();
     let mut removed_session_ids = Vec::new();
+    let mut progress = RemovalProgress::default();
     let mut staged_worktree_paths = HashSet::new();
     // Closing a project closes every root it spans, not just the primary one.
     let roots = app_state
@@ -7157,6 +7344,13 @@ pub async fn remove_project(
                         worktree_path = %session.worktree_path.display(),
                         "skipping linked worktree removal because another project still has a session there"
                     );
+                    progress.record_failure(
+                        PendingRemovalStep::StageWorktree {
+                            repo_path: session.repo_path.clone(),
+                            worktree_path: session.worktree_path.clone(),
+                        },
+                        WORKTREE_IN_USE_BY_OTHER_SESSIONS,
+                    );
                     app_state.sessions.remove(&session.id).ok();
                     continue;
                 }
@@ -7175,6 +7369,13 @@ pub async fn remove_project(
                             error = %err,
                             "failed to stage linked worktree removal"
                         );
+                        progress.record_failure(
+                            PendingRemovalStep::StageWorktree {
+                                repo_path: session.repo_path.clone(),
+                                worktree_path: session.worktree_path.clone(),
+                            },
+                            err,
+                        );
                     }
                 }
             }
@@ -7186,20 +7387,40 @@ pub async fn remove_project(
     // per root. Closing it has to clear all of them or the source folders keep
     // a record nothing points at any more.
     for root in &roots {
-        let drop_settings = remove_settings.unwrap_or(false)
-            || project_settings::should_remove_on_project_close(root).unwrap_or(false);
+        let explicitly_remove_settings = remove_settings.unwrap_or(false);
+        let drop_settings = if explicitly_remove_settings {
+            true
+        } else {
+            match project_settings::should_remove_on_project_close(root) {
+                Ok(drop_settings) => drop_settings,
+                Err(error) => {
+                    progress.record_failure(
+                        PendingRemovalStep::RemoveProjectSettings {
+                            repo_path: root.clone(),
+                            respect_preference: true,
+                        },
+                        error,
+                    );
+                    false
+                }
+            }
+        };
         if !drop_settings {
             continue;
         }
         if let Err(err) = project_settings::remove(root) {
             tracing::warn!(error = %err, path = %root.display(), "failed to remove project settings");
+            progress.record_failure(
+                PendingRemovalStep::RemoveProjectSettings {
+                    repo_path: root.clone(),
+                    respect_preference: false,
+                },
+                err,
+            );
         }
     }
-    persist(&app_state);
-    Ok(RemovalOutcome::complete(
-        removed_worktrees,
-        removed_session_ids,
-    ))
+    persist_removal_state(&app_state, &mut progress);
+    Ok(progress.into_outcome(&app_state, removed_worktrees, removed_session_ids, None))
 }
 
 #[tauri::command]
@@ -7212,6 +7433,7 @@ pub async fn remove_session(
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = app_state.sessions.get(&id)?;
     let sessions_to_remove = session_removal_cascade(&app_state, &session);
+    let mut progress = RemovalProgress::default();
     let removed_session_ids = sessions_to_remove
         .iter()
         .map(|session| session.id.to_string())
@@ -7245,6 +7467,13 @@ pub async fn remove_session(
                     error = %err,
                     "failed to stage linked worktree removal"
                 );
+                progress.record_failure(
+                    PendingRemovalStep::StageWorktree {
+                        repo_path: session.repo_path.clone(),
+                        worktree_path: session.worktree_path.clone(),
+                    },
+                    err,
+                );
                 None
             }
         }
@@ -7261,24 +7490,25 @@ pub async fn remove_session(
     if should_remove_local_project_mirror(&session, &app_state.sessions.list()) {
         app_state.projects.remove(&session.repo_path);
     }
-    persist(&app_state);
-    let Some(removed_worktree) = removed_worktree else {
-        if let Ok(dir) = persistence::data_dir() {
-            for session in &sessions_to_remove {
-                scrollback::delete(&dir, &session.id.to_string()).ok();
-            }
+    let result = match removed_worktree {
+        Some(removed_worktree) => {
+            let removal = SessionRemoval::new(&removed_worktree, &sessions_to_remove);
+            app_state.pending_session_removals.lock().insert(
+                removed_worktree.token.clone(),
+                PendingSessionRemoval {
+                    worktree: removed_worktree,
+                    sessions: sessions_to_remove,
+                },
+            );
+            Some(removal)
         }
-        return Ok(RemovalOutcome::complete(None, removed_session_ids));
+        None => {
+            cleanup_removed_scrollbacks(&removed_session_ids, &mut progress);
+            None
+        }
     };
-    let removal = SessionRemoval::new(&removed_worktree, &sessions_to_remove);
-    app_state.pending_session_removals.lock().insert(
-        removed_worktree.token.clone(),
-        PendingSessionRemoval {
-            worktree: removed_worktree,
-            sessions: sessions_to_remove,
-        },
-    );
-    Ok(RemovalOutcome::complete(Some(removal), removed_session_ids))
+    persist_removal_state(&app_state, &mut progress);
+    Ok(progress.into_outcome(&app_state, result, removed_session_ids, None))
 }
 
 #[tauri::command]
@@ -8100,18 +8330,34 @@ pub async fn remove_worktree(
                 WORKTREE_IN_USE_BY_OTHER_SESSIONS.to_string(),
             ));
         }
-        let removed_session_ids = matching_sessions
-            .iter()
-            .map(|session| session.id.to_string())
-            .collect();
-        let removed =
-            stage_remove_linked_worktree_and_sessions_blocking(app_state, repo_path, worktree_path)
-                .await?;
-        return Ok(RemovalOutcome::complete(removed, removed_session_ids));
+        return stage_remove_linked_worktree_and_sessions_blocking(
+            app_state,
+            repo_path,
+            worktree_path,
+        )
+        .await;
     }
     ensure_no_sessions_using_worktree_path_except(&app_state, &worktree_path, None)?;
     let removed = stage_remove_linked_worktree_blocking(repo_path, worktree_path).await?;
     Ok(RemovalOutcome::complete(removed, Vec::new()))
+}
+
+#[tauri::command]
+pub async fn retry_removal_cleanup(
+    state: State<'_, AppState>,
+    retry_token: String,
+) -> AppResult<RemovalOutcome<Vec<worktree::RemovedWorktree>>> {
+    let app_state = state.inner().clone();
+    run_blocking("retry removal cleanup", move || {
+        retry_removal_cleanup_inner(&app_state, &retry_token)
+    })
+    .await
+}
+
+#[tauri::command]
+pub fn discard_removal_retry(state: State<'_, AppState>, retry_token: String) -> AppResult<()> {
+    state.pending_removal_retries.lock().remove(&retry_token);
+    Ok(())
 }
 
 #[tauri::command]
@@ -11194,7 +11440,7 @@ fn stage_remove_linked_worktree_at_path_and_sessions(
     state: &AppState,
     repo_path: &Path,
     worktree_path: &Path,
-) -> AppResult<Option<worktree::RemovedWorktree>> {
+) -> AppResult<RemovalOutcome<Option<worktree::RemovedWorktree>>> {
     let sessions = sessions_using_linked_worktree(state, repo_path, worktree_path);
 
     for session in &sessions {
@@ -11202,17 +11448,17 @@ fn stage_remove_linked_worktree_at_path_and_sessions(
     }
 
     let removed = stage_remove_linked_worktree_at_path(repo_path, worktree_path)?;
-
-    if let Ok(dir) = persistence::data_dir() {
-        for session in &sessions {
-            scrollback::delete(&dir, &session.id.to_string()).ok();
-        }
-    }
+    let removed_session_ids = sessions
+        .iter()
+        .map(|session| session.id.to_string())
+        .collect::<Vec<_>>();
+    let mut progress = RemovalProgress::default();
+    cleanup_removed_scrollbacks(&removed_session_ids, &mut progress);
     for session in sessions {
         state.sessions.remove(&session.id).ok();
     }
-    persist(state);
-    Ok(removed)
+    persist_removal_state(state, &mut progress);
+    Ok(progress.into_outcome(state, removed, removed_session_ids, None))
 }
 
 pub(crate) fn stage_remove_linked_worktree_at_path(
@@ -11404,18 +11650,19 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 mod tests {
     use super::{
         auto_title_enabled_for_new_session, can_store_generated_session_title,
-        collect_memory_usage_from_roots, configured_git_identity, create_unique_worktree,
-        daemon_attach_replay_scrollback, daemon_spawn_name_for_session,
-        detach_requested_by_stale_renderer, discard_pending_session_removal_from_dir,
-        font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env,
-        memory_root_pids, normalize_session_goal, normalize_session_graph, poll_defers_to_hook,
-        remove_linked_worktree_at_path, restore_pending_session_removal, seed_initial_commit,
-        should_remove_local_project_mirror, should_route_session_to_daemon,
-        terminate_session_runtime, validate_editor_command, validate_new_project_name,
-        ChatProviderAdapter, ProcessMemorySnapshot,
+        cleanup_removed_scrollbacks_from_dir, collect_memory_usage_from_roots,
+        configured_git_identity, create_unique_worktree, daemon_attach_replay_scrollback,
+        daemon_spawn_name_for_session, detach_requested_by_stale_renderer,
+        discard_pending_session_removal_from_dir, font_name_from_path,
+        infer_acornd_root_from_session_pids, inject_agent_hook_env, memory_root_pids,
+        normalize_session_goal, normalize_session_graph, poll_defers_to_hook,
+        remove_linked_worktree_at_path, restore_pending_session_removal,
+        retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror,
+        should_route_session_to_daemon, terminate_session_runtime, validate_editor_command,
+        validate_new_project_name, ChatProviderAdapter, ProcessMemorySnapshot, RemovalProgress,
     };
     use crate::error::{AppError, AppResult};
-    use crate::state::{AppState, PendingSessionRemoval};
+    use crate::state::{AppState, PendingRemovalStep, PendingSessionRemoval};
     #[cfg(unix)]
     use acorn_session::{AgentStatusSource, SessionStatus};
     use acorn_session::{
@@ -15993,6 +16240,128 @@ mod tests {
         .expect("retry cleanup");
 
         assert!(state.pending_session_removals.lock().is_empty());
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn scrollback_cleanup_records_only_failed_items_for_both_removal_paths() {
+        let data_dir = tempfile::tempdir().expect("temporary data directory");
+        let session_ok = Uuid::new_v4().to_string();
+        let session_blocked = Uuid::new_v4().to_string();
+        let worktree_blocked = Uuid::new_v4().to_string();
+        acorn_session::scrollback::save(data_dir.path(), &session_ok, "saved")
+            .expect("save removable scrollback");
+        for id in [&session_blocked, &worktree_blocked] {
+            std::fs::create_dir_all(data_dir.path().join("scrollback").join(format!("{id}.txt")))
+                .expect("create blocking scrollback directory");
+        }
+
+        let mut session_progress = RemovalProgress::default();
+        cleanup_removed_scrollbacks_from_dir(
+            data_dir.path(),
+            &[session_ok.clone(), session_blocked.clone()],
+            &mut session_progress,
+        );
+        let mut worktree_progress = RemovalProgress::default();
+        cleanup_removed_scrollbacks_from_dir(
+            data_dir.path(),
+            std::slice::from_ref(&worktree_blocked),
+            &mut worktree_progress,
+        );
+
+        assert_eq!(session_progress.issues.len(), 1);
+        assert_eq!(session_progress.issues[0].target, session_blocked);
+        assert!(matches!(
+            session_progress.retry_steps.as_slice(),
+            [PendingRemovalStep::DeleteScrollbacks { session_ids }]
+                if session_ids == &[session_blocked]
+        ));
+        assert_eq!(worktree_progress.issues.len(), 1);
+        assert_eq!(worktree_progress.issues[0].target, worktree_blocked);
+        assert!(matches!(
+            worktree_progress.retry_steps.as_slice(),
+            [PendingRemovalStep::DeleteScrollbacks { session_ids }]
+                if session_ids == &[worktree_blocked]
+        ));
+        assert_eq!(
+            acorn_session::scrollback::load(data_dir.path(), &session_ok)
+                .expect("load deleted scrollback"),
+            None,
+        );
+    }
+
+    #[test]
+    fn removal_retry_registry_exposes_only_an_opaque_capability() {
+        let state = AppState::new();
+        let mut progress = RemovalProgress::default();
+        progress.record_failure(PendingRemovalStep::PersistSessions, "disk full");
+
+        let outcome = progress.into_outcome(&state, (), Vec::new(), None);
+
+        let retry_token = outcome.retry_token.expect("retry token");
+        Uuid::parse_str(&retry_token).expect("opaque UUID token");
+        let pending = state.pending_removal_retries.lock();
+        assert!(matches!(
+            pending.get(&retry_token).map(Vec::as_slice),
+            Some([PendingRemovalStep::PersistSessions])
+        ));
+        assert_eq!(outcome.issues[0].target, "sessions");
+        assert_eq!(outcome.issues[0].message, "disk full");
+    }
+
+    #[test]
+    fn worktree_cleanup_retry_stays_blocked_until_live_sessions_are_gone() {
+        let repo_dir = unique_repo_dir("safe-worktree-cleanup-retry");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path = crate::worktree::create_worktree(&repo_dir, "retry-safe")
+            .expect("create linked worktree");
+        let state = AppState::new();
+        let peer = state.sessions.insert(worktree_session(
+            "peer",
+            repo_dir.to_str().expect("repo path"),
+            worktree_path.to_str().expect("worktree path"),
+        ));
+        let retry_token = Uuid::new_v4().to_string();
+        state.pending_removal_retries.lock().insert(
+            retry_token.clone(),
+            vec![PendingRemovalStep::StageWorktree {
+                repo_path: repo_dir.clone(),
+                worktree_path: worktree_path.clone(),
+            }],
+        );
+
+        let blocked = retry_removal_cleanup_inner(&state, &retry_token)
+            .expect("blocked retry returns a partial outcome");
+
+        assert!(blocked.result.is_empty());
+        assert_eq!(blocked.retry_token.as_deref(), Some(retry_token.as_str()));
+        assert_eq!(blocked.issues.len(), 1);
+        assert_eq!(
+            blocked.issues[0].message,
+            super::WORKTREE_IN_USE_BY_OTHER_SESSIONS,
+        );
+        assert!(worktree_path.exists());
+
+        state
+            .sessions
+            .remove(&peer.id)
+            .expect("remove blocking peer");
+        let completed =
+            retry_removal_cleanup_inner(&state, &retry_token).expect("retry after peer removal");
+
+        assert_eq!(completed.result.len(), 1);
+        assert!(completed.issues.is_empty());
+        assert_eq!(completed.retry_token, None);
+        assert!(!worktree_path.exists());
+        let removed = &completed.result[0];
+        crate::worktree::discard_removed_worktree(
+            Path::new(&removed.repo_path),
+            Path::new(&removed.worktree_path),
+            &removed.token,
+            Path::new(&removed.git_common_dir),
+        )
+        .expect("discard staged worktree");
         std::fs::remove_dir_all(&repo_dir).ok();
     }
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7382,6 +7382,9 @@ pub async fn remove_project(
             app_state.sessions.remove(&session.id).ok();
         }
     }
+    if !removed_session_ids.is_empty() {
+        cleanup_removed_scrollbacks(&removed_session_ids, &mut progress);
+    }
     app_state.projects.remove(roots.first().unwrap_or(&path));
     // Settings are keyed per repository, so a multi-root project has one record
     // per root. Closing it has to clear all of them or the source folders keep

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -858,6 +858,8 @@ pub fn run() {
             commands::list_project_worktrees,
             commands::list_project_branches,
             commands::remove_worktree,
+            commands::retry_removal_cleanup,
+            commands::discard_removal_retry,
             commands::restore_removed_worktree,
             commands::discard_removed_worktree,
             commands::restore_removed_session,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -23,6 +23,23 @@ pub struct PendingSessionRemoval {
     pub sessions: Vec<Session>,
 }
 
+#[derive(Debug, Clone)]
+pub enum PendingRemovalStep {
+    DeleteScrollbacks {
+        session_ids: Vec<String>,
+    },
+    StageWorktree {
+        repo_path: PathBuf,
+        worktree_path: PathBuf,
+    },
+    RemoveProjectSettings {
+        repo_path: PathBuf,
+        respect_preference: bool,
+    },
+    PersistSessions,
+    PersistProjects,
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub sessions: Arc<SessionStore>,
@@ -43,6 +60,10 @@ pub struct AppState {
     /// restore/discard commands, so the renderer never sends session records
     /// back into the backend.
     pub pending_session_removals: Arc<Mutex<HashMap<String, PendingSessionRemoval>>>,
+    /// Failed cleanup steps from otherwise-completed removal operations. The
+    /// renderer receives only the opaque map key and cannot supply filesystem
+    /// paths or choose which backend operation is retried.
+    pub pending_removal_retries: Arc<Mutex<HashMap<String, Vec<PendingRemovalStep>>>>,
     /// Shutdown handle for the currently running IPC listener thread.
     /// `None` when bind failed at boot. `ipc_restart` swaps in a new handle
     /// after signaling the previous listener to exit.
@@ -103,6 +124,7 @@ impl AppState {
             sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             pending_session_removals: Arc::new(Mutex::new(HashMap::new())),
+            pending_removal_retries: Arc::new(Mutex::new(HashMap::new())),
             ipc_handle: Arc::new(Mutex::new(None)),
             ipc_workspace_requests: Arc::new(Mutex::new(Default::default())),
             daemon_bridge: DaemonBridge::new(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -121,6 +121,7 @@ import type { TranslationKey, Translator } from "./lib/i18n";
 import type { Session } from "./lib/types";
 import { useTranslation } from "./lib/useTranslation";
 import {
+  showRemovalOutcomeIssues,
   showStoreSessionRemovalToast,
   showStoreWorktreeRemovalToast,
 } from "./lib/operationToasts";
@@ -1242,12 +1243,10 @@ function App() {
     );
     if (recordedWorktree && !canDeleteWorktree) {
       clearPendingRemove();
-      void removeSession(pendingRemove.id, false).then(() =>
-        showStoreOperationToast(
-          null,
-          "toasts.session.removeFailed",
-        ),
-      );
+      void removeSession(pendingRemove.id, false).then((outcome) => {
+        showStoreOperationToast(null, "toasts.session.removeFailed");
+        showRemovalOutcomeIssues(outcome);
+      });
       return;
     }
     const autoDeleteWorktree = shouldAutoDeleteSessionWorktree(
@@ -1263,7 +1262,7 @@ function App() {
       clearPendingRemove();
       void removeSession(pendingRemove.id, true).then((outcome) =>
         showStoreSessionRemovalToast(
-          outcome?.result,
+          outcome,
           "toasts.session.sessionWorktreeRemoved",
           "toasts.session.sessionWorktreeRemovedUndo",
           "toasts.session.sessionWorktreeRemoveFailed",
@@ -1277,12 +1276,10 @@ function App() {
       return;
     }
     clearPendingRemove();
-    void removeSession(pendingRemove.id, false).then(() =>
-      showStoreOperationToast(
-        null,
-        "toasts.session.removeFailed",
-      ),
-    );
+    void removeSession(pendingRemove.id, false).then((outcome) => {
+      showStoreOperationToast(null, "toasts.session.removeFailed");
+      showRemovalOutcomeIssues(outcome);
+    });
   }, [
     pendingRemove,
     pendingRemoveHasOwnedSessions,
@@ -1954,7 +1951,7 @@ function App() {
             (outcome) => {
               if (choice === "session_and_worktree") {
                 showStoreSessionRemovalToast(
-                  outcome?.result,
+                  outcome,
                   "toasts.session.sessionWorktreeRemoved",
                   "toasts.session.sessionWorktreeRemovedUndo",
                   "toasts.session.sessionWorktreeRemoveFailed",
@@ -1964,6 +1961,7 @@ function App() {
                 return;
               }
               showStoreOperationToast(null, "toasts.session.removeFailed");
+              showRemovalOutcomeIssues(outcome);
             },
           );
         }}
@@ -1981,7 +1979,7 @@ function App() {
           ).then((outcome) => {
             if (choice === "project_and_worktrees") {
               showStoreWorktreeRemovalToast(
-                outcome?.result,
+                outcome,
                 "toasts.project.worktreesRemoved",
                 "toasts.project.worktreesRemovedUndo",
                 "toasts.project.worktreesRemoveFailed",
@@ -1991,6 +1989,7 @@ function App() {
               return;
             }
             showStoreOperationToast(null, "toasts.project.removeFailed");
+            showRemovalOutcomeIssues(outcome);
           });
         }}
       />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1261,9 +1261,9 @@ function App() {
       !pendingRemoveHasOwnedSessions
     ) {
       clearPendingRemove();
-      void removeSession(pendingRemove.id, true).then((removal) =>
+      void removeSession(pendingRemove.id, true).then((outcome) =>
         showStoreSessionRemovalToast(
-          removal,
+          outcome?.result,
           "toasts.session.sessionWorktreeRemoved",
           "toasts.session.sessionWorktreeRemovedUndo",
           "toasts.session.sessionWorktreeRemoveFailed",
@@ -1951,10 +1951,10 @@ function App() {
           clearPendingRemove();
           if (!target || choice === "cancel") return;
           void removeSession(target.id, choice === "session_and_worktree").then(
-            (removal) => {
+            (outcome) => {
               if (choice === "session_and_worktree") {
                 showStoreSessionRemovalToast(
-                  removal,
+                  outcome?.result,
                   "toasts.session.sessionWorktreeRemoved",
                   "toasts.session.sessionWorktreeRemovedUndo",
                   "toasts.session.sessionWorktreeRemoveFailed",
@@ -1978,10 +1978,10 @@ function App() {
           void removeProject(
             target.repo_path,
             choice === "project_and_worktrees",
-          ).then((removedWorktrees) => {
+          ).then((outcome) => {
             if (choice === "project_and_worktrees") {
               showStoreWorktreeRemovalToast(
-                removedWorktrees,
+                outcome?.result,
                 "toasts.project.worktreesRemoved",
                 "toasts.project.worktreesRemovedUndo",
                 "toasts.project.worktreesRemoveFailed",

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -39,6 +39,7 @@ import { suggestDefaultSessionName } from "../lib/sessionName";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import type { SessionNotificationKind } from "../lib/types";
+import { showRemovalOutcomeIssues } from "../lib/operationToasts";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -242,9 +243,10 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   async function handleRemoveSession(id: string) {
     const show = useToasts.getState().show;
     try {
-      await useAppStore.getState().removeSession(id);
+      const outcome = await useAppStore.getState().removeSession(id);
       const error = useAppStore.getState().consumeError();
       if (error) show(`${t("toasts.session.removeFailed")} ${error}`);
+      showRemovalOutcomeIssues(outcome);
     } finally {
       close();
     }

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -8,7 +8,7 @@ import type {
   ProjectWorktree,
   Session,
 } from "../lib/types";
-import type { WorktreeRemoval } from "../lib/api";
+import type { WorktreeRemoval, WorktreeRemovalOutcome } from "../lib/api";
 
 vi.mock("../lib/api", () => ({
   api: {
@@ -26,7 +26,7 @@ vi.mock("../lib/api", () => ({
         repoPath: string,
         worktreePath: string,
         removeSessions?: boolean,
-      ) => Promise<WorktreeRemoval | null>
+      ) => Promise<WorktreeRemovalOutcome>
     >(),
     discardRemovedWorktree: vi.fn<
       (removal: WorktreeRemoval) => Promise<void>
@@ -45,6 +45,17 @@ import { useAppStore } from "../store";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
 
 const mockApi = vi.mocked(api);
+
+function worktreeRemovalOutcome(
+  result: WorktreeRemoval | null,
+): WorktreeRemovalOutcome {
+  return {
+    result,
+    removedSessionIds: [],
+    issues: [],
+    retryToken: null,
+  };
+}
 
 async function flushPromises() {
   await act(async () => {
@@ -113,7 +124,7 @@ describe("ProjectSettingsModal", () => {
     mockApi.listProjectBranches.mockResolvedValue([]);
     mockApi.listProjects.mockResolvedValue([]);
     mockApi.listSessions.mockResolvedValue([]);
-    mockApi.removeWorktree.mockResolvedValue(null);
+    mockApi.removeWorktree.mockResolvedValue(worktreeRemovalOutcome(null));
     mockApi.discardRemovedWorktree.mockResolvedValue();
   });
 
@@ -250,7 +261,9 @@ describe("ProjectSettingsModal", () => {
         modified_ms: null,
       },
     ]);
-    mockApi.removeWorktree.mockResolvedValueOnce(removal);
+    mockApi.removeWorktree.mockResolvedValueOnce(
+      worktreeRemovalOutcome(removal),
+    );
     const onClose = vi.fn();
 
     await act(async () => {
@@ -449,7 +462,7 @@ describe("ProjectSettingsModal", () => {
     ]);
     mockApi.removeWorktree
       .mockRejectedValueOnce(new Error("not a linked git worktree"))
-      .mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(worktreeRemovalOutcome(null));
 
     await act(async () => {
       root.render(

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -625,7 +625,7 @@ export function ProjectSettingsModal({
     setRemovingPath(target.path);
     setWorktreeError(null);
     try {
-      const removedWorktree = await removeProjectWorktree(
+      const outcome = await removeProjectWorktree(
         target.rootPath,
         target.path,
         targetSessions.length > 0,
@@ -638,7 +638,7 @@ export function ProjectSettingsModal({
             worktree.path !== target.path,
         ),
       );
-      await discardRemovedWorktreesWithRetry(removedWorktree);
+      await discardRemovedWorktreesWithRetry(outcome.result);
     } catch (e) {
       setWorktreeError({ kind: "remove", message: String(e) });
     } finally {
@@ -689,13 +689,13 @@ export function ProjectSettingsModal({
           continue;
         }
         try {
-          const removedWorktree = await removeProjectWorktree(
+          const outcome = await removeProjectWorktree(
             target.rootPath,
             target.path,
             false,
           );
-          if (removedWorktree) {
-            removals.push(removedWorktree);
+          if (outcome.result) {
+            removals.push(outcome.result);
           }
           removedKeys.add(`${target.rootPath}\u0000${target.path}`);
         } catch (e) {

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -13,7 +13,10 @@ import { useEffect, useMemo, useState } from "react";
 import { api, type WorktreeRemoval } from "../lib/api";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
-import { discardRemovedWorktreesWithRetry } from "../lib/operationToasts";
+import {
+  discardRemovedWorktreesWithRetry,
+  showRemovalOutcomeIssues,
+} from "../lib/operationToasts";
 import { STANDARD_PR_GENERATION_PROMPT } from "../lib/project-settings";
 import { basenamePath, projectRootPaths } from "../lib/projectFolders";
 import {
@@ -638,6 +641,7 @@ export function ProjectSettingsModal({
             worktree.path !== target.path,
         ),
       );
+      showRemovalOutcomeIssues(outcome);
       await discardRemovedWorktreesWithRetry(outcome.result);
     } catch (e) {
       setWorktreeError({ kind: "remove", message: String(e) });
@@ -697,6 +701,7 @@ export function ProjectSettingsModal({
           if (outcome.result) {
             removals.push(outcome.result);
           }
+          showRemovalOutcomeIssues(outcome);
           removedKeys.add(`${target.rootPath}\u0000${target.path}`);
         } catch (e) {
           failures.push(`${target.name}: ${String(e)}`);

--- a/src/components/PullRequestDetailModal.modal.test.tsx
+++ b/src/components/PullRequestDetailModal.modal.test.tsx
@@ -126,7 +126,12 @@ describe("PullRequestDetailModal — body checkbox toggle", () => {
     });
     mockApi.listProjectWorktrees.mockResolvedValue([]);
     mockApi.listProjectBranches.mockResolvedValue([]);
-    mockApi.removeWorktree.mockResolvedValue(null);
+    mockApi.removeWorktree.mockResolvedValue({
+      result: null,
+      removedSessionIds: [],
+      issues: [],
+      retryToken: null,
+    });
     window.localStorage.clear();
     useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
   });

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -116,7 +116,9 @@ import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import { useCurrentPullRequest } from "../lib/useCurrentPullRequest";
 import {
+  showRemovalOutcomeIssues,
   showSessionRemovalToast,
+  showStoreResultToast,
   showWorktreeRemovalToast,
 } from "../lib/operationToasts";
 import {
@@ -591,6 +593,7 @@ export function Sidebar() {
           showToast(`${t("toasts.session.removeFailed")} ${error}`);
           return;
         }
+        showRemovalOutcomeIssues(outcome);
       }
       removeProjectFolder(folderGroup.folder.id);
       if (removedSessions.length > 0) {
@@ -634,6 +637,7 @@ export function Sidebar() {
           },
         },
       );
+      showRemovalOutcomeIssues(outcome);
     } catch (e) {
       console.error("remove project folder worktree failed", e);
       showToast(`${t("toasts.session.worktreeRemoveFailed")} ${String(e)}`);
@@ -1522,9 +1526,18 @@ export function Sidebar() {
                         onRenameFolder={renameProjectFolder}
                         onRemoveFolder={requestRemoveProjectFolder}
                         onMoveSessionToFolder={moveSessionToProjectFolder}
-                        onRemoveProject={() =>
-                          requestRemoveProject(project.repoPath)
-                        }
+                        onRemoveProject={() => {
+                          const removal = requestRemoveProject(project.repoPath);
+                          if (removal) {
+                            void removal.then((outcome) =>
+                              showStoreResultToast(
+                                null,
+                                "toasts.project.removeFailed",
+                                outcome,
+                              ),
+                            );
+                          }
+                        }}
                         onOpenSettings={() =>
                           setSettingsProject({
                             name: project.name,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -574,7 +574,7 @@ export function Sidebar() {
       const removedSessions: SessionRemoval[] = [];
       for (const session of folderGroup.sessions) {
         const currentState = useAppStore.getState();
-        const removal = await removeSession(
+        const outcome = await removeSession(
           session.id,
           deleteIsolatedWorktreesWithoutPrompt &&
             shouldAutoDeleteSessionWorktree(
@@ -583,8 +583,8 @@ export function Sidebar() {
               currentState.sessions,
             ),
         );
-        if (removal) {
-          removedSessions.push(removal);
+        if (outcome?.result) {
+          removedSessions.push(outcome.result);
         }
         const error = useAppStore.getState().consumeError();
         if (error) {
@@ -610,13 +610,13 @@ export function Sidebar() {
 
   async function removeProjectFolderAndWorktree(folder: ProjectFolder) {
     try {
-      const removedWorktree = await api.removeWorktree(
+      const outcome = await api.removeWorktree(
         folder.repoPath,
         folder.cwdPath,
       );
       removeProjectFolder(folder.id);
       showWorktreeRemovalToast(
-        removedWorktree,
+        outcome.result,
         "toasts.session.worktreeRemoved",
         "toasts.session.worktreeRemovedUndo",
         "toasts.session.worktreeRestored",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2834,10 +2834,11 @@ export function Terminal({
               if (session && hasRecordedWorktree(session)) {
                 store.requestRemoveSession(sessionId);
               } else {
-                void store.removeSession(sessionId, false).then(() => {
+                void store.removeSession(sessionId, false).then((outcome) => {
                   showStoreResultToast(
                     null,
                     "toasts.session.removeFailed",
+                    outcome,
                   );
                 });
               }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -127,6 +127,30 @@ export interface SessionRemoval extends WorktreeRemoval {
   sessionIds: string[];
 }
 
+export type RemovalIssueKind =
+  | "worktree"
+  | "scrollback"
+  | "settings"
+  | "persistence";
+
+export interface RemovalIssue {
+  kind: RemovalIssueKind;
+  target: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface RemovalOutcome<T> {
+  result: T;
+  removedSessionIds: string[];
+  issues: RemovalIssue[];
+  retryToken: string | null;
+}
+
+export type SessionRemovalOutcome = RemovalOutcome<SessionRemoval | null>;
+export type WorktreeRemovalOutcome = RemovalOutcome<WorktreeRemoval | null>;
+export type ProjectRemovalOutcome = RemovalOutcome<WorktreeRemoval[]>;
+
 export interface ChatSessionStateChangedPayload {
   session_id: string;
   state: ChatSessionState;
@@ -201,8 +225,8 @@ export const api = {
   removeSession(
     id: string,
     removeWorktree = false,
-  ): Promise<SessionRemoval | null> {
-    return invoke<SessionRemoval | null>("remove_session", { id, removeWorktree });
+  ): Promise<SessionRemovalOutcome> {
+    return invoke<SessionRemovalOutcome>("remove_session", { id, removeWorktree });
   },
   setSessionStatus(id: string, status: SessionStatus): Promise<Session> {
     return invoke<Session>("set_session_status", { id, status });
@@ -447,8 +471,8 @@ export const api = {
     removeSessions = true,
     removeWorktrees = false,
     removeSettings = false,
-  ): Promise<WorktreeRemoval[]> {
-    return invoke<WorktreeRemoval[]>("remove_project", {
+  ): Promise<ProjectRemovalOutcome> {
+    return invoke<ProjectRemovalOutcome>("remove_project", {
       repoPath,
       removeSessions,
       removeWorktrees,
@@ -972,8 +996,8 @@ export const api = {
     repoPath: string,
     worktreePath: string,
     removeSessions = false,
-  ): Promise<WorktreeRemoval | null> {
-    return invoke<WorktreeRemoval | null>(
+  ): Promise<WorktreeRemovalOutcome> {
+    return invoke<WorktreeRemovalOutcome>(
       "remove_worktree",
       removeSessions
         ? { repoPath, worktreePath, removeSessions }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -150,6 +150,7 @@ export interface RemovalOutcome<T> {
 export type SessionRemovalOutcome = RemovalOutcome<SessionRemoval | null>;
 export type WorktreeRemovalOutcome = RemovalOutcome<WorktreeRemoval | null>;
 export type ProjectRemovalOutcome = RemovalOutcome<WorktreeRemoval[]>;
+export type RemovalCleanupRetryOutcome = RemovalOutcome<WorktreeRemoval[]>;
 
 export interface ChatSessionStateChangedPayload {
   session_id: string;
@@ -1003,6 +1004,16 @@ export const api = {
         ? { repoPath, worktreePath, removeSessions }
         : { repoPath, worktreePath },
     );
+  },
+  retryRemovalCleanup(
+    retryToken: string,
+  ): Promise<RemovalCleanupRetryOutcome> {
+    return invoke<RemovalCleanupRetryOutcome>("retry_removal_cleanup", {
+      retryToken,
+    });
+  },
+  discardRemovalRetry(retryToken: string): Promise<void> {
+    return invoke<void>("discard_removal_retry", { retryToken });
   },
   restoreRemovedWorktree(removal: WorktreeRemoval): Promise<void> {
     return invoke<void>("restore_removed_worktree", { ...removal });

--- a/src/lib/operationToasts.test.ts
+++ b/src/lib/operationToasts.test.ts
@@ -4,6 +4,8 @@ vi.mock("./api", () => ({
   api: {
     discardRemovedSession: vi.fn(),
     discardRemovedWorktree: vi.fn(),
+    discardRemovalRetry: vi.fn(),
+    retryRemovalCleanup: vi.fn(),
     restoreRemovedSession: vi.fn(),
     restoreRemovedWorktree: vi.fn(),
   },
@@ -11,6 +13,7 @@ vi.mock("./api", () => ({
 
 import { api, type SessionRemoval, type WorktreeRemoval } from "./api";
 import {
+  showRemovalOutcomeIssues,
   showSessionRemovalToast,
   showWorktreeRemovalToast,
 } from "./operationToasts";
@@ -108,5 +111,60 @@ describe("removal cleanup toasts", () => {
 
     expect(mockApi.discardRemovedSession).toHaveBeenCalledTimes(2);
     expect(mockApi.discardRemovedSession).toHaveBeenLastCalledWith(removal);
+  });
+
+  it("shows exact partial-removal failures and retries by opaque token", async () => {
+    const retriedRemoval = worktreeRemoval("retried-worktree");
+    mockApi.retryRemovalCleanup.mockResolvedValue({
+      result: [retriedRemoval],
+      removedSessionIds: [],
+      issues: [],
+      retryToken: null,
+    });
+
+    showRemovalOutcomeIssues({
+      result: null,
+      removedSessionIds: ["session-1"],
+      issues: [
+        {
+          kind: "scrollback",
+          target: "session-1",
+          message: "Permission denied",
+          retryable: true,
+        },
+      ],
+      retryToken: "opaque-retry-token",
+    });
+
+    const issueToast = useToasts.getState().toasts[0];
+    expect(issueToast.message).toContain("session-1: Permission denied");
+    await issueToast.action?.();
+
+    expect(mockApi.retryRemovalCleanup).toHaveBeenCalledWith(
+      "opaque-retry-token",
+    );
+    expect(useToasts.getState().toasts[1]?.message).toContain(
+      "retried-worktree",
+    );
+  });
+
+  it("forgets an ignored removal retry token without exposing cleanup inputs", async () => {
+    showRemovalOutcomeIssues({
+      result: [],
+      removedSessionIds: [],
+      issues: [
+        {
+          kind: "persistence",
+          target: "sessions",
+          message: "read-only file system",
+          retryable: true,
+        },
+      ],
+      retryToken: "ignored-token",
+    });
+
+    await useToasts.getState().toasts[0]?.onDismiss?.();
+
+    expect(mockApi.discardRemovalRetry).toHaveBeenCalledWith("ignored-token");
   });
 });

--- a/src/lib/operationToasts.ts
+++ b/src/lib/operationToasts.ts
@@ -2,7 +2,12 @@ import { createTranslator, type TranslationKey } from "./i18n";
 import { useSettings } from "./settings";
 import { TOAST_TTL_MS, useToasts } from "./toasts";
 import { useAppStore } from "../store";
-import { api, type SessionRemoval, type WorktreeRemoval } from "./api";
+import {
+  api,
+  type RemovalOutcome,
+  type SessionRemoval,
+  type WorktreeRemoval,
+} from "./api";
 
 export function currentText(
   key: TranslationKey,
@@ -36,6 +41,7 @@ export function showTranslatedErrorToast(
 export function showStoreResultToast(
   successKey: TranslationKey | null,
   failureKey: TranslationKey,
+  outcome?: RemovalOutcome<unknown> | null,
 ): void {
   const error = useAppStore.getState().consumeError();
   if (error) {
@@ -45,6 +51,59 @@ export function showStoreResultToast(
   if (successKey) {
     showTranslatedToast(successKey);
   }
+  showRemovalOutcomeIssues(outcome);
+}
+
+function removalIssueDetails(outcome: RemovalOutcome<unknown>): string {
+  return outcome.issues
+    .map((issue) => `${issue.target}: ${issue.message}`)
+    .join("; ");
+}
+
+export function showRemovalOutcomeIssues(
+  outcome: RemovalOutcome<unknown> | null | undefined,
+): void {
+  if (!outcome || outcome.issues.length === 0) return;
+
+  const retryToken = outcome.retryToken;
+  const canRetry =
+    retryToken !== null && outcome.issues.some((issue) => issue.retryable);
+  const key = canRetry
+    ? "toasts.removal.partialFailureRetry"
+    : "toasts.removal.partialFailure";
+  useToasts
+    .getState()
+    .show(currentText(key, { error: removalIssueDetails(outcome) }), {
+      action: canRetry
+        ? async () => {
+            try {
+              const retryOutcome = await api.retryRemovalCleanup(retryToken);
+              if (retryOutcome.result.length > 0) {
+                showWorktreeRemovalToast(
+                  retryOutcome.result,
+                  "toasts.session.worktreeRemoved",
+                  "toasts.session.worktreeRemovedUndo",
+                  "toasts.session.worktreeRestored",
+                  "toasts.session.worktreeRestoreFailed",
+                );
+              } else if (retryOutcome.issues.length === 0) {
+                showTranslatedToast("toasts.removal.cleanupCompleted");
+              }
+              showRemovalOutcomeIssues(retryOutcome);
+            } catch (error) {
+              showTranslatedErrorToast(
+                "toasts.removal.cleanupRetryFailed",
+                error,
+              );
+            }
+          }
+        : undefined,
+      onDismiss: retryToken
+        ? async () => {
+            await api.discardRemovalRetry(retryToken);
+          }
+        : undefined,
+    });
 }
 
 function worktreeName(removal: WorktreeRemoval): string {
@@ -186,7 +245,10 @@ export function showWorktreeRemovalToast(
 }
 
 export function showStoreWorktreeRemovalToast(
-  removals: WorktreeRemoval | WorktreeRemoval[] | null | undefined,
+  outcome:
+    | RemovalOutcome<WorktreeRemoval | WorktreeRemoval[] | null>
+    | null
+    | undefined,
   successKey: TranslationKey,
   undoKey: TranslationKey,
   failureKey: TranslationKey,
@@ -199,12 +261,13 @@ export function showStoreWorktreeRemovalToast(
     return;
   }
   showWorktreeRemovalToast(
-    removals,
+    outcome?.result,
     successKey,
     undoKey,
     restoredKey,
     restoreFailedKey,
   );
+  showRemovalOutcomeIssues(outcome);
 }
 
 export function showSessionRemovalToast(
@@ -256,7 +319,10 @@ export function showSessionRemovalToast(
 }
 
 export function showStoreSessionRemovalToast(
-  removals: SessionRemoval | SessionRemoval[] | null | undefined,
+  outcome:
+    | RemovalOutcome<SessionRemoval | SessionRemoval[] | null>
+    | null
+    | undefined,
   successKey: TranslationKey,
   undoKey: TranslationKey,
   failureKey: TranslationKey,
@@ -269,10 +335,11 @@ export function showStoreSessionRemovalToast(
     return;
   }
   showSessionRemovalToast(
-    removals,
+    outcome?.result,
     successKey,
     undoKey,
     restoredKey,
     restoreFailedKey,
   );
+  showRemovalOutcomeIssues(outcome);
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,11 @@
 {
   "toasts": {
+    "removal": {
+      "partialFailure": "Removal completed, but cleanup needs attention: {error}.",
+      "partialFailureRetry": "Removal completed, but cleanup needs attention: {error}. Retry",
+      "cleanupCompleted": "Removal cleanup completed.",
+      "cleanupRetryFailed": "Failed to retry removal cleanup:"
+    },
     "session": {
       "createFailed": "Failed to create session:",
       "removeFailed": "Failed to remove session:",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,5 +1,11 @@
 {
   "toasts": {
+    "removal": {
+      "partialFailure": "削除は完了しましたが、後処理の確認が必要です: {error}。",
+      "partialFailureRetry": "削除は完了しましたが、後処理の確認が必要です: {error}。再試行",
+      "cleanupCompleted": "削除後のクリーンアップが完了しました。",
+      "cleanupRetryFailed": "削除後のクリーンアップを再試行できませんでした:"
+    },
     "session": {
       "createFailed": "セッションの作成に失敗しました:",
       "removeFailed": "セッションを削除できませんでした:",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,5 +1,11 @@
 {
   "toasts": {
+    "removal": {
+      "partialFailure": "제거는 완료했지만 후처리를 확인해야 합니다: {error}.",
+      "partialFailureRetry": "제거는 완료했지만 후처리를 확인해야 합니다: {error}. 다시 시도",
+      "cleanupCompleted": "제거 후처리를 완료했습니다.",
+      "cleanupRetryFailed": "제거 후처리를 다시 시도하지 못했습니다:"
+    },
     "session": {
       "createFailed": "세션을 만들지 못했습니다:",
       "removeFailed": "세션을 제거하지 못했습니다:",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,5 +1,11 @@
 {
   "toasts": {
+    "removal": {
+      "partialFailure": "删除已完成，但后续清理需要处理：{error}。",
+      "partialFailureRetry": "删除已完成，但后续清理需要处理：{error}。重试",
+      "cleanupCompleted": "删除后的清理已完成。",
+      "cleanupRetryFailed": "无法重试删除后的清理："
+    },
     "session": {
       "createFailed": "无法创建会话：",
       "removeFailed": "无法删除会话：",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -25,8 +25,18 @@ vi.mock("./lib/api", () => {
       ),
       ptyInWorktreeAll: vi.fn(async () => ({} as Record<string, boolean>)),
       createSession: vi.fn(async () => ({}) as Session),
-      removeSession: vi.fn(async () => null),
-      removeWorktree: vi.fn(async () => null),
+      removeSession: vi.fn(async () => ({
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      })),
+      removeWorktree: vi.fn(async () => ({
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      })),
       renameSession: vi.fn(async () => ({}) as Session),
       generateSessionTitle: vi.fn(
         async () =>
@@ -46,7 +56,12 @@ vi.mock("./lib/api", () => {
       mergeProjectSource: vi.fn(async () => ({}) as Project),
       splitProjectSource: vi.fn(async () => ({}) as Project),
       createNewProject: vi.fn(async () => ({}) as Project),
-      removeProject: vi.fn(async () => []),
+      removeProject: vi.fn(async () => ({
+        result: [],
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      })),
       reorderProjects: vi.fn(async (paths: string[]) =>
         paths.map<Project>((repo_path, i) => ({
           repo_path,
@@ -71,7 +86,7 @@ vi.mock("./lib/api", () => {
   };
 });
 
-import { api } from "./lib/api";
+import { api, type RemovalOutcome } from "./lib/api";
 import { useAppStore } from "./store";
 import { defaultTabByGroup } from "./lib/rightPanelGroups";
 import { DEFAULT_SETTINGS, useSettings } from "./lib/settings";
@@ -81,6 +96,18 @@ const mockApi = vi.mocked(api);
 
 const REPO_A = "/Users/me/repo-a";
 const REPO_B = "/Users/me/repo-b";
+
+function removalOutcome<T>(
+  result: T,
+  removedSessionIds: string[] = [],
+): RemovalOutcome<T> {
+  return {
+    result,
+    removedSessionIds,
+    issues: [],
+    retryToken: null,
+  };
+}
 
 function project(repoPath: string, position: number): Project {
   return {
@@ -256,9 +283,9 @@ beforeEach(() => {
   mockApi.listSessions.mockResolvedValue([]);
   mockApi.listProjects.mockResolvedValue([]);
   mockApi.detectSessionStatuses.mockResolvedValue([]);
-  mockApi.removeSession.mockResolvedValue(null);
-  mockApi.removeWorktree.mockResolvedValue(null);
-  mockApi.removeProject.mockResolvedValue([]);
+  mockApi.removeSession.mockResolvedValue(removalOutcome(null));
+  mockApi.removeWorktree.mockResolvedValue(removalOutcome(null));
+  mockApi.removeProject.mockResolvedValue(removalOutcome([]));
   mockApi.loadChatSessionState.mockResolvedValue({
     messages: [],
     turns: [],
@@ -1698,7 +1725,7 @@ describe("removeSession", () => {
     await seed([project(REPO_A, 0)], [a1, a2]);
     useAppStore.getState().selectSession("a1");
 
-    const pending = deferred<null>();
+    const pending = deferred<RemovalOutcome<null>>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a2]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -1709,7 +1736,7 @@ describe("removeSession", () => {
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
     expect(useAppStore.getState().activeSessionId).toBe("a2");
 
-    pending.resolve(null);
+    pending.resolve(removalOutcome(null, ["a1"]));
     await removal;
     expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a2"]);
   });
@@ -1727,7 +1754,7 @@ describe("removeSession", () => {
     useAppStore.getState().setSessionSilenced("a1", true);
     useAppStore.getState().setSessionSilenced("a2", true);
 
-    const pending = deferred<null>();
+    const pending = deferred<RemovalOutcome<null>>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a2]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -1739,7 +1766,7 @@ describe("removeSession", () => {
     ).toEqual(["n2"]);
     expect(useAppStore.getState().silencedSessionIds).toEqual({ a2: true });
 
-    pending.resolve(null);
+    pending.resolve(removalOutcome(null, ["a1"]));
     await removal;
   });
 
@@ -1798,13 +1825,15 @@ describe("removeSession", () => {
     });
     await seed([project(REPO_A, 0)], [control, worker]);
 
-    mockApi.removeSession.mockResolvedValueOnce(null);
+    mockApi.removeSession.mockResolvedValueOnce(
+      removalOutcome(null, ["ctl", "worker"]),
+    );
     mockApi.listSessions.mockResolvedValue([]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
 
     const removed = await useAppStore.getState().removeSession("ctl", true);
 
-    expect(removed).toBeNull();
+    expect(removed).toEqual(removalOutcome(null, ["ctl", "worker"]));
     expect(mockApi.removeSession).toHaveBeenCalledWith("ctl", true);
     expect(useAppStore.getState().error).toBeNull();
   });
@@ -1826,7 +1855,7 @@ describe("removeSession", () => {
     });
     expect(useAppStore.getState().layout.kind).toBe("split");
 
-    const pending = deferred<null>();
+    const pending = deferred<RemovalOutcome<null>>();
     mockApi.removeSession.mockReturnValueOnce(pending.promise);
     mockApi.listSessions.mockResolvedValue([a1]);
     mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
@@ -1840,7 +1869,7 @@ describe("removeSession", () => {
     expect(mid.panes[mid.focusedPaneId].tabIds).toEqual(["a1"]);
     expect(mid.activeSessionId).toBe("a1");
 
-    pending.resolve(null);
+    pending.resolve(removalOutcome(null, ["a2"]));
     await removal;
 
     const after = useAppStore.getState();
@@ -3373,7 +3402,7 @@ describe("removeProject", () => {
     expect(useAppStore.getState().activeProject).toBe(REPO_B);
 
     // After remove, refreshAll re-pulls projects/sessions; return both stripped of B.
-    mockApi.removeProject.mockResolvedValueOnce([]);
+    mockApi.removeProject.mockResolvedValueOnce(removalOutcome([]));
     mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
     mockApi.listSessions.mockResolvedValueOnce([]);
 
@@ -3532,7 +3561,7 @@ describe("requestRemoveProject", () => {
 
   it("removes the project directly without a confirmation modal when no sessions remain", async () => {
     await seed([project(REPO_A, 0), project(REPO_B, 1)], []);
-    mockApi.removeProject.mockResolvedValueOnce([]);
+    mockApi.removeProject.mockResolvedValueOnce(removalOutcome([]));
     mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
     mockApi.listSessions.mockResolvedValueOnce([]);
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -589,7 +589,9 @@ interface AppStateModel {
     orderedFolderIds: string[],
   ) => void;
   reorderSessions: (repoPath: string, orderedIds: string[]) => Promise<void>;
-  requestRemoveProject: (repoPath: string) => void;
+  requestRemoveProject: (
+    repoPath: string,
+  ) => Promise<ProjectRemovalOutcome | null> | null;
   clearPendingRemoveProject: () => void;
   setRightTab: (tab: RightTab) => void;
   /** Switch to `group` and restore that group's last sub-tab. */
@@ -3796,10 +3798,10 @@ export const useAppStore = create<AppStateModel>()(
   requestRemoveProject(repoPath) {
     const hasSessions = get().sessions.some((s) => s.repo_path === repoPath);
     if (!hasSessions) {
-      void get().removeProject(repoPath, false);
-      return;
+      return get().removeProject(repoPath, false);
     }
     set({ pendingRemoveProject: repoPath });
+    return null;
   },
 
   clearPendingRemoveProject() {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,8 +3,9 @@ import { persist, createJSONStorage } from "zustand/middleware";
 import {
   api,
   type AiExecutionRequest,
-  type SessionRemoval,
-  type WorktreeRemoval,
+  type ProjectRemovalOutcome,
+  type SessionRemovalOutcome,
+  type WorktreeRemovalOutcome,
 } from "./lib/api";
 import type {
   AgentTranscriptSummary,
@@ -525,7 +526,7 @@ interface AppStateModel {
   removeSession: (
     id: string,
     removeWorktree?: boolean,
-  ) => Promise<SessionRemoval | null>;
+  ) => Promise<SessionRemovalOutcome | null>;
   renameSession: (id: string, name: string) => Promise<void>;
   generateSessionTitle: (
     id: string,
@@ -549,7 +550,7 @@ interface AppStateModel {
     repoPath: string,
     removeWorktrees?: boolean,
     removeSettings?: boolean,
-  ) => Promise<WorktreeRemoval[]>;
+  ) => Promise<ProjectRemovalOutcome | null>;
   /** Register an existing project spanning `roots` and open its first session. */
   addProjectAt: (name: string, roots: string[]) => Promise<Project>;
   renameProject: (repoPath: string, name: string) => Promise<boolean>;
@@ -581,7 +582,7 @@ interface AppStateModel {
     repoPath: string,
     worktreePath: string,
     removeSessions?: boolean,
-  ) => Promise<WorktreeRemoval | null>;
+  ) => Promise<WorktreeRemovalOutcome>;
   reorderProjects: (orderedRepoPaths: string[]) => Promise<void>;
   reorderProjectFolders: (
     repoPath: string,
@@ -3232,10 +3233,10 @@ export const useAppStore = create<AppStateModel>()(
     }
 
     try {
-      const removal = await api.removeSession(id, removeWorktree);
+      const outcome = await api.removeSession(id, removeWorktree);
       await get().refreshAll();
       set({ error: null });
-      return removal ?? null;
+      return outcome;
     } catch (e) {
       const message = errorMessage(e);
       await get().refreshAll();
@@ -3500,7 +3501,7 @@ export const useAppStore = create<AppStateModel>()(
 
   async removeProject(repoPath, removeWorktrees = false, removeSettings = false) {
     try {
-      const removedWorktrees = await api.removeProject(
+      const outcome = await api.removeProject(
         repoPath,
         true,
         removeWorktrees,
@@ -3568,10 +3569,10 @@ export const useAppStore = create<AppStateModel>()(
       });
       await get().refreshAll();
       set({ error: null });
-      return removedWorktrees ?? [];
+      return outcome;
     } catch (e) {
       set({ error: errorMessage(e) });
-      return [];
+      return null;
     }
   },
 
@@ -3604,7 +3605,7 @@ export const useAppStore = create<AppStateModel>()(
         set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
         throw new Error(WORKTREE_IN_USE_BY_OTHER_SESSIONS);
       }
-      const removedWorktree = await api.removeWorktree(
+      const outcome = await api.removeWorktree(
         repoPath,
         worktreePath,
         removeSessions,
@@ -3703,7 +3704,7 @@ export const useAppStore = create<AppStateModel>()(
       });
       await get().refreshAll();
       set({ error: null });
-      return removedWorktree ?? null;
+      return outcome;
     } catch (e) {
       set({ error: errorMessage(e) });
       throw e;

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -490,7 +490,12 @@ test.describe("workspace canvas mode", () => {
       const id = (args as { id: string }).id;
       w.__canvasRemoveCalls = [...(w.__canvasRemoveCalls ?? []), args];
       w.__canvasRemovedIds = [...(w.__canvasRemovedIds ?? []), id];
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [id],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -1076,7 +1081,12 @@ test.describe("workspace canvas mode", () => {
         ...(w.__canvasRemovedIds ?? []),
         (args as { id: string }).id,
       ];
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [(args as { id: string }).id],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -564,6 +564,15 @@ export const tauriMockSource = `
         retryToken: null,
       });
     }
+    if (cmd === 'retry_removal_cleanup') {
+      return Promise.resolve({
+        result: [],
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      });
+    }
+    if (cmd === 'discard_removal_retry') return Promise.resolve(undefined);
     if (cmd === 'restore_removed_worktree') return Promise.resolve(undefined);
     if (cmd === 'discard_removed_worktree') return Promise.resolve(undefined);
     if (cmd === 'restore_removed_session') return Promise.resolve(undefined);

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -548,7 +548,22 @@ export const tauriMockSource = `
     if (cmd === 'is_path_linked_worktree') return Promise.resolve(false);
     if (cmd === 'list_project_worktrees') return Promise.resolve([]);
     if (cmd === 'list_project_branches') return Promise.resolve([]);
-    if (cmd === 'remove_worktree') return Promise.resolve(null);
+    if (cmd === 'remove_session' || cmd === 'remove_worktree') {
+      return Promise.resolve({
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      });
+    }
+    if (cmd === 'remove_project') {
+      return Promise.resolve({
+        result: [],
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      });
+    }
     if (cmd === 'restore_removed_worktree') return Promise.resolve(undefined);
     if (cmd === 'discard_removed_worktree') return Promise.resolve(undefined);
     if (cmd === 'restore_removed_session') return Promise.resolve(undefined);

--- a/tests/e2e/kanban.spec.ts
+++ b/tests/e2e/kanban.spec.ts
@@ -227,11 +227,16 @@ test.describe("workspace kanban mode", () => {
       const w = window as unknown as { __kanbanSessionRemoved?: boolean };
       w.__kanbanSessionRemoved = true;
       return {
-        token: "kanban-removal-token",
-        repoPath: "/tmp/demo",
-        worktreePath: "/tmp/demo/.worktrees/completed",
-        gitCommonDir: "/tmp/demo/.git",
-        sessionIds: ["completed"],
+        result: {
+          token: "kanban-removal-token",
+          repoPath: "/tmp/demo",
+          worktreePath: "/tmp/demo/.worktrees/completed",
+          gitCommonDir: "/tmp/demo/.git",
+          sessionIds: ["completed"],
+        },
+        removedSessionIds: ["completed"],
+        issues: [],
+        retryToken: null,
       };
     });
 

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -769,7 +769,12 @@ test.describe("pane / sidebar shortcuts", () => {
     await tauri.handle("remove_session", () => {
       const w = window as unknown as { __removed?: boolean };
       w.__removed = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: ["s-1"],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");

--- a/tests/e2e/project-settings.spec.ts
+++ b/tests/e2e/project-settings.spec.ts
@@ -167,10 +167,15 @@ test.describe("project settings", () => {
       w.__removeWorktreeCalls.push(args);
       const worktreePath = (args as { worktreePath?: string }).worktreePath;
       return {
-        token: "remove-feature-alpha",
-        repoPath: "/tmp/acorn",
-        worktreePath,
-        gitCommonDir: "/tmp/acorn/.git",
+        result: {
+          token: "remove-feature-alpha",
+          repoPath: "/tmp/acorn",
+          worktreePath,
+          gitCommonDir: "/tmp/acorn/.git",
+        },
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
       };
     });
     await tauri.handle("discard_removed_worktree", (args) => {
@@ -336,7 +341,12 @@ test.describe("project settings", () => {
       w.__worktrees = (w.__worktrees ?? []).filter(
         (worktree) => worktree.path !== worktreePath,
       );
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -713,7 +723,12 @@ test.describe("project settings", () => {
       w.__worktrees = (w.__worktrees ?? []).filter(
         (worktree) => worktree.path !== worktreePath,
       );
-      return undefined;
+      return {
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -833,7 +848,12 @@ test.describe("project settings", () => {
       const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
       w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
       w.__removeWorktreeCalls.push(args);
-      return undefined;
+      return {
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -217,6 +217,103 @@ test.describe("session lifecycle", () => {
     expect(calls[0].removeWorktree).toBe(false);
   });
 
+  test("partial session removal reports the exact cleanup failure and retries by token", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      return w.__sessionRemoved
+        ? []
+        : [
+            {
+              id: "s-1",
+              name: "alpha",
+              repo_path: "/tmp/demo",
+              worktree_path: "/tmp/demo",
+              branch: "main",
+              isolated: false,
+              status: "ready",
+              created_at: "2026-01-01T00:00:00Z",
+              updated_at: "2026-01-01T00:00:05Z",
+              last_message: null,
+            },
+          ];
+    });
+    await tauri.handle("remove_session", () => {
+      const w = window as unknown as { __sessionRemoved?: boolean };
+      w.__sessionRemoved = true;
+      return {
+        result: null,
+        removedSessionIds: ["s-1"],
+        issues: [
+          {
+            kind: "scrollback",
+            target: "s-1",
+            message: "Permission denied",
+            retryable: true,
+          },
+        ],
+        retryToken: "opaque-cleanup-token",
+      };
+    });
+    await tauri.handle("retry_removal_cleanup", (args) => {
+      const w = window as unknown as { __cleanupRetryCalls?: unknown[] };
+      w.__cleanupRetryCalls = w.__cleanupRetryCalls ?? [];
+      w.__cleanupRetryCalls.push(args);
+      return {
+        result: [],
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
+    });
+    await tauri.handle("discard_removal_retry", (args) => {
+      const w = window as unknown as { __discardRetryCalls?: unknown[] };
+      w.__discardRetryCalls = w.__discardRetryCalls ?? [];
+      w.__discardRetryCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /^alpha main · Ready/ })
+      .first();
+    await row.hover();
+    await sidebar
+      .getByRole("button", { name: "Remove session", exact: true })
+      .click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /^Remove$/ })
+      .click();
+
+    const issueToast = page.getByText(
+      "Removal completed, but cleanup needs attention: s-1: Permission denied. Retry",
+    );
+    await expect(issueToast).toBeVisible();
+    await issueToast.click();
+    await expect(page.getByText("Removal cleanup completed.")).toBeVisible();
+
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __cleanupRetryCalls?: unknown[] })
+            .__cleanupRetryCalls,
+      ),
+    ).toEqual([{ retryToken: "opaque-cleanup-token" }]);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __discardRetryCalls?: unknown[] })
+            .__discardRetryCalls ?? [],
+      ),
+    ).toEqual([]);
+  });
+
   test("closing a working session shows a warning before removal", async ({
     page,
     tauri,

--- a/tests/e2e/session-lifecycle.spec.ts
+++ b/tests/e2e/session-lifecycle.spec.ts
@@ -172,7 +172,12 @@ test.describe("session lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__sessionRemoved = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [String(args?.id ?? "")],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -255,7 +260,12 @@ test.describe("session lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__sessionRemoved = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [String(args?.id ?? "")],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -357,7 +367,12 @@ test.describe("session lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__sessionRemoved = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [String(args?.id ?? "")],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -430,11 +445,16 @@ test.describe("session lifecycle", () => {
       const w = window as unknown as { __sessionRemoved?: boolean };
       w.__sessionRemoved = true;
       return {
-        token: "session-undo-token",
-        repoPath: "/tmp/demo",
-        worktreePath: "/tmp/demo/.acorn/worktrees/alpha",
-        gitCommonDir: "/tmp/demo/.git",
-        sessionIds: ["s-1"],
+        result: {
+          token: "session-undo-token",
+          repoPath: "/tmp/demo",
+          worktreePath: "/tmp/demo/.acorn/worktrees/alpha",
+          gitCommonDir: "/tmp/demo/.git",
+          sessionIds: ["s-1"],
+        },
+        removedSessionIds: ["s-1"],
+        issues: [],
+        retryToken: null,
       };
     });
     await tauri.handle("restore_removed_session", (args) => {
@@ -542,7 +562,12 @@ test.describe("session lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__sessionRemoved = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [String(args?.id ?? "")],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -676,7 +701,12 @@ test.describe("session lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__sessionRemoved = true;
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [String(args?.id ?? "")],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -1421,7 +1421,12 @@ test.describe("sidebar: project lifecycle", () => {
       w.__removeCalls.push(args);
       const id = String(args?.id ?? "");
       w.__removedIds = Array.from(new Set([...(w.__removedIds ?? []), id]));
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [id],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -1572,7 +1577,12 @@ test.describe("sidebar: project lifecycle", () => {
       w.__removeCalls.push(args);
       const id = String(args?.id ?? "");
       w.__removedIds = Array.from(new Set([...(w.__removedIds ?? []), id]));
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [id],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -1654,7 +1664,12 @@ test.describe("sidebar: project lifecycle", () => {
       const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
       w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
       w.__removeWorktreeCalls.push(args);
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
     await page.addInitScript(() => {
       localStorage.setItem(
@@ -1746,10 +1761,15 @@ test.describe("sidebar: project lifecycle", () => {
     ]);
     await tauri.handle("list_sessions", () => []);
     await tauri.respond("remove_worktree", {
-      token: "undo-token",
-      repoPath: "/tmp/demo",
-      worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
-      gitCommonDir: "/tmp/demo/.git",
+      result: {
+        token: "undo-token",
+        repoPath: "/tmp/demo",
+        worktreePath: "/tmp/demo/.acorn/worktrees/feature-empty",
+        gitCommonDir: "/tmp/demo/.git",
+      },
+      removedSessionIds: [],
+      issues: [],
+      retryToken: null,
     });
     await tauri.handle("restore_removed_worktree", (args) => {
       const w = window as unknown as { __restoreWorktreeCalls?: unknown[] };
@@ -1859,7 +1879,12 @@ test.describe("sidebar: project lifecycle", () => {
       const w = window as unknown as { __removeWorktreeCalls?: unknown[] };
       w.__removeWorktreeCalls = w.__removeWorktreeCalls ?? [];
       w.__removeWorktreeCalls.push(args);
-      return null;
+      return {
+        result: null,
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
     await page.addInitScript(() => {
       localStorage.setItem(
@@ -4025,7 +4050,12 @@ test.describe("sidebar: project lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__projectRemoved = true;
-      return null;
+      return {
+        result: [],
+        removedSessionIds: [],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");
@@ -4096,7 +4126,12 @@ test.describe("sidebar: project lifecycle", () => {
       w.__removeCalls = w.__removeCalls ?? [];
       w.__removeCalls.push(args);
       w.__projectRemoved = true;
-      return null;
+      return {
+        result: [],
+        removedSessionIds: ["sess-1"],
+        issues: [],
+        retryToken: null,
+      };
     });
 
     await page.goto("/");


### PR DESCRIPTION
## Summary

Removal commands now distinguish a completed user action from cleanup steps that still need attention, building on the recoverable cleanup behavior in #828.

1. **Explicit partial outcomes** — return the removed value, removed session IDs, itemized issues, and an optional retry capability from session, project, and worktree removal commands.
2. **Exact backend retries** — retain only failed worktree, scrollback, settings, or persistence steps behind an opaque process-local token; successful steps are not repeated.
3. **Visible recovery UI** — show the exact target and backend error at every removal call site, retry on click, and preserve undo when a retry stages a worktree.
4. **Safety and sibling coverage** — re-check live-session worktree guards during retry and cover both session and worktree scrollback cleanup paths.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Cleanup failures | Logged or silently treated as success | Itemized in the UI after the removal completes |
| Retry scope | User repeats the broad action or cannot retry | Backend retries only the failed steps |
| Renderer authority | Cleanup details would need to be resent to retry | Renderer sends one opaque capability token |
| Worktree safety | Initial removal guard only | Initial removal and delayed retry both reject live-session paths |

## Design notes

- Failures before irreversible mutation, including runtime termination and initial worktree guards, remain command errors.
- Failures after sessions or projects have been removed are captured in RemovalOutcome so the frontend can refresh to the authoritative state without presenting false success.
- Pending retry steps live in AppState for the current process. Dismissing the issue toast forgets the capability; retrying keeps the same capability only while failures remain.
- Persistence retries re-snapshot the current stores instead of replaying stale serialized data.
- The two commits intentionally separate the shared contract wiring from behavior changes.

## Follow-up (not in this PR)

- Persist retry journals across app restarts only if product behavior should support cleanup recovery beyond the current process lifetime.

## Test plan

- [x] pnpm run typecheck — passed.
- [x] pnpm test — 113 files and 1,354 tests passed.
- [x] cargo check -p acorn — passed with five unchanged dead-code warnings.
- [x] cargo test -p acorn --lib -- --test-threads=1 --skip top_level_wrappers_create_one_provider_independent_invocation_owner — 751 passed, 1 ignored, 1 known hanging test excluded.
- [x] pnpm exec playwright test tests/e2e/session-lifecycle.spec.ts tests/e2e/sidebar.spec.ts tests/e2e/project-settings.spec.ts tests/e2e/kanban.spec.ts tests/e2e/canvas.spec.ts tests/e2e/panes.spec.ts — 127 passed.

## Notes

- This is a stacked draft PR based on fix/removal-cleanup-retry / #828 so review stays limited to the partial-outcome work unit.
- The default parallel Rust suite exposed three existing timing-sensitive agent-wrapper or PTY tests. Each passed in isolation, and the full serial suite passed; the failures were not caused by this PR.