### PR TITLE
fix(projects): isolate unit-test persistence from app state

### DIFF
--- a/docs/COMMON.md
+++ b/docs/COMMON.md
@@ -33,6 +33,11 @@ Two recurring traps in E2E:
 1. **Handler functions are serialized to source.** They cannot close over test-side variables, helpers, or imports. Inline the data inside each handler.
 2. **OS keyboard shortcuts (Cmd+P, Cmd+,) are intercepted by Chromium.** Use `pressHotkey()` from `tests/e2e/support.ts`, not `page.keyboard.press()`.
 
+Rust unit tests resolve persistence through a process-local temporary data
+directory and ignore inherited `ACORN_DATA_DIR`. Keep project source-grouping
+helpers free of `persist()` calls; the Tauri command boundary owns the durable
+write.
+
 ## Code conventions
 
 - **Custom window events use the `acorn:` prefix** (`acorn:new-session`, `acorn:add-project`, `acorn:terminal-clear`). When adding a global event, follow this convention so listener wiring stays greppable.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -6891,7 +6891,9 @@ pub fn merge_project_source(
     repo_path: String,
     source_path: String,
 ) -> AppResult<Project> {
-    merge_project_source_inner(&state, repo_path, source_path)
+    let project = merge_project_source_inner(&state, repo_path, source_path)?;
+    persist(&state);
+    Ok(project)
 }
 
 fn merge_project_source_inner(
@@ -6937,7 +6939,6 @@ fn merge_project_source_inner(
         .projects
         .set_source_paths(&project.repo_path, source_paths)
         .ok_or_else(|| AppError::InvalidPath(format!("project is not registered: {repo_path}")))?;
-    persist(state);
     Ok(updated)
 }
 
@@ -6952,7 +6953,9 @@ pub fn split_project_source(
     repo_path: String,
     source_path: String,
 ) -> AppResult<Project> {
-    split_project_source_inner(&state, repo_path, source_path)
+    let project = split_project_source_inner(&state, repo_path, source_path)?;
+    persist(&state);
+    Ok(project)
 }
 
 fn split_project_source_inner(
@@ -6983,7 +6986,6 @@ fn split_project_source_inner(
     let split = state
         .projects
         .ensure(source.clone(), project_basename(&source));
-    persist(state);
     Ok(split)
 }
 
@@ -7041,7 +7043,9 @@ pub fn reorder_project_sources(
     repo_path: String,
     order: Vec<String>,
 ) -> AppResult<Project> {
-    reorder_project_sources_inner(state.inner(), repo_path, order)
+    let project = reorder_project_sources_inner(state.inner(), repo_path, order)?;
+    persist(&state);
+    Ok(project)
 }
 
 fn reorder_project_sources_inner(
@@ -7066,7 +7070,6 @@ fn reorder_project_sources_inner(
         .projects
         .set_source_paths(&project.repo_path, source_paths)
         .ok_or_else(|| AppError::InvalidPath(format!("project is not registered: {repo_path}")))?;
-    persist(state);
     Ok(updated)
 }
 

--- a/src-tauri/src/persistence.rs
+++ b/src-tauri/src/persistence.rs
@@ -1,6 +1,10 @@
+#[cfg(test)]
+use std::cell::RefCell;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::OnceLock;
 use std::sync::{Mutex, MutexGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -26,6 +30,30 @@ const MAX_GRAPH_RUN_FILE_BYTES: u64 = 64 * 1024 * 1024;
 pub const CHAT_SESSION_SCHEMA_VERSION: u32 = 1;
 static SESSION_SAVE_LOCK: Mutex<()> = Mutex::new(());
 static GRAPH_RUN_SAVE_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+thread_local! {
+    static TEST_DATA_DIR_OVERRIDE: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+struct TestDataDirOverrideGuard(Option<PathBuf>);
+
+#[cfg(test)]
+impl Drop for TestDataDirOverrideGuard {
+    fn drop(&mut self) {
+        TEST_DATA_DIR_OVERRIDE.with(|slot| {
+            *slot.borrow_mut() = self.0.take();
+        });
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_data_dir<T>(dir: &Path, run: impl FnOnce() -> T) -> T {
+    let previous = TEST_DATA_DIR_OVERRIDE.with(|slot| slot.replace(Some(dir.to_path_buf())));
+    let _guard = TestDataDirOverrideGuard(previous);
+    run()
+}
 
 fn lock_session_save() -> MutexGuard<'static, ()> {
     SESSION_SAVE_LOCK
@@ -445,6 +473,7 @@ fn should_migrate_legacy_prod_files() -> AppResult<bool> {
     Ok(acorn_paths::effective_profile()? == acorn_paths::PROD_PROFILE)
 }
 
+#[cfg(not(test))]
 fn migrate_legacy_prod_files(profile_dir: &Path) -> AppResult<()> {
     if !should_migrate_legacy_prod_files()? {
         return Ok(());
@@ -472,10 +501,34 @@ fn migrate_legacy_prod_files(profile_dir: &Path) -> AppResult<()> {
 ///
 /// Runtime state lives under the stable `io.im-ian.acorn` app dir, split by
 /// `ACORN_PROFILE` or by the build default (`dev` for debug, `prod` for
-/// release). `ACORN_DATA_DIR` can still redirect the whole tree for tests.
+/// release). `ACORN_DATA_DIR` can redirect the whole tree at runtime. Unit
+/// tests always use a process-local temporary directory so a shell inherited
+/// from Acorn cannot route test writes back into the running app's profile.
 pub fn data_dir() -> AppResult<PathBuf> {
+    #[cfg(test)]
+    {
+        if let Some(dir) = TEST_DATA_DIR_OVERRIDE.with(|slot| slot.borrow().clone()) {
+            fs::create_dir_all(&dir)?;
+            return Ok(dir);
+        }
+
+        static TEST_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+        let dir = TEST_DATA_DIR.get_or_init(|| {
+            std::env::temp_dir().join(format!(
+                "acorn-unit-tests-{}-{}",
+                std::process::id(),
+                Uuid::new_v4()
+            ))
+        });
+        fs::create_dir_all(dir)?;
+        return Ok(dir.clone());
+    }
+
+    #[cfg(not(test))]
     let dir = acorn_paths::data_dir()?;
+    #[cfg(not(test))]
     migrate_legacy_prod_files(&dir)?;
+    #[cfg(not(test))]
     Ok(dir)
 }
 
@@ -1432,15 +1485,24 @@ mod tests {
     }
 
     #[test]
-    fn data_dir_is_resolvable() {
+    fn unit_test_data_dir_is_isolated_from_runtime_profiles() {
         let dir = data_dir().expect("data dir resolves");
         assert!(dir.exists(), "data dir should be created");
+        assert!(
+            dir.starts_with(std::env::temp_dir()),
+            "unit test data must stay under the system temp directory: {}",
+            dir.display()
+        );
+        if let Some(runtime_dir) = std::env::var_os(acorn_paths::ENV_DATA_DIR_OVERRIDE) {
+            assert_ne!(dir, PathBuf::from(runtime_dir));
+        }
     }
 
     #[test]
     fn load_sessions_returns_empty_when_missing() {
         let sessions = load_sessions().expect("load should not error on missing file");
-        // Cannot assert empty without test isolation — at least confirm it returns.
+        // The shared test directory can be populated by another concurrently
+        // running persistence test, so this only verifies a clean read result.
         let _ = sessions;
     }
 

--- a/src-tauri/src/project_settings.rs
+++ b/src-tauri/src/project_settings.rs
@@ -171,20 +171,10 @@ fn normalize_settings(mut settings: ProjectSettings) -> ProjectSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn with_data_dir(test: impl FnOnce(&Path)) {
-        let _guard = ENV_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        unsafe {
-            std::env::set_var(acorn_paths::ENV_DATA_DIR_OVERRIDE, dir.path());
-        }
-        test(dir.path());
-        unsafe {
-            std::env::remove_var(acorn_paths::ENV_DATA_DIR_OVERRIDE);
-        }
+        persistence::with_test_data_dir(dir.path(), || test(dir.path()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevent Rust unit tests from writing project fixtures into a live Acorn data profile.

1. **Persistence boundary** — keep project source merge, split, and reorder helpers in memory and persist only from their Tauri command entry points.
2. **Test data isolation** — route unit-test persistence to a process-local temporary directory, ignoring an inherited `ACORN_DATA_DIR`.
3. **Parallel-safe overrides** — replace project-settings tests' process-global environment mutation with a scoped thread-local data-directory override.
4. **Guardrail documentation** — record the test persistence and source-grouping helper contracts in `docs/COMMON.md`.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Rust tests launched from an Acorn-owned shell | An inherited `ACORN_DATA_DIR` could route fixture writes into the active app profile | Unit-test persistence always resolves to temporary test state |
| Project source grouping | Test fixtures could replace `projects.json`, causing source roots to reappear as standalone projects after restart | Unit tests cannot alter the runtime project registry |
| Runtime source commands | Durable writes happened inside helpers also called directly by tests | User-visible behavior is unchanged; the Tauri boundary performs the same durable write |

## Design notes

- The isolation is compiled only for unit tests. Debug and release app builds continue to honor `ACORN_DATA_DIR` and retain production-profile legacy migration.
- Tests that need independent persistence round trips use a scoped thread-local override, avoiding process-global environment races.
- Source-grouping helpers now express only the in-memory state transition; their Tauri commands retain persistence ownership.

## Follow-up (not in this PR)

- Profiles already affected still require manual regrouping or local cleanup. This PR intentionally avoids deleting projects by fixture-like names because legitimate projects may use those names.

## Test plan

- [x] `pnpm run dev:sidecar` — debug sidecars built successfully.
- [x] Targeted source merge, split, reorder, data-directory isolation, and project-settings tests — 9 passed.
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` in a clean environment — 806 passed, 1 ignored.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml -p acorn --lib` — production configuration compiled successfully (two pre-existing dead-code warnings).
- [x] `rustfmt --edition 2021 --check src-tauri/src/commands.rs src-tauri/src/persistence.rs src-tauri/src/project_settings.rs` — passed.
- [x] `git diff --check origin/main...HEAD` — passed.

## Notes

- No live Acorn profile data was modified as part of this change.
- Frontend behavior and assets are unchanged; repository CI remains the cross-platform validation gate.
