### PR TITLE
fix(sidebar): expand collapsed groups when new sessions arrive

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -320,6 +320,9 @@ export function Sidebar() {
   const projects = useAppStore((s) => s.projects);
   const projectFolders = useAppStore((s) => s.projectFolders);
   const sessionFolderIds = useAppStore((s) => s.sessionFolderIds);
+  const sessionListInitialized = useAppStore(
+    (s) => s.sessionListInitialized,
+  );
   const activeSessionId = useAppStore((s) => s.activeSessionId);
   const activeProject = useAppStore((s) => s.activeProject);
   const activeProjectFolderId = useAppStore((s) => s.activeProjectFolderId);
@@ -385,6 +388,7 @@ export function Sidebar() {
     useState<SessionCreateScope | null>(null);
   const [pendingRemoveProjectFolderId, setPendingRemoveProjectFolderId] =
     useState<string | null>(null);
+  const knownSessionIdsRef = useRef<Set<string> | null>(null);
 
   useEffect(() => {
     saveStringSet(COLLAPSED_KEY, collapsed);
@@ -412,6 +416,58 @@ export function Sidebar() {
     () => buildProjectRootIndex(projects),
     [projects],
   );
+  useEffect(() => {
+    if (!sessionListInitialized) return;
+
+    const currentSessionIds = new Set(sessions.map((session) => session.id));
+    const knownSessionIds = knownSessionIdsRef.current;
+    knownSessionIdsRef.current = currentSessionIds;
+    if (!knownSessionIds) return;
+
+    const addedSessionIds = new Set(
+      sessions
+        .filter((session) => !knownSessionIds.has(session.id))
+        .map((session) => session.id),
+    );
+    if (addedSessionIds.size === 0) return;
+
+    const projectRepoPaths = new Set<string>();
+    const projectFolderIds = new Set<string>();
+    for (const project of projectGroups) {
+      for (const folderGroup of project.folders) {
+        if (
+          !folderGroup.sessions.some((session) =>
+            addedSessionIds.has(session.id),
+          )
+        ) {
+          continue;
+        }
+        projectRepoPaths.add(project.repoPath);
+        projectFolderIds.add(folderGroup.folder.id);
+      }
+    }
+
+    if (projectRepoPaths.size > 0) {
+      setCollapsed((prev) => {
+        if (![...projectRepoPaths].some((repoPath) => prev.has(repoPath))) {
+          return prev;
+        }
+        const next = new Set(prev);
+        for (const repoPath of projectRepoPaths) next.delete(repoPath);
+        return next;
+      });
+    }
+    if (projectFolderIds.size > 0) {
+      setCollapsedFolders((prev) => {
+        if (![...projectFolderIds].some((folderId) => prev.has(folderId))) {
+          return prev;
+        }
+        const next = new Set(prev);
+        for (const folderId of projectFolderIds) next.delete(folderId);
+        return next;
+      });
+    }
+  }, [projectGroups, sessionListInitialized, sessions]);
   // A source folder's workspace makes its own root active; the project row it
   // belongs to still has to read as the active one.
   const activeProjectRoot = activeProject
@@ -889,12 +945,6 @@ export function Sidebar() {
         if (!created) return;
         await useAppStore.getState().refreshAll();
         selectSession(created.id);
-        setCollapsed((prev) => {
-          if (!prev.has(created.repo_path)) return prev;
-          const next = new Set(prev);
-          next.delete(created.repo_path);
-          return next;
-        });
         return;
       }
       const request = buildSessionCreateRequest(
@@ -914,12 +964,6 @@ export function Sidebar() {
       if (!created || error) {
         showToast(`${t("toasts.session.createFailed")} ${error ?? ""}`.trim());
       }
-      setCollapsed((prev) => {
-        if (!prev.has(request.repoPath)) return prev;
-        const next = new Set(prev);
-        next.delete(request.repoPath);
-        return next;
-      });
     } catch (e) {
       console.error("create session failed", e);
       showToast(`${t("toasts.session.createFailed")} ${String(e)}`);

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -234,6 +234,7 @@ function resetStore(): void {
       pendingRemoveId: null,
       pendingRemoveProject: null,
       sessionsLoadedCleanly: true,
+      sessionListInitialized: false,
       liveInWorktree: {},
       generatingSessionTitleIds: {},
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -462,6 +462,12 @@ interface AppStateModel {
    */
   sessionsLoadedCleanly: boolean;
   /**
+   * Whether at least one backend session snapshot has loaded successfully.
+   * Sidebar consumers use the first snapshot as a baseline so persisted
+   * collapse state is only changed for sessions that arrive afterwards.
+   */
+  sessionListInitialized: boolean;
+  /**
    * Session ids whose *live* PTY cwd resolves inside a linked git worktree
    * (`.git` is a file). Separate from `Session.in_worktree`, which only
    * reflects the recorded `worktree_path` at spawn / adoption time — this
@@ -1702,6 +1708,7 @@ export const useAppStore = create<AppStateModel>()(
   pendingRemoveProject: null,
   pendingSourceMerge: null,
   sessionsLoadedCleanly: true,
+  sessionListInitialized: false,
   liveInWorktree: {},
   generatingSessionTitleIds: {},
 
@@ -1758,6 +1765,7 @@ export const useAppStore = create<AppStateModel>()(
           loading: false,
           error: null,
           sessionsLoadedCleanly: nextSessionsLoadedCleanly,
+          sessionListInitialized: true,
           sessionNotifications: shouldPruneActivity
             ? s.sessionNotifications.filter((notification) =>
                 sessionIds.has(notification.sessionId),
@@ -1902,6 +1910,7 @@ export const useAppStore = create<AppStateModel>()(
         loading: false,
         error: refreshError,
         sessionsLoadedCleanly: nextSessionsLoadedCleanly,
+        sessionListInitialized: s.sessionListInitialized || receivedSessions,
         sessionNotifications: shouldPruneActivity
           ? s.sessionNotifications.filter((notification) =>
               sessionIds.has(notification.sessionId),

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -2780,6 +2780,108 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
+  test("a new session expands its collapsed project and source folder", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+        source_paths: ["/tmp/demo-api"],
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __sourceSessions?: unknown[] };
+      w.__sourceSessions = w.__sourceSessions ?? [
+        {
+          id: "source-existing",
+          name: "existing",
+          repo_path: "/tmp/demo-api",
+          worktree_path: "/tmp/demo-api",
+          branch: "main",
+          isolated: false,
+          project_scoped: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "manual",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: 0,
+          in_worktree: false,
+        },
+      ];
+      return w.__sourceSessions;
+    });
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "acorn:sidebar:collapsed-projects",
+        JSON.stringify(["/tmp/demo"]),
+      );
+      localStorage.setItem(
+        "acorn:sidebar:collapsed-project-folders",
+        JSON.stringify(["/tmp/demo-api"]),
+      );
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator("aside");
+    await expect(
+      sidebar.getByRole("button", { name: "Expand project", exact: true }),
+    ).toBeVisible();
+    await expect(
+      sidebar.locator('[data-sidebar-workspace-id="/tmp/demo-api"]'),
+    ).toHaveCount(0);
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __sourceSessions: unknown[];
+        __ACORN_EMIT_TAURI_EVENT__?: (event: string, payload: unknown) => void;
+      };
+      w.__sourceSessions.push({
+        id: "source-new",
+        name: "new source session",
+        repo_path: "/tmp/demo-api",
+        worktree_path: "/tmp/demo-api",
+        branch: "main",
+        isolated: false,
+        project_scoped: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:01Z",
+        last_message: null,
+        title_source: "manual",
+        kind: "regular",
+        owner: { kind: "user" },
+        position: 1,
+        in_worktree: false,
+      });
+      w.__ACORN_EMIT_TAURI_EVENT__?.("acorn:ipc-sessions-changed", {
+        action: "created",
+        session_id: "source-new",
+      });
+    });
+
+    await expect(
+      sidebar.getByRole("button", {
+        name: /^new source session main · Ready/,
+      }),
+    ).toBeVisible();
+    await expect(
+      sidebar.getByRole("button", { name: "Collapse project", exact: true }),
+    ).toBeVisible();
+    await expect(
+      sidebar
+        .locator('[data-sidebar-workspace-id="/tmp/demo-api"]')
+        .getByRole("button", { name: "Collapse workspace", exact: true }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
   test("project header uses full title width until hover actions need ellipsis", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
New sessions now reveal themselves in the sidebar even when their containing project or source workspace was collapsed.

1. **Track post-boot additions** — mark the first successful backend session snapshot as the baseline, then detect session IDs that arrive afterward.
2. **Expand the full destination path** — resolve every added project session through the existing project-folder grouping and open both its project and actual source/workspace row.
3. **Cover every creation path** — centralize expansion around refreshed session state so sidebar actions, shortcuts, other views, and IPC-created sessions behave consistently.
4. **Protect persisted UI state** — keep stored collapse preferences intact during initial app hydration.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Session arrives in a collapsed project | New row remains hidden | Project expands automatically |
| Session arrives in a collapsed source/workspace row | Source row remains collapsed | Project and destination row both expand |
| App starts with existing sessions | Persisted collapse state could be mistaken for new content by naive detection | First successful snapshot establishes a no-op baseline |

## Design notes
- `sessionListInitialized` is ephemeral store state and is intentionally excluded from persisted workspace data.
- Sidebar expansion uses `buildProjectFolderGroups`, so source roots resolve to their owning project and named/worktree workspace assignments remain authoritative.
- The previous path-specific expansion inside `onNewSession` was removed to avoid partial behavior and duplicate state updates.

## Test plan
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 123 files, 1,450 tests pass
- [x] `pnpm run build` — production frontend build passes
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "a new session expands its collapsed project and source folder"` — 1 test passes