### PR TITLE
fix(todos): keep an unreadable project from hiding session todos

### DIFF
--- a/src-tauri/src/todos.rs
+++ b/src-tauri/src/todos.rs
@@ -117,6 +117,12 @@ fn locate_transcript_in(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(path_access_error("read", &canonical_root, error)),
     };
+    // A sibling project directory we cannot read says nothing about the
+    // transcript we are looking for: session ids are UUIDs, so an exact match
+    // found elsewhere is still the right answer. Remember the first access
+    // failure and only report it if the scan ends without a match, so one
+    // unreadable directory cannot mask every session's todos.
+    let mut first_access_error: Option<AppError> = None;
     for (index, entry) in entries.enumerate() {
         if index >= limits.max_project_dir_entries {
             return Err(limit_error(
@@ -124,11 +130,23 @@ fn locate_transcript_in(
                 limits.max_project_dir_entries,
             ));
         }
-        let entry = entry.map_err(|error| path_access_error("read", &canonical_root, error))?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                first_access_error
+                    .get_or_insert_with(|| path_access_error("read", &canonical_root, error));
+                continue;
+            }
+        };
         let entry_path = entry.path();
-        let entry_type = entry
-            .file_type()
-            .map_err(|error| path_access_error("inspect", &entry_path, error))?;
+        let entry_type = match entry.file_type() {
+            Ok(entry_type) => entry_type,
+            Err(error) => {
+                first_access_error
+                    .get_or_insert_with(|| path_access_error("inspect", &entry_path, error));
+                continue;
+            }
+        };
         if !entry_type.is_dir() {
             continue;
         }
