### PR TITLE
fix(app): prevent blank screens when startup assets fail

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,81 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Acorn</title>
+    <style>
+      html,
+      body,
+      #root {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        background: #f4f1ea;
+        color: #24221f;
+        font-family: Inter, "SF Pro Text", system-ui, sans-serif;
+      }
+
+      .acorn-startup-fallback {
+        box-sizing: border-box;
+        display: grid;
+        min-height: 100%;
+        place-items: center;
+        padding: 24px;
+      }
+
+      .acorn-startup-fallback section {
+        box-sizing: border-box;
+        width: min(100%, 480px);
+        padding: 24px;
+        border: 1px solid #d7d1c6;
+        border-radius: 12px;
+        background: #fffdf8;
+      }
+
+      .acorn-startup-fallback h1 {
+        margin: 0;
+        font-size: 20px;
+      }
+
+      .acorn-startup-fallback p {
+        margin: 12px 0 0;
+        color: #686158;
+        font-size: 14px;
+        line-height: 1.6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #1f2326;
+          color: #ededed;
+        }
+
+        .acorn-startup-fallback section {
+          border-color: #3a3f43;
+          background: #272b2f;
+        }
+
+        .acorn-startup-fallback p {
+          color: #a5aaad;
+        }
+      }
+    </style>
   </head>
 
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <main class="acorn-startup-fallback">
+        <section role="status" aria-labelledby="acorn-startup-title">
+          <h1 id="acorn-startup-title">Acorn is starting</h1>
+          <p>
+            If this screen remains, the interface could not load. Quit and
+            reopen Acorn; if it happens again, reinstall the latest version.
+            Your terminal sessions and projects will remain.
+          </p>
+        </section>
+      </main>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/tests/e2e/app-recovery.spec.ts
+++ b/tests/e2e/app-recovery.spec.ts
@@ -1,6 +1,40 @@
 import { test, expect } from "./support";
 
 test.describe("app recovery", () => {
+  test("keeps an emergency message when the entry module cannot load", async ({
+    page,
+    errorTracker,
+  }) => {
+    errorTracker.allow(/failed to load resource/i);
+    await page.route(/\/src\/main\.tsx(?:\?.*)?$/, (route) => route.abort());
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: "Acorn is starting" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/If this screen remains, the interface could not load/i),
+    ).toBeVisible();
+  });
+
+  test("keeps an emergency message when the application module cannot load", async ({
+    page,
+    errorTracker,
+  }) => {
+    errorTracker.allow(/failed to load resource/i);
+    await page.route(/\/src\/App\.tsx(?:\?.*)?$/, (route) => route.abort());
+
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: "Acorn is starting" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/If this screen remains, the interface could not load/i),
+    ).toBeVisible();
+  });
+
   test("recovers from incompatible persisted UI state instead of staying blank", async ({
     page,
     errorTracker,


### PR DESCRIPTION
## Summary

This PR closes the pre-React startup gap that could leave an updated Acorn window completely blank when its frontend assets failed to load.

1. **Static emergency shell** — ship a small, accessible startup message and self-contained light/dark styling directly in `index.html`, so useful recovery guidance remains even when the JavaScript entry point cannot run.
2. **Preserved startup contract** — keep the existing static application import and React recovery boundary unchanged; a healthy boot replaces the shell normally, while render-time workspace incompatibilities still use the scoped workspace reset flow.
3. **Failure-path coverage** — add Playwright regressions for both a missing entry module and a missing application module graph.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Entry or application module fails after an update | Empty white window | Styled recovery guidance remains visible, including reopen/reinstall steps and a data-retention note |
| Persisted workspace state is incompatible | React recovery boundary offers a scoped workspace-view reset | Unchanged |
| Healthy startup | Empty mount point until React renders | Emergency shell is replaced by the normal app without changing the existing bundle/loading order |

## Design notes

- The emergency UI has no dependency on the frontend JavaScript or extracted application CSS, because those assets may be the part that failed during an update.
- The normal application remains statically imported. This preserves document-load and hotkey-registration timing and avoids adding a new async chunk to the critical startup path.
- The static shell does not clear storage or mutate user state. The existing React boundary remains responsible for render-time incompatibilities where a workspace-only reset is appropriate.

## Test plan

- [x] `pnpm run build` — TypeScript and the production frontend bundle pass; the generated `dist/index.html` retains the emergency shell.
- [x] `pnpm run test` — 123 files and 1,450 tests pass.
- [x] `pnpm run test:e2e` — all 344 Chromium E2E tests pass.
- [x] `pnpm exec playwright test tests/e2e/app-recovery.spec.ts --project=chromium` — all 4 focused recovery tests pass on the rebased branch.
- [x] Manual Playwright check — blocking the entry module leaves the styled emergency message visible instead of a white window.
- [x] `git diff --check` — passes.

## Notes

- The production build retains the repository's existing large-chunk and ineffective-dynamic-import warnings; this PR does not add a dynamic import or a new startup chunk.
