### PR TITLE
chore(rust): gate formatting in CI and at commit time

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Format staged Rust files so formatting never lands as a separate diff.
+# Enable once per clone: git config core.hooksPath .githooks
+# ponytail: no filename-with-space handling — this repo has none.
+files=$(git diff --cached --name-only --diff-filter=ACM -- '*.rs')
+[ -z "$files" ] && exit 0
+rustfmt --edition 2021 $files || exit 1
+git add $files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,3 +385,24 @@ jobs:
           path: staged/**
           if-no-files-found: error
           retention-days: 1
+
+  rustfmt:
+    name: Rust format
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # rustfmt only parses — no crate compilation, so this job needs neither
+      # a cargo cache nor a sidecar build. Style is pinned in
+      # src-tauri/rustfmt.toml so every toolchain formats identically.
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check

--- a/docs/COMMON.md
+++ b/docs/COMMON.md
@@ -51,6 +51,7 @@ write.
 - **Logic stuck inside a component** that wants a unit test should be extracted to `src/lib/`. Don't try to test it through the rendered component. Example: `Sidebar.tsx`'s project folder grouping logic should live in `src/lib/projectFolders.ts`.
 - **`src/lib/api.ts` is the only place that calls `invoke()` from app code.** New backend commands get a wrapper there with explicit types. Components import from `api`, not from `@tauri-apps/api/core`.
 - **Comments describe current state only.** No history accumulation, no "previously/legacy/v1/PR #N" framing, no WHAT restatement. Present-tense WHY only — see [`docs/COMMENTS.md`](COMMENTS.md).
+- **Rust is `rustfmt`-formatted, and CI enforces it.** Style is pinned in `src-tauri/rustfmt.toml`, the `Rust format` CI job runs `cargo fmt --all --check`, and `.githooks/pre-commit` reformats staged `.rs` files so drift never reaches a commit. Enable the hook once per clone: `git config core.hooksPath .githooks`.
 
 ## Things that go wrong if you forget
 

--- a/src-tauri/rustfmt.toml
+++ b/src-tauri/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2021"


### PR DESCRIPTION
## Why

`cargo fmt` drift keeps re-landing because nothing in the repo checks it. There is no rustfmt config, no CI job, and no commit hook, so hand-wrapped Rust passes review, and the next person who runs `cargo fmt --all` gets a diff touching files they never edited. #840 was an entire commit spent restoring formatting after the fact, and its own body noted the gap: "CI does not run `cargo fmt --check`, so nothing caught it."

## What

Three pieces, each closing the gap at a different point.

- **`src-tauri/rustfmt.toml`** pins `style_edition = "2021"` so the output does not depend on which rustfmt version a machine happens to have. Every crate in the workspace is already edition 2021; making the style explicit means a future toolchain default cannot silently reshuffle imports.
- **`Rust format` CI job** runs `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check`. rustfmt only parses, so this job needs neither a cargo cache nor a sidecar build — it is a checkout, a toolchain with the `rustfmt` component, and one command, with a 5-minute timeout.
- **`.githooks/pre-commit`** reformats staged `.rs` files and re-stages them, so drift never becomes a commit in the first place. Opt-in per clone with `git config core.hooksPath .githooks`; the enablement line is documented in `docs/COMMON.md`.

## Notes

`main` is already fmt-clean under the pinned style, so this PR carries **no code reformatting** — only the four tooling and docs files.

## Verification

- [x] `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` passes on this branch with the pin in place
- [x] Pre-commit hook exercised locally: staged a deliberately misformatted `fn ponytail_probe( )->u8{1}` in `pty_env.rs`, hook rewrote it to `fn ponytail_probe() -> u8 {` and re-staged the file; probe then reverted
- [x] All eleven workspace crates confirmed `edition = "2021"`, matching the pinned `style_edition`