@@ -136,7 +154,11 @@ fn locate_transcript_in(
         let candidate_meta = match std::fs::symlink_metadata(&candidate) {
             Ok(metadata) => metadata,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(path_access_error("inspect", &candidate, error)),
+            Err(error) => {
+                first_access_error
+                    .get_or_insert_with(|| path_access_error("inspect", &candidate, error));
+                continue;
+            }
         };
         if candidate_meta.file_type().is_symlink() || !candidate_meta.is_file() {
             continue;
@@ -144,13 +166,20 @@ fn locate_transcript_in(
         let resolved = match candidate.canonicalize() {
             Ok(resolved) => resolved,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(path_access_error("resolve", &candidate, error)),
+            Err(error) => {
+                first_access_error
+                    .get_or_insert_with(|| path_access_error("resolve", &candidate, error));
+                continue;
+            }
         };
         if resolved.starts_with(&canonical_root) {
             return Ok(Some(resolved));
         }
     }
-    Ok(None)
+    match first_access_error {
+        Some(error) => Err(error),
+        None => Ok(None),
+    }
 }
 
 fn path_access_error(operation: &str, path: &Path, error: std::io::Error) -> AppError {
@@ -836,6 +865,53 @@ mod tests {
             let error = result.unwrap_err().to_string();
             assert!(error.contains("failed to read transcript path"));
             assert!(error.contains(&root.path().display().to_string()));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_sibling_project_does_not_hide_a_readable_transcript() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        // read_dir order is not specified, so seed enough unreadable siblings
+        // that at least one is almost certainly visited before the match.
+        for index in 0..4 {
+            let sibling = root.path().join(format!("-unreadable-{index}"));
+            std::fs::create_dir(&sibling).unwrap();
+            std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o000)).unwrap();
+        }
+        let expected = write_transcript(root.path(), b"\n");
+
+        let result = locate_transcript_in(root.path(), SESSION_ID, small_limits());
+
+        for index in 0..4 {
+            let sibling = root.path().join(format!("-unreadable-{index}"));
+            std::fs::set_permissions(&sibling, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        assert_eq!(result.unwrap().unwrap(), expected.canonicalize().unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_project_is_reported_when_no_transcript_matches() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("-unreadable");
+        std::fs::create_dir(&project).unwrap();
+        std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let permission_bits_enforced = std::fs::read_dir(&project).is_err();
+
+        let result = locate_transcript_in(root.path(), SESSION_ID, small_limits());
+
+        std::fs::set_permissions(&project, std::fs::Permissions::from_mode(0o700)).unwrap();
+        if permission_bits_enforced {
+            let error = result.unwrap_err().to_string();
+            assert!(
+                error.contains("failed to inspect transcript path"),
+                "an unreadable project must not look like an empty todo list: {error}"
+            );
         }
     }
 

--- a/src/components/RightPanel.test.tsx
+++ b/src/components/RightPanel.test.tsx
@@ -498,6 +498,55 @@ describe("RightPanel background tab loading", () => {
     expect(mockApi.listUnscopedAgentHistory).toHaveBeenCalledWith(100);
   });
 
+  it("keeps the Todos tab reachable when transcript access fails", async () => {
+    useAppStore.setState({
+      sessions: [
+        {
+          id: "local-todos",
+          name: "claude",
+          repo_path: "/Users/tester",
+          worktree_path: "/Users/tester",
+          branch: "HEAD",
+          isolated: false,
+          project_scoped: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+          last_message: null,
+          title_source: "default",
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          in_worktree: false,
+          agent_provider: "claude",
+        },
+      ],
+      activeSessionId: "local-todos",
+      activeTabId: "local-todos",
+      activeProject: REPO,
+      rightTab: "history",
+    });
+    mockApi.readSessionTodos.mockRejectedValue(
+      new Error("transcript permission denied"),
+    );
+
+    await act(async () => {
+      root.render(<RightPanel />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+    await flushPromises();
+
+    expect(mockApi.readSessionTodos).toHaveBeenCalledWith(
+      "local-todos",
+      "/Users/tester",
+    );
+    const todosButton = buttonContaining(container, "Todos");
+    act(() => todosButton.click());
+    expect(container.textContent).toContain("transcript permission denied");
+  });
+
   it("filters agent history by provider", async () => {
     useAppStore.setState({ rightTab: "history" });
     mockApi.listAgentHistory.mockResolvedValue([

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -343,7 +343,9 @@ export function RightPanel() {
     active?.id ?? null,
     active?.worktree_path ?? null,
   );
-  const showTodos = todosState.todos.length > 0;
+  // An access failure is not an empty list: keep the tab reachable so the
+  // reason is visible instead of the todos silently disappearing.
+  const showTodos = todosState.todos.length > 0 || todosState.error !== null;
   const isCodeGitRepo = useIsGitRepository(
     codePanelRepoPath,
     gitRepoProbeVersion,
@@ -524,7 +526,11 @@ export function RightPanel() {
       ) : null}
       <div className="flex-1 overflow-hidden">
         {rightTab === "todos" ? (
-          active && showTodos ? (
+          active && todosState.error ? (
+            <div className="p-3 text-xs text-danger" role="alert">
+              {todosState.error}
+            </div>
+          ) : active && showTodos ? (
             <TodosTab todos={todosState.todos} />
           ) : (
             <Empty msg={rt(t, "rightPanel.empty.noTodos")} />


### PR DESCRIPTION
## Summary

Second slice of #791. `todos::locate_transcript_in` already refuses to report an access failure as an empty todo list, but it fails the *whole* scan on the first project directory it cannot inspect. Session ids are UUIDs, so a sibling project directory says nothing about the transcript being looked up: a single `chmod 000` directory under `~/.claude/projects` turned every session's todo lookup into an error, including sessions whose own transcript is perfectly readable.

The scan now remembers the first access failure and keeps going. If an exact match is found the answer is returned as before; only a scan that ends with no match reports the remembered error. An unreadable project therefore still cannot be mistaken for "no todos", but it also cannot mask a readable one.

`RightPanel` had the matching gap on the frontend. `useSessionTodos` already stored the request error, but `showTodos` was `todos.length > 0`, so a failed request hid the Todos tab entirely — the same "this session has no todos" presentation the backend was hardened against. The tab now stays reachable when the request failed and renders the error inside it.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| One unreadable project dir, transcript readable elsewhere | Every todo lookup errors | The matching transcript is returned |
| Unreadable project dir, no matching transcript | Error | Error (unchanged) |
| Missing projects root or transcript | Empty todo list | Empty todo list (unchanged) |
| `read_session_todos` fails | Todos tab disappears | Tab stays, shows the error |

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn --lib` — 866 passed, 1 ignored.
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -p acorn --lib --tests` — 0 errors, pre-existing warnings only.
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1451 passed (123 files).
- [x] Negative control (Rust): restoring the immediate `return Err` makes `unreadable_sibling_project_does_not_hide_a_readable_transcript` fail with `Other("failed to inspect transcript path .../-unreadable-3/<uuid>.jsonl: Permission denied (os error 13)")`.
- [x] Negative control (frontend): reverting `RightPanel.tsx` makes `keeps the Todos tab reachable when transcript access fails` fail.

## Notes

`read_dir` order is unspecified, so `unreadable_sibling_project_does_not_hide_a_readable_transcript` seeds four unreadable siblings to make it near-certain that at least one is visited before the match. Both new Unix tests skip their assertion when permission bits are not enforced (running as root).

Refs #791 — slices 3 (`agent_resume` + persister) and 4 (`agent_history`) already landed on `main` via #834; slice 5 (frontend resume modal) follows separately.
