### PR TITLE
feat(ipc): authenticated self-close + post-ACK runtime teardown

### DIFF
--- a/docs/CONTROL_SESSIONS.md
+++ b/docs/CONTROL_SESSIONS.md
@@ -213,6 +213,7 @@ acorn-ipc new-session   <name> [--workspace current|PATH] [--workspace-id ID] [-
 acorn-ipc send-keys     -t <uuid> --data "ls" --enter [--allow-foreign]
 acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]
 acorn-ipc select-session -t <uuid> [--allow-foreign]
+acorn-ipc close-self
 acorn-ipc kill-session  -t <uuid> [--allow-foreign]
 ```
 
@@ -270,6 +271,13 @@ control session itself. Passing `--allow-foreign` is the explicit escape
 hatch for a direct user request to touch a user-owned session or a session
 owned by another control session.
 
+`close-self` is the explicit self-closing path for a control session. The
+server first acknowledges the request, waits for the CLI to read the response
+and close its socket, then terminates the source session's complete runtime and
+removes its session record. The normal control-session removal cascade applies,
+so every session owned by that controller is closed too; unrelated and
+user-owned sessions are left running.
+
 ### Examples
 
 Send a command to every regular sibling and wait for output:
@@ -291,6 +299,12 @@ new_id=$(acorn-ipc new-session "patch-bot" --isolated)
 acorn-ipc select-session -t "$new_id"
 ```
 
+Close the current controller only after its work and final report are complete:
+
+```sh
+acorn-ipc close-self
+```
+
 ## Security model
 
 - Unix socket files are created with mode `0600`. Windows named pipes use an
@@ -306,8 +320,9 @@ acorn-ipc select-session -t "$new_id"
   The backend sends the source `repo_path` to the renderer and treats the
   response as project-scoped workspace metadata, not as permission to touch
   sessions in other projects.
-- `kill-session` refuses to kill the source control session itself, so a
-  badly-written agent can't accidentally remove the only seat it has.
+- `kill-session` refuses to kill the source control session itself. Self-close
+  requires the separate, explicit `close-self` request and can only target the
+  authenticated source session.
 
 There is currently no inter-process whitelist beyond the env-var handshake.
 If an Acorn terminal leaks its `ACORN_RESUME_TOKEN` or a control session leaks

