### PR TITLE
fix(canvas): distinguish session removal with trash icon

### DIFF
--- a/src/components/WorkspaceCanvas.tsx
+++ b/src/components/WorkspaceCanvas.tsx
@@ -14,6 +14,7 @@ import {
   Scan,
   Sparkles,
   Terminal as TerminalIcon,
+  Trash2,
   Undo2,
   Waypoints,
   X,
@@ -1540,7 +1541,7 @@ const WorkspaceCanvasSessionNode = memo(
               data-testid="workspace-canvas-node-close"
               onClick={onClose}
             >
-              <X size={12} />
+              <Trash2 size={12} />
             </IconButton>
           </Tooltip>
         </header>

--- a/tests/e2e/canvas.spec.ts
+++ b/tests/e2e/canvas.spec.ts
@@ -518,7 +518,9 @@ test.describe("workspace canvas mode", () => {
 
     await expect(node).toHaveCount(0);
     const beta = page.locator('[data-canvas-session-id="beta"]');
-    await beta.getByRole("button", { name: "Close beta" }).click();
+    const removeButton = beta.getByRole("button", { name: "Close beta" });
+    await expect(removeButton.locator("svg")).toHaveClass(/lucide-trash-2/);
+    await removeButton.click();
     await expect(
       dialog.getByRole("heading", { name: "Remove session" }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

This PR makes canvas session removal visually distinct from the expanded terminal popover close action.

1. **Canvas session action** — replace the inline X beside Expand with a trash icon while preserving the existing removal confirmation flow.
2. **Regression coverage** — assert the trash glyph and the existing removal dialog behavior in the canvas Playwright suite.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Canvas session header | Remove and expanded-popover close both used an X | Remove uses a trash icon; expanded-popover close keeps its X |
| Session removal behavior | Opens the removal confirmation dialog | Unchanged |

## Design notes

- The button tooltip, accessible name, and requestRemoveSession wiring remain unchanged; this is a visual affordance fix only.
- The scope is the inline action beside Expand, where the ambiguity occurs. The labeled canvas context-menu action remains unchanged.

## Test plan

- [x] pnpm run build — TypeScript and Vite production build pass
- [x] pnpm exec playwright test tests/e2e/canvas.spec.ts — 17 tests pass