### PR TITLE
style(rust): restore rustfmt formatting

### DIFF
--- a/src-tauri/src/agent_hooks.rs
+++ b/src-tauri/src/agent_hooks.rs
@@ -2097,9 +2097,8 @@ fn parse_spooled_hook_event(
         .iter()
         .position(|byte| *byte == b'\n')
         .ok_or_else(|| SpoolFileError::Invalid("missing transport metadata line".to_string()))?;
-    let meta: SpooledTransportMeta =
-        serde_json::from_slice(&raw[..meta_end])
-            .map_err(|err| SpoolFileError::Invalid(err.to_string()))?;
+    let meta: SpooledTransportMeta = serde_json::from_slice(&raw[..meta_end])
+        .map_err(|err| SpoolFileError::Invalid(err.to_string()))?;
     let head = synthetic_request_head(&meta)?;
     parse_agent_hook_request(&head, &raw[meta_end + 1..]).map_err(SpoolFileError::Invalid)
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12189,7 +12189,16 @@ mod tests {
         can_store_generated_session_title, cleanup_removed_scrollbacks_from_dir,
         collect_memory_usage_from_roots, configured_git_identity, create_unique_worktree,
         daemon_attach_replay_scrollback, daemon_spawn_name_for_session,
-        detach_requested_by_stale_renderer, discard_pending_session_removal_from_dir, ensure_new_project_destination_available, font_name_from_path, infer_acornd_root_from_session_pids, inject_agent_hook_env, linked_worktree_root_for_registered_path, memory_root_pids, normalize_session_goal, normalize_session_graph, poll_defers_to_hook, project_creation_git_error, remove_linked_worktree_at_path, restore_pending_session_removal, retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror, should_route_session_to_daemon, terminate_session_runtime, validate_display_name, validate_editor_command, validate_new_project_name, validate_pty_caller_env, ChatProviderAdapter, MAX_PTY_WORKSPACE_NAME_BYTES, ProcessMemorySnapshot, RemovalProgress,
+        detach_requested_by_stale_renderer, discard_pending_session_removal_from_dir,
+        ensure_new_project_destination_available, font_name_from_path,
+        infer_acornd_root_from_session_pids, inject_agent_hook_env,
+        linked_worktree_root_for_registered_path, memory_root_pids, normalize_session_goal,
+        normalize_session_graph, poll_defers_to_hook, project_creation_git_error,
+        remove_linked_worktree_at_path, restore_pending_session_removal,
+        retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror,
+        should_route_session_to_daemon, terminate_session_runtime, validate_display_name,
+        validate_editor_command, validate_new_project_name, validate_pty_caller_env,
+        ChatProviderAdapter, ProcessMemorySnapshot, RemovalProgress, MAX_PTY_WORKSPACE_NAME_BYTES,
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingRemovalStep, PendingSessionRemoval};

--- a/src-tauri/src/session_titles.rs
+++ b/src-tauri/src/session_titles.rs
@@ -116,9 +116,7 @@ pub fn resolve_title_input(session_id: uuid::Uuid) -> Option<ResolvedTitleInput>
 /// corrupt, or belongs to another session. Those must not be reported as "no
 /// input", because the caller turns that into a silent `Skipped` for a title
 /// the user explicitly asked to generate.
-pub fn resolve_chat_title_input(
-    session_id: uuid::Uuid,
-) -> AppResult<Option<ResolvedTitleInput>> {
+pub fn resolve_chat_title_input(session_id: uuid::Uuid) -> AppResult<Option<ResolvedTitleInput>> {
     let state = crate::persistence::load_chat_session_state(&session_id.to_string())?;
     Ok(chat_title_input_from_state(&state))
 }
@@ -270,11 +268,9 @@ mod tests {
         let session_id = uuid::Uuid::new_v4();
 
         // A session with no state file yet has nothing to title — not an error.
-        assert!(
-            resolve_chat_title_input_from_dir(base.path(), session_id)
-                .expect("a missing state file is an empty session")
-                .is_none()
-        );
+        assert!(resolve_chat_title_input_from_dir(base.path(), session_id)
+            .expect("a missing state file is an empty session")
+            .is_none());
 
         // A state file that exists but cannot be parsed is a real failure. It
         // must not be reported as "nothing to title", which the command turns

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -505,7 +505,10 @@ fn path_entry_exists(path: &Path) -> AppResult<bool> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(AppError::Io(std::io::Error::new(
             error.kind(),
-            format!("failed to inspect worktree path {}: {error}", path.display()),
+            format!(
+                "failed to inspect worktree path {}: {error}",
+                path.display()
+            ),
         ))),
     }
 }


### PR DESCRIPTION
## Summary

Five spots in the access-error series (#782–#837) landed with hand-wrapped formatting that `rustfmt` does not produce, in `agent_hooks.rs`, `commands.rs`, `session_titles.rs`, and `worktree.rs`.

`main` was fmt-clean immediately before that series (`cargo fmt --check` at `2e2c786` reports zero diffs), so this drift is entirely from those PRs. CI runs Frontend, E2E, and the Windows NSIS smoke — none of them runs `cargo fmt --check`, which is why it went unnoticed.

## Formatting only

- `commands.rs` — token multiset identical to `main`; `rustfmt` only re-wrapped a long `use` list.
- `session_titles.rs` — differs by exactly one removed trailing comma.
- `agent_hooks.rs`, `worktree.rs` — identical ignoring whitespace.

## Test plan

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — zero diffs (was five)
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` — 864 passed, 1 ignored
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets` — 0 errors, 70 warnings, the same 70 the pre-series baseline produces
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 1450 passed (123 files)

## Worth considering separately

CI has no `cargo fmt --check` step, and it also never compiles the tests for the `acorn` lib or `acorn-paths` — the Windows job's `cargo test` only covers `acorn-local-ipc`, `acorn-platform`, and `acorn-daemon`, and the release build skips `#[cfg(test)]` entirely. A `cargo fmt --check` + `cargo test -p acorn --lib` step would have caught both this and any non-compiling test in that crate.