--- a/src-tauri/crates/acorn-daemon/src/pty.rs
+++ b/src-tauri/crates/acorn-daemon/src/pty.rs
@@ -511,6 +511,7 @@ fn wait_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     #[cfg(any(unix, windows))]
     fn long_running_test_spec(id: Uuid) -> SpawnSpec {
@@ -551,6 +552,99 @@ mod tests {
         assert_eq!(repeated.pid, first.pid);
         assert_eq!(registry.count_alive(), 1);
         manager.kill(&id).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn repeated_targeted_kills_release_daemon_state_and_preserve_sibling() {
+        let manager = PtyManager::new(Arc::new(|_, _| {}));
+        let registry = SessionRegistry::new();
+        let scratch = std::env::temp_dir().join(format!(
+            "acorn-daemon-pty-kill-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock after unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&scratch).expect("create daemon PTY scratch directory");
+        let sibling_id = Uuid::new_v4();
+        let sibling = manager
+            .spawn(long_running_test_spec(sibling_id), registry.clone())
+            .expect("spawn unrelated daemon PTY");
+        let sibling_pid = sibling.pid.expect("unrelated daemon PTY pid");
+        let mut killed_pids = Vec::new();
+
+        for cycle in 0..12 {
+            let id = Uuid::new_v4();
+            let descendant_pid_path = scratch.join(format!("descendant-{cycle}.pid"));
+            let mut spec = long_running_test_spec(id);
+            spec.command = "/bin/sh".to_string();
+            spec.args = vec![
+                "-c".to_string(),
+                format!(
+                    "sleep 30 & echo $! > '{}' && wait",
+                    descendant_pid_path.display()
+                ),
+            ];
+            let spawned = manager
+                .spawn(spec, registry.clone())
+                .expect("spawn daemon PTY tree");
+            let root_pid = spawned.pid.expect("daemon PTY root pid");
+            wait_until(Duration::from_secs(5), || descendant_pid_path.exists());
+            let descendant_pid = std::fs::read_to_string(&descendant_pid_path)
+                .expect("read daemon descendant pid")
+                .trim()
+                .parse::<u32>()
+                .expect("parse daemon descendant pid");
+            assert!(pid_is_alive(root_pid));
+            assert!(pid_is_alive(descendant_pid));
+
+            manager.kill(&id).expect("kill daemon PTY tree");
+            wait_until(Duration::from_secs(5), || {
+                !manager.handles.contains_key(&id)
+                    && registry.get(&id).is_none()
+                    && !pid_is_alive(root_pid)
+                    && !pid_is_alive(descendant_pid)
+            });
+            assert!(manager.handles.contains_key(&sibling_id));
+            assert!(registry.get(&sibling_id).is_some());
+            assert!(pid_is_alive(sibling_pid));
+            killed_pids.extend([root_pid, descendant_pid]);
+        }
+
+        assert_eq!(manager.handles.len(), 1);
+        assert_eq!(registry.count_total(), 1);
+        assert!(killed_pids.iter().all(|pid| !pid_is_alive(*pid)));
+        assert!(pid_is_alive(sibling_pid));
+
+        manager
+            .kill(&sibling_id)
+            .expect("kill unrelated daemon test PTY");
+        wait_until(Duration::from_secs(5), || {
+            manager.handles.is_empty() && registry.count_total() == 0 && !pid_is_alive(sibling_pid)
+        });
+        std::fs::remove_dir_all(&scratch).expect("remove daemon PTY scratch directory");
+    }
+
+    #[cfg(unix)]
+    fn wait_until(timeout: Duration, condition: impl Fn() -> bool) {
+        let deadline = Instant::now() + timeout;
+        while !condition() {
+            assert!(
+                Instant::now() < deadline,
+                "condition did not become true before {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(unix)]
+    fn pid_is_alive(pid: u32) -> bool {
+        let Ok(pid) = i32::try_from(pid) else {
+            return false;
+        };
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
     }
 
     #[cfg(windows)]

--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -143,6 +143,9 @@ enum Command {
         #[arg(long = "allow-foreign")]
         allow_foreign: bool,
     },
+    /// Close this control session and every session it owns. The server
+    /// acknowledges the request before terminating the caller's PTY tree.
+    CloseSelf,
     /// Kill a session (close the PTY, drop the session from state).
     KillSession {
         /// UUID of the target session.
@@ -298,6 +301,7 @@ fn build_request_with_workspace_env(
             target_session_id: target.clone(),
             allow_foreign: *allow_foreign,
         },
+        Command::CloseSelf => Request::CloseSelf,
         Command::KillSession {
             target,
             allow_foreign,
@@ -779,6 +783,12 @@ mod tests {
     fn promote_self_command_builds_request() {
         let req = build_request(&Command::PromoteSelf).expect("build");
         assert!(matches!(req, Request::PromoteSelf));
+    }
+
+    #[test]
+    fn close_self_command_builds_request() {
+        let req = build_request(&Command::CloseSelf).expect("build");
+        assert!(matches!(req, Request::CloseSelf));
     }
 
     #[test]

--- a/src-tauri/crates/acorn-ipc/src/primer.rs
+++ b/src-tauri/crates/acorn-ipc/src/primer.rs
@@ -92,6 +92,9 @@ pub fn primer_for(
          - Do not repurpose, send input to, read from, focus, or kill user-owned \
          sessions or sessions owned by another control session unless the user \
          made that direct request; then pass `--allow-foreign`.\n\
+         - Use `close-self` only as the final action after the requested work, \
+         verification, delivery, and completion report are all finished. It \
+         closes this controller and every session it owns.\n\
          \n\
          Available commands (project-scoped — other projects are not reachable):\n\
          \n\
@@ -103,6 +106,7 @@ pub fn primer_for(
            acorn-ipc send-keys     -t <uuid> --data '…' --enter [--allow-foreign]\n\
            acorn-ipc read-buffer   -t <uuid> [--max-bytes N] [--allow-foreign]\n\
            acorn-ipc select-session -t <uuid> [--allow-foreign]\n\
+           acorn-ipc close-self                         # final action; closes this controller\n\
            acorn-ipc kill-session  -t <uuid> [--allow-foreign]\n\
          \n\
          The newer `acornd` CLI talks to the same project graph via the\n\

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -86,6 +86,11 @@ pub enum Request {
         #[serde(default)]
         allow_foreign: bool,
     },
+    /// Tear down the authenticated source control session itself after the
+    /// response has been delivered. Kept separate from `KillSession` so an
+    /// agent must make an explicit self-closing request instead of accidentally
+    /// targeting its own UUID through the general destructive command.
+    CloseSelf,
     /// Tear down a target session (kill its PTY, remove it from state).
     /// Destructive — the server logs every invocation to the audit log.
     KillSession {
@@ -252,6 +257,17 @@ mod tests {
         };
         let encoded = serde_json::to_string(&env).expect("encode");
         assert!(encoded.contains("\"kind\":\"list-workspaces\""));
+    }
+
+    #[test]
+    fn close_self_request_uses_kebab_case_kind() {
+        let env = Envelope {
+            protocol_version: PROTOCOL_VERSION,
+            source_session_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            request: Request::CloseSelf,
+        };
+        let encoded = serde_json::to_string(&env).expect("encode");
+        assert!(encoded.contains("\"kind\":\"close-self\""));
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6892,7 +6892,7 @@ pub(crate) fn terminate_session_pty(state: &AppState, id: &Uuid) {
     }
 }
 
-fn terminate_session_runtime(state: &AppState, id: &Uuid) -> AppResult<()> {
+pub(crate) fn terminate_session_runtime(state: &AppState, id: &Uuid) -> AppResult<()> {
     let run_was_active = state.chat_runs.cancel_active(id);
     terminate_session_pty(state, id);
     if !run_was_active {

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -23,7 +23,7 @@
 //! handler code linear and reuses the existing blocking PTY pool without
 //! a runtime hop.
 
-use std::io::{BufRead, BufReader, ErrorKind, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
@@ -46,7 +46,7 @@ use uuid::Uuid;
 
 use crate::commands::{
     create_unique_project_worktree, sanitize_worktree_name, session_removal_cascade,
-    terminate_session_pty,
+    terminate_session_runtime,
 };
 use crate::ipc::workspaces::{ListWorkspacesRequestPayload, LIST_WORKSPACES_REQUEST_EVENT};
 use crate::persistence;
@@ -59,7 +59,7 @@ use acorn_session::{Session, SessionKind, SessionOwner, SessionStore};
 /// wired up in `src/components/Sidebar.tsx`'s sibling for `acorn:*` events.
 const SELECT_SESSION_EVENT: &str = "acorn:ipc-select-session";
 /// Fired whenever an IPC handler mutates the persisted session list
-/// (`new-session`, `kill-session`). The frontend listens and re-fetches
+/// (`new-session`, `close-self`, `kill-session`). The frontend listens and re-fetches
 /// via `list_sessions` so a control-session-driven mutation surfaces in
 /// the sidebar without the user clicking anything. Payload is the
 /// affected session's id as a string, mostly for debugging — the
@@ -194,6 +194,17 @@ fn run_listener<R: Runtime>(
 /// buffer without limit, so a misbehaving client writing an endless unbroken
 /// line could exhaust memory. Generous compared to any real `Envelope`.
 const MAX_REQUEST_BYTES: u64 = 1024 * 1024;
+const CLOSE_SELF_CLIENT_DISCONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PostResponseAction {
+    CloseSelf { source_id: Uuid },
+}
+
+struct DispatchOutcome {
+    response: Response,
+    post_response: Option<PostResponseAction>,
+}
 
 fn handle_connection<R: Runtime>(
     stream: Stream,
@@ -206,21 +217,95 @@ fn handle_connection<R: Runtime>(
     if n == 0 {
         return Ok(());
     }
-    let response = match serde_json::from_str::<Envelope>(line.trim_end()) {
-        Ok(envelope) => dispatch(envelope, app, state),
-        Err(err) => Response::Error {
-            code: ErrorCode::Invalid,
-            message: format!("malformed request: {err}"),
+    let outcome = match serde_json::from_str::<Envelope>(line.trim_end()) {
+        Ok(envelope) => dispatch_connection(envelope, app, state),
+        Err(err) => DispatchOutcome {
+            response: Response::Error {
+                code: ErrorCode::Invalid,
+                message: format!("malformed request: {err}"),
+            },
+            post_response: None,
         },
     };
-    let mut out = serde_json::to_vec(&response).unwrap_or_else(|_| {
+    let mut out = serde_json::to_vec(&outcome.response).unwrap_or_else(|_| {
         b"{\"kind\":\"error\",\"code\":\"internal\",\"message\":\"failed to serialize response\"}"
             .to_vec()
     });
     out.push(b'\n');
-    reader.get_mut().write_all(&out)?;
-    reader.get_mut().flush()?;
-    Ok(())
+    let write_result = reader
+        .get_mut()
+        .write_all(&out)
+        .and_then(|_| reader.get_mut().flush());
+    if write_result.is_ok() {
+        if outcome.post_response.is_some() {
+            wait_for_close_self_client_disconnect(reader.get_mut());
+        }
+        if let Some(action) = outcome.post_response {
+            execute_post_response(action, app, state);
+        }
+    }
+    write_result
+}
+
+fn dispatch_connection<R: Runtime>(
+    envelope: Envelope,
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> DispatchOutcome {
+    let close_self_source = matches!(&envelope.request, Request::CloseSelf)
+        .then(|| Uuid::parse_str(&envelope.source_session_id).ok())
+        .flatten();
+    let response = dispatch(envelope, app, state);
+    let post_response = if matches!(response, Response::Ack) {
+        close_self_source.map(|source_id| PostResponseAction::CloseSelf { source_id })
+    } else {
+        None
+    };
+    DispatchOutcome {
+        response,
+        post_response,
+    }
+}
+
+fn wait_for_close_self_client_disconnect(stream: &mut Stream) {
+    if let Err(err) = stream.set_recv_timeout(Some(CLOSE_SELF_CLIENT_DISCONNECT_TIMEOUT)) {
+        tracing::warn!(error = %err, "ipc: close-self could not set client disconnect timeout");
+        return;
+    }
+    let mut unexpected = [0_u8; 1];
+    match stream.read(&mut unexpected) {
+        Ok(0) => {}
+        Ok(_) => tracing::warn!("ipc: close-self client sent data after the response"),
+        Err(err) if matches!(err.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => {
+            tracing::warn!("ipc: close-self client did not disconnect after the response");
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "ipc: close-self client disconnect wait failed");
+        }
+    }
+}
+
+fn execute_post_response<R: Runtime>(
+    action: PostResponseAction,
+    app: &AppHandle<R>,
+    state: &AppState,
+) {
+    let result = match action {
+        PostResponseAction::CloseSelf { source_id } => {
+            let source = match state.sessions.get(&source_id) {
+                Ok(source) => source,
+                Err(err) => {
+                    tracing::warn!(%source_id, error = %err, "ipc: close-self source disappeared");
+                    return;
+                }
+            };
+            let sessions_to_remove = session_removal_cascade(state, &source);
+            remove_ipc_sessions(&sessions_to_remove, app, state)
+        }
+    };
+    if let Err(err) = result {
+        tracing::error!(error = %err, "ipc: post-response action failed");
+    }
 }
 
 /// Top-level request dispatch. Except for `promote-self`, resolves the source
@@ -285,6 +370,7 @@ fn dispatch<R: Runtime>(envelope: Envelope, app: &AppHandle<R>, state: &AppState
             target_session_id,
             allow_foreign,
         } => handle_select_session(&source, &target_session_id, allow_foreign, app, state),
+        Request::CloseSelf => Response::Ack,
         Request::KillSession {
             target_session_id,
             allow_foreign,
@@ -302,6 +388,7 @@ fn request_label(req: &Request) -> &'static str {
         Request::ReadBuffer { .. } => "read-buffer",
         Request::NewSession { .. } => "new-session",
         Request::SelectSession { .. } => "select-session",
+        Request::CloseSelf => "close-self",
         Request::KillSession { .. } => "kill-session",
     }
 }
@@ -791,21 +878,34 @@ fn handle_kill_session<R: Runtime>(
         };
     }
     let sessions_to_remove = session_removal_cascade(state, &target);
-    for session in &sessions_to_remove {
-        terminate_session_pty(state, &session.id);
+    if let Err(message) = remove_ipc_sessions(&sessions_to_remove, app, state) {
+        return Response::Error {
+            code: ErrorCode::Internal,
+            message,
+        };
     }
-    for session in &sessions_to_remove {
-        if let Err(err) = state.sessions.remove(&session.id) {
-            return Response::Error {
-                code: ErrorCode::Internal,
-                message: format!("remove failed: {err}"),
-            };
-        }
+    Response::Ack
+}
+
+fn remove_ipc_sessions<R: Runtime>(
+    sessions_to_remove: &[Session],
+    app: &AppHandle<R>,
+    state: &AppState,
+) -> Result<(), String> {
+    for session in sessions_to_remove {
+        terminate_session_runtime(state, &session.id)
+            .map_err(|err| format!("terminate {} failed: {err}", session.id))?;
+    }
+    for session in sessions_to_remove {
+        state
+            .sessions
+            .remove(&session.id)
+            .map_err(|err| format!("remove {} failed: {err}", session.id))?;
     }
     if let Err(err) = persistence::save_sessions(&state.sessions) {
-        tracing::warn!(error = %err, "ipc: persist after kill-session failed");
+        tracing::warn!(error = %err, "ipc: persist after session removal failed");
     }
-    for session in &sessions_to_remove {
+    for session in sessions_to_remove {
         if let Err(err) = app.emit(
             SESSIONS_CHANGED_EVENT,
             SessionsChangedPayload {
@@ -823,7 +923,7 @@ fn handle_kill_session<R: Runtime>(
             );
         }
     }
-    Response::Ack
+    Ok(())
 }
 
 #[cfg(test)]
@@ -831,6 +931,12 @@ mod tests {
     use super::*;
     use acorn_session::SessionStatus;
     use std::path::PathBuf;
+    use tauri::Manager;
+
+    #[cfg(unix)]
+    const CLOSE_SELF_TEST_ROLE: &str = "ACORN_CLOSE_SELF_TEST_ROLE";
+    #[cfg(unix)]
+    const CLOSE_SELF_TEST_DIRECTORY: &str = "ACORN_CLOSE_SELF_TEST_DIRECTORY";
 
     fn make_session(repo: &str, name: &str, kind: SessionKind) -> Session {
         let mut s = Session::new(
@@ -876,6 +982,38 @@ mod tests {
         let ctl = store.insert(make_session("/tmp/repo", "ctl", SessionKind::Control));
         let result = resolve_source(&ctl.id.to_string(), &store);
         assert!(result.is_ok(), "control session should be allowed");
+    }
+
+    #[test]
+    fn close_self_requires_an_authorized_control_source() {
+        let app = tauri::test::mock_builder()
+            .manage(AppState::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let state = app.state::<AppState>().inner().clone();
+        let regular =
+            state
+                .sessions
+                .insert(make_session("/tmp/A", "regular", SessionKind::Regular));
+        let outcome = dispatch_connection(
+            Envelope {
+                protocol_version: PROTOCOL_VERSION,
+                source_session_id: regular.id.to_string(),
+                request: Request::CloseSelf,
+            },
+            app.handle(),
+            &state,
+        );
+
+        assert!(matches!(
+            outcome.response,
+            Response::Error {
+                code: ErrorCode::Unauthorized,
+                ..
+            }
+        ));
+        assert_eq!(outcome.post_response, None);
+        assert!(state.sessions.get(&regular.id).is_ok());
     }
 
     #[test]
@@ -1073,6 +1211,228 @@ mod tests {
             std::collections::HashSet::from([controller.id, worker.id, nested.id])
         );
         assert!(!ids.contains(&user.id));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_self_runtime_helper() {
+        if std::env::var(CLOSE_SELF_TEST_ROLE).as_deref() != Ok("helper") {
+            return;
+        }
+        let scratch = PathBuf::from(
+            std::env::var_os(CLOSE_SELF_TEST_DIRECTORY).expect("helper scratch directory"),
+        );
+        let app = tauri::test::mock_builder()
+            .manage(AppState::new())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("build mock app");
+        let state = app.state::<AppState>().inner().clone();
+        state.daemon_bridge.set_enabled(false);
+
+        let sibling =
+            state
+                .sessions
+                .insert(make_session("/tmp/A", "unrelated", SessionKind::Regular));
+        state
+            .pty
+            .spawn(
+                app.handle().clone(),
+                std::sync::Arc::new(|_, _, _| {}),
+                sibling.id,
+                scratch.clone(),
+                "/bin/cat".to_string(),
+                Vec::new(),
+                |_| {},
+                80,
+                24,
+            )
+            .expect("spawn unrelated PTY");
+        let sibling_pid = state.pty.child_pid(&sibling.id).expect("unrelated pid");
+        let cycle_count = std::env::var("ACORN_CLOSE_SELF_TEST_CYCLES")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(12);
+
+        let mut closed_ids = Vec::new();
+        let mut closed_pids = Vec::new();
+        for cycle in 0..cycle_count {
+            let source = state.sessions.insert(make_session(
+                "/tmp/A",
+                &format!("controller-{cycle}"),
+                SessionKind::Control,
+            ));
+            let worker = state.sessions.insert({
+                let mut session =
+                    make_session("/tmp/A", &format!("worker-{cycle}"), SessionKind::Regular);
+                session.owner = SessionOwner::control(source.id);
+                session
+            });
+            let descendant_pid_path = scratch.join(format!("descendant-{cycle}.pid"));
+            state
+                .pty
+                .spawn(
+                    app.handle().clone(),
+                    std::sync::Arc::new(|_, _, _| {}),
+                    source.id,
+                    scratch.clone(),
+                    "/bin/sh".to_string(),
+                    vec![
+                        "-c".to_string(),
+                        format!(
+                            "sleep 30 & echo $! > '{}' && wait",
+                            descendant_pid_path.display()
+                        ),
+                    ],
+                    |_| {},
+                    80,
+                    24,
+                )
+                .expect("spawn source PTY tree");
+            state
+                .pty
+                .spawn(
+                    app.handle().clone(),
+                    std::sync::Arc::new(|_, _, _| {}),
+                    worker.id,
+                    scratch.clone(),
+                    "/bin/cat".to_string(),
+                    Vec::new(),
+                    |_| {},
+                    80,
+                    24,
+                )
+                .expect("spawn owned worker PTY");
+
+            wait_until(Duration::from_secs(5), || descendant_pid_path.exists());
+            let descendant_pid = std::fs::read_to_string(&descendant_pid_path)
+                .expect("read descendant pid")
+                .trim()
+                .parse::<u32>()
+                .expect("parse descendant pid");
+            let source_pid = state.pty.child_pid(&source.id).expect("source pid");
+            let worker_pid = state.pty.child_pid(&worker.id).expect("worker pid");
+            assert!(pid_is_alive(source_pid));
+            assert!(pid_is_alive(descendant_pid));
+            assert!(pid_is_alive(worker_pid));
+
+            let endpoint = scratch.join(format!("close-self-{cycle}.sock"));
+            let listener = acorn_local_ipc::bind(&endpoint).expect("bind close-self endpoint");
+            let server = std::thread::spawn({
+                let app_handle = app.handle().clone();
+                let state = state.clone();
+                move || {
+                    let stream = listener.accept().expect("accept close-self client");
+                    handle_connection(stream, &app_handle, &state)
+                        .expect("handle close-self request");
+                }
+            });
+            let mut client =
+                acorn_local_ipc::connect(&endpoint).expect("connect close-self client");
+            let envelope = Envelope {
+                protocol_version: PROTOCOL_VERSION,
+                source_session_id: source.id.to_string(),
+                request: Request::CloseSelf,
+            };
+            let mut request = serde_json::to_vec(&envelope).expect("encode close-self request");
+            request.push(b'\n');
+            client
+                .write_all(&request)
+                .expect("write close-self request");
+            client.flush().expect("flush close-self request");
+            let mut client = BufReader::new(client);
+            let mut response_line = String::new();
+            client
+                .read_line(&mut response_line)
+                .expect("read close-self response");
+            let response: Response =
+                serde_json::from_str(response_line.trim()).expect("decode close-self response");
+            assert_eq!(response, Response::Ack);
+
+            assert!(
+                state.pty.contains(&source.id),
+                "source PTY must stay alive until the client drops the acknowledged socket"
+            );
+            assert!(state.sessions.get(&source.id).is_ok());
+            drop(client);
+            server.join().expect("close-self server thread");
+            acorn_local_ipc::cleanup(&endpoint);
+
+            wait_until(Duration::from_secs(5), || {
+                !state.pty.contains(&source.id)
+                    && !state.pty.contains(&worker.id)
+                    && !pid_is_alive(source_pid)
+                    && !pid_is_alive(descendant_pid)
+                    && !pid_is_alive(worker_pid)
+            });
+            assert!(state.sessions.get(&source.id).is_err());
+            assert!(state.sessions.get(&worker.id).is_err());
+            assert!(state.sessions.get(&sibling.id).is_ok());
+            assert!(state.pty.contains(&sibling.id));
+            assert!(pid_is_alive(sibling_pid));
+
+            closed_ids.extend([source.id, worker.id]);
+            closed_pids.extend([source_pid, descendant_pid, worker_pid]);
+        }
+
+        assert_eq!(state.sessions.list().len(), 1);
+        assert!(closed_ids.iter().all(|id| !state.pty.contains(id)));
+        assert!(closed_pids.iter().all(|pid| !pid_is_alive(*pid)));
+        assert!(state.pty.contains(&sibling.id));
+        assert!(pid_is_alive(sibling_pid));
+
+        state
+            .pty
+            .kill(&sibling.id)
+            .expect("kill unrelated test PTY");
+        wait_until(Duration::from_secs(5), || {
+            !state.pty.contains(&sibling.id) && !pid_is_alive(sibling_pid)
+        });
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn close_self_repeatedly_releases_process_trees_and_preserves_unrelated_sessions() {
+        let scratch = tempfile::tempdir().expect("create close-self scratch directory");
+        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "ipc::server::tests::close_self_runtime_helper",
+                "--nocapture",
+            ])
+            .env(CLOSE_SELF_TEST_ROLE, "helper")
+            .env(CLOSE_SELF_TEST_DIRECTORY, scratch.path())
+            .env(
+                acorn_paths::ENV_DATA_DIR_OVERRIDE,
+                scratch.path().join("data"),
+            )
+            .status()
+            .expect("run close-self helper");
+
+        assert!(
+            status.success(),
+            "close-self runtime helper failed: {status}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn wait_until(timeout: Duration, condition: impl Fn() -> bool) {
+        let deadline = std::time::Instant::now() + timeout;
+        while !condition() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "condition did not become true before {timeout:?}"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(unix)]
+    fn pid_is_alive(pid: u32) -> bool {
+        let Ok(pid) = i32::try_from(pid) else {
+            return false;
+        };
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Control sessions can now close themselves through an explicit authenticated IPC command after their work and final report are complete.

1. **Explicit self-close protocol** — add `acorn-ipc close-self` as a request distinct from general `kill-session`, restricted to the authenticated control-session source.
2. **Post-ACK teardown** — write and flush the acknowledgement, wait for the client socket to disconnect, and only then terminate the caller's full runtime so the final IPC response is not cut off.
3. **Complete cascade cleanup** — cancel active chat/graph work, terminate in-process or daemon-backed PTYs and descendants, remove owned session records, persist the store, and notify the frontend while preserving unrelated sessions.
4. **Process and leak coverage** — exercise repeated source/worker/descendant teardown, daemon handle/registry drainage, unrelated sibling survival, and memory-leak instrumentation.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Completed control session | Could not explicitly close itself | Can call authenticated `acorn-ipc close-self` |
| Response delivery | Self-targeting through `kill-session` was rejected | ACK is delivered before source runtime teardown |
| Cleanup scope | IPC removal only terminated the PTY path | Full chat/graph runtime, PTY tree, daemon attachment, and session records are cleaned |
| Isolation | General ownership rules only | Repeated tests prove unrelated sibling sessions and processes stay alive |

## Design notes

- `close-self` is intentionally separate from `kill-session`: the general destructive command still refuses to target its source, while the new request can only resolve to its authenticated source UUID.
- Connection dispatch returns a post-response action. Cleanup runs on the same connection worker only after response write/flush succeeds and the official CLI drops the acknowledged socket; no detached cleanup timer or helper process is created.
- IPC removal now shares the same `terminate_session_runtime` path as UI removal, so active graph/chat work is cancelled before session records disappear and daemon-backed PTYs do not survive the row removal.
- The control-session ownership cascade remains the source of truth. Owned descendants are removed; user-owned and unrelated sessions are untouched.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --workspace -- --test-threads=1` — 1,047 tests pass; 1 pre-existing ignored test
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn agent_wrappers::tests::codex_wrapper_ -- --test-threads=1 --nocapture` — 8 pass
- [x] `cargo check --manifest-path src-tauri/Cargo.toml --workspace --all-targets --locked` — passes
- [x] `pnpm run build:sidecar` — release `acorn-ipc` and `acornd` sidecars build and stage successfully
- [x] `rustfmt --edition 2021 --check <changed Rust files>` and `git diff --check` — pass
- [x] macOS `leaks --atExit` around the 12-cycle daemon PTY teardown test — 0 leaks / 0 bytes
- [x] 12-cycle real local-socket close-self test — ACK-before-disconnect, source/owned/descendant teardown, and unrelated sibling survival all pass

## Notes

- The default parallel full-workspace run exposes an existing timing race in three `agent_wrappers` recorder tests (empty recorder output). The same failure remains when the new repeated close-self test is skipped, and all eight affected Codex-wrapper tests plus the complete workspace pass with one test thread. This PR does not touch `agent_wrappers`.
