### PR TITLE
fix(resume): keep failed resume-modal actions recoverable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -168,6 +168,10 @@ function appText(t: Translator, key: AppTranslationKey): string {
   return t(key);
 }
 
+function unknownErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function isEditableTextElement(
   element: Element | null,
 ): element is HTMLInputElement | HTMLTextAreaElement {
@@ -631,23 +635,53 @@ function App() {
     for (const sid of toProbe) probedSessionsRef.current.add(sid);
     void Promise.all(
       toProbe.map(async (sid) => {
-        const candidates = await Promise.all(
+        const probes = await Promise.all(
           AGENT_PROVIDER_ORDER.map(async (agent) => {
-            const candidate = await api
-              .getAgentResumeCandidate(agent, sid)
-              .catch(() => null);
-            return [agent, candidate] as const;
+            try {
+              const candidate = await api.getAgentResumeCandidate(agent, sid);
+              return { agent, candidate, failure: null } as const;
+            } catch (error: unknown) {
+              return { agent, candidate: null, failure: { error } } as const;
+            }
           }),
         );
-        const pick = pickResumeCandidate(candidates);
-        return pick ? ([sid, pick] as const) : null;
+        const pick = pickResumeCandidate(
+          probes.map(({ agent, candidate }) => [agent, candidate] as const),
+        );
+        return {
+          entry: pick ? ([sid, pick] as const) : null,
+          failures: probes.flatMap(({ agent, failure }) =>
+            failure === null
+              ? []
+              : [{ sessionId: sid, agent, error: failure.error }],
+          ),
+        };
       }),
     )
-      .then((entries) => {
+      .then((results) => {
         const latestSessions = new Map(
           useAppStore.getState().sessions.map((session) => [session.id, session]),
         );
-        const additions = entries
+        // A provider probe that threw is not "no previous conversation": the
+        // session's modal silently never appears. Say so once instead.
+        const failures = results
+          .flatMap((result) => result.failures)
+          .filter(({ sessionId }) => latestSessions.has(sessionId));
+        if (failures.length > 0) {
+          for (const failure of failures) {
+            console.warn(
+              `[App] ${failure.agent} resume candidate probe failed for ${failure.sessionId}`,
+              failure.error,
+            );
+          }
+          showToast(
+            `${appText(t, "app.toast.agentResumeProbeFailed")} ${unknownErrorMessage(
+              failures[0].error,
+            )}`,
+          );
+        }
+        const additions = results
+          .map((result) => result.entry)
           .filter(
             (e): e is readonly [
               string,
@@ -666,10 +700,10 @@ function App() {
         });
       })
       .catch(() => {
-        // Best-effort probe — failures here just mean a session won't
-        // surface its modal on this boot. The next launch retries.
+        // Per-provider failures are reported above; this only catches an
+        // unexpected orchestration failure. The next launch retries.
       });
-  }, [sessions, resumeModalEnabled, resumePrimeVersion]);
+  }, [sessions, resumeModalEnabled, resumePrimeVersion, showToast, t]);
 
   const resumeCandidate = useMemo(() => {
     if (!activeSessionId) return null;

--- a/src/components/AgentResumeModal.test.tsx
+++ b/src/components/AgentResumeModal.test.tsx
@@ -73,12 +73,16 @@ describe("AgentResumeModal", () => {
     return onDismiss;
   }
 
-  function clickButton(label: string) {
+  async function clickButton(label: string) {
     const button = Array.from(document.querySelectorAll("button")).find(
       (b) => b.textContent?.includes(label),
     );
     if (!button) throw new Error(`button "${label}" not found`);
-    act(() => button.click());
+    await act(async () => {
+      button.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
   }
 
   it("renders nothing when candidate is null", () => {
@@ -102,9 +106,9 @@ describe("AgentResumeModal", () => {
     expect(document.body.textContent).toContain(CANDIDATE.preview);
   });
 
-  it("Resume on a claude candidate dispatches `claude --resume <uuid>` to the PTY without ack", () => {
+  it("Resume on a claude candidate dispatches `claude --resume <uuid>` to the PTY without ack", async () => {
     const onDismiss = render("claude", CANDIDATE);
-    clickButton("Resume");
+    await clickButton("Resume");
     expect(mocks.ptyWrite).toHaveBeenCalledWith(
       SESSION_ID,
       `claude --resume ${CANDIDATE.uuid}\r`,
@@ -116,9 +120,9 @@ describe("AgentResumeModal", () => {
     expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
   });
 
-  it("Resume on a codex candidate dispatches `codex resume <uuid>` to the PTY without ack", () => {
+  it("Resume on a codex candidate dispatches `codex resume <uuid>` to the PTY without ack", async () => {
     const onDismiss = render("codex", CANDIDATE);
-    clickButton("Resume");
+    await clickButton("Resume");
     expect(mocks.ptyWrite).toHaveBeenCalledWith(
       SESSION_ID,
       `codex resume ${CANDIDATE.uuid}\r`,
@@ -127,9 +131,9 @@ describe("AgentResumeModal", () => {
     expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
   });
 
-  it("Resume on a Grok candidate dispatches `grok --resume <uuid>` to the PTY without ack", () => {
+  it("Resume on a Grok candidate dispatches `grok --resume <uuid>` to the PTY without ack", async () => {
     const onDismiss = render("grok", CANDIDATE);
-    clickButton("Resume");
+    await clickButton("Resume");
     expect(mocks.ptyWrite).toHaveBeenCalledWith(
       SESSION_ID,
       `grok --resume ${CANDIDATE.uuid}\r`,
@@ -140,22 +144,19 @@ describe("AgentResumeModal", () => {
 
   it("Copy ID writes the UUID to the clipboard and toasts", async () => {
     const onDismiss = render("claude", CANDIDATE);
-    clickButton("Copy ID");
+    await clickButton("Copy ID");
     expect(mocks.clipboardWriteText).toHaveBeenCalledWith(CANDIDATE.uuid);
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(mocks.acknowledgeAgentResume).toHaveBeenCalledWith(
       "claude",
       SESSION_ID,
     );
-    // Allow the clipboard promise to flush before checking the toast.
-    await Promise.resolve();
-    await Promise.resolve();
     expect(mocks.toastShow).toHaveBeenCalledWith("Session ID copied.");
   });
 
-  it("Cancel on a claude candidate writes a single `#`-commented resume command for recall", () => {
+  it("Cancel on a claude candidate writes a single `#`-commented resume command for recall", async () => {
     const onDismiss = render("claude", CANDIDATE);
-    clickButton("Cancel");
+    await clickButton("Cancel");
     expect(mocks.ptyWrite).toHaveBeenCalledTimes(1);
     const payload = mocks.ptyWrite.mock.calls[0][1];
     expect(payload).toBe(`# claude --resume ${CANDIDATE.uuid}\r`);
@@ -166,9 +167,9 @@ describe("AgentResumeModal", () => {
     );
   });
 
-  it("Cancel on a codex candidate writes a single `#`-commented `codex resume` command", () => {
+  it("Cancel on a codex candidate writes a single `#`-commented `codex resume` command", async () => {
     const onDismiss = render("codex", CANDIDATE);
-    clickButton("Cancel");
+    await clickButton("Cancel");
     const payload = mocks.ptyWrite.mock.calls[0][1];
     expect(payload).toBe(`# codex resume ${CANDIDATE.uuid}\r`);
     expect(onDismiss).toHaveBeenCalledTimes(1);
@@ -176,5 +177,65 @@ describe("AgentResumeModal", () => {
       "codex",
       SESSION_ID,
     );
+  });
+  it("keeps the candidate open when acknowledgement cannot be stored", async () => {
+    mocks.acknowledgeAgentResume.mockRejectedValueOnce(
+      new Error("agent state ack Permission denied"),
+    );
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onDismiss = render("claude", CANDIDATE);
+
+    await clickButton("Cancel");
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Failed to remember that this conversation was dismissed: agent state ack Permission denied",
+    );
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
+  it("keeps the candidate open when the resume command cannot be written", async () => {
+    mocks.ptyWrite.mockRejectedValueOnce(new Error("PTY access denied"));
+    const onDismiss = render("claude", CANDIDATE);
+
+    await clickButton("Resume");
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Failed to send the resume command: PTY access denied",
+    );
+  });
+
+  it("keeps the candidate open and unacknowledged when clipboard access fails", async () => {
+    mocks.clipboardWriteText.mockRejectedValueOnce(
+      new Error("clipboard permission denied"),
+    );
+    const onDismiss = render("claude", CANDIDATE);
+
+    await clickButton("Copy ID");
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')?.textContent).toContain(
+      "Failed to copy session ID. clipboard permission denied",
+    );
+  });
+
+  it("reports a failed recall hint but still persists explicit cancellation", async () => {
+    mocks.ptyWrite.mockRejectedValueOnce(new Error("PTY closed"));
+    const onDismiss = render("claude", CANDIDATE);
+
+    await clickButton("Cancel");
+
+    expect(mocks.toastShow).toHaveBeenCalledWith(
+      "Failed to add the resume hint: PTY closed",
+    );
+    expect(mocks.acknowledgeAgentResume).toHaveBeenCalledWith(
+      "claude",
+      SESSION_ID,
+    );
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -1,12 +1,19 @@
 import { Copy, History, Play } from "lucide-react";
-import { useMemo, type ReactElement } from "react";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 import { api, type AgentKind, type ResumeCandidate } from "../lib/api";
 import { buildAgentResumeCommand } from "../lib/agentProvider";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useToasts } from "../lib/toasts";
 import { writeClipboardText } from "../lib/clipboardText";
 import { useTranslation } from "../lib/useTranslation";
-import { Button, CodeValue, Modal, ModalFooter, ModalHeader } from "./ui";
+import {
+  Button,
+  CodeValue,
+  Modal,
+  ModalFooter,
+  ModalHeader,
+  Notice,
+} from "./ui";
 
 interface AgentResumeModalProps {
   /** Session whose previous agent conversation is being offered. */
@@ -16,10 +23,9 @@ interface AgentResumeModalProps {
   /** Candidate metadata to render; `null` hides the modal. */
   candidate: ResumeCandidate | null;
   /**
-   * Invoked after any modal action (or backdrop dismiss) so the host can
-   * drop the candidate from its state. The modal also calls the matching
-   * `acknowledgeAgentResume` API itself; the host only needs to clear its
-   * in-memory candidate slot.
+   * Invoked once the selected action's required writes have completed, so the
+   * host can drop the candidate from its in-memory state. A failed action
+   * keeps the modal open with the reason instead.
    */
   onDismiss: () => void;
 }
@@ -33,6 +39,10 @@ type DialogTranslationKey = Extract<TranslationKey, `dialogs.${string}`>;
 
 function dt(t: Translator, key: DialogTranslationKey): string {
   return t(key);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 const COPY: Record<AgentKind, AgentCopy> = {
@@ -56,16 +66,19 @@ const COPY: Record<AgentKind, AgentCopy> = {
 
 /**
  * Renders the focus-time "Resume previous conversation" modal. Three
- * actions, all of which acknowledge the candidate so the same UUID does
- * not re-pop on the next focus event:
+ * actions, each of which closes the modal only once its required writes
+ * have landed — a failure that closed the modal anyway would drop the
+ * candidate from memory while the acknowledgement never reached disk, so
+ * the same UUID would silently pop again on the next focus event:
  *
  * - **Resume** — sends `<agent-resume-command> <uuid>\r` into the PTY.
  *   The agent's own resume flag (claude: `--resume`, codex: `resume`
  *   subcommand) takes it from there.
- * - **Copy ID** — copies the UUID to clipboard with a toast.
- * - **Cancel** — types two `#`-prefixed shell-comment lines into the
+ * - **Copy ID** — copies the UUID, then acknowledges the candidate.
+ * - **Cancel** — types one `#`-prefixed shell-comment line into the
  *   PTY so the user can still see (and later copy) the resume command
- *   if they change their mind. `#` lines are inert if Enter is mashed.
+ *   if they change their mind, then acknowledges the candidate. The hint
+ *   is best-effort; the acknowledgement is not.
  */
 export function AgentResumeModal({
   sessionId,
@@ -77,6 +90,9 @@ export function AgentResumeModal({
   const showToast = useToasts((s) => s.show);
   const copy = COPY[agent];
 
+  const [busy, setBusy] = useState<"resume" | "copy" | "dismiss" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
   const lastActivityLabel = useMemo(
     () => formatRelativeTime(candidate?.lastActivityUnix ?? 0, t),
     [candidate?.lastActivityUnix, t],
@@ -85,20 +101,46 @@ export function AgentResumeModal({
   const lastAgentMessage =
     candidate?.lastAgentMessage?.trim() || candidate?.preview?.trim() || null;
 
+  useEffect(() => {
+    setBusy(null);
+    setError(null);
+  }, [agent, candidate?.uuid, sessionId]);
+
   if (!candidate) return null;
 
-  const ack = () => {
-    void api.acknowledgeAgentResume(agent, sessionId).catch(() => {});
+  const acknowledge = async (): Promise<boolean> => {
+    try {
+      await api.acknowledgeAgentResume(agent, sessionId);
+      return true;
+    } catch (ackError: unknown) {
+      console.warn(
+        `[AgentResumeModal] failed to acknowledge ${agent} candidate for ${sessionId}`,
+        ackError,
+      );
+      setError(
+        `${dt(t, "dialogs.agentResume.ackFailed")} ${errorMessage(ackError)}`,
+      );
+      return false;
+    }
   };
 
-  const handleResume = () => {
+  const handleResume = async () => {
+    if (busy) return;
+    setBusy("resume");
+    setError(null);
     // PTYs expect a carriage return (`\r`, what xterm sends when the
     // user presses Enter) to commit a line. Using `\n` lands as a
     // literal LF in zsh's line buffer instead of running the command.
     const cmd = `${buildAgentResumeCommand(agent, candidate.uuid)}\r`;
-    void api.ptyWrite(sessionId, cmd).catch((err: unknown) => {
-      console.error("[AgentResumeModal] failed to write resume cmd", err);
-    });
+    try {
+      await api.ptyWrite(sessionId, cmd);
+    } catch (writeError: unknown) {
+      setError(
+        `${dt(t, "dialogs.agentResume.resumeFailed")} ${errorMessage(writeError)}`,
+      );
+      setBusy(null);
+      return;
+    }
     // Deliberately do NOT ack here. Resume means "I want to keep
     // working in this conversation"; after the user exits the
     // resumed agent run, the same JSONL UUID stays on disk
@@ -108,40 +150,71 @@ export function AgentResumeModal({
     onDismiss();
   };
 
-  const handleCopy = () => {
-    void writeClipboardText(candidate.uuid)
-      .then(() => showToast(dt(t, "dialogs.agentResume.sessionIdCopied")))
-      .catch(() => showToast(dt(t, "dialogs.agentResume.copyFailed")));
+  const handleCopy = async () => {
+    if (busy) return;
+    setBusy("copy");
+    setError(null);
+    try {
+      await writeClipboardText(candidate.uuid);
+    } catch (copyError: unknown) {
+      setError(
+        `${dt(t, "dialogs.agentResume.copyFailed")} ${errorMessage(copyError)}`,
+      );
+      setBusy(null);
+      return;
+    }
+    if (!(await acknowledge())) {
+      setBusy(null);
+      return;
+    }
+    showToast(dt(t, "dialogs.agentResume.sessionIdCopied"));
     onDismiss();
-    ack();
   };
 
   // Backdrop click / Esc takes the same path as Cancel (without the
   // shell-comment hint write): the user explicitly closed the modal
   // without choosing Resume, so we ack and stop offering it.
-  const dismiss = () => {
-    onDismiss();
-    ack();
+  const dismiss = async () => {
+    if (busy) return;
+    setBusy("dismiss");
+    setError(null);
+    if (await acknowledge()) {
+      onDismiss();
+      return;
+    }
+    setBusy(null);
   };
 
-  const handleCancelWithHint = () => {
+  const handleCancelWithHint = async () => {
+    if (busy) return;
+    setBusy("dismiss");
+    setError(null);
     // Single `#`-prefixed line so the shell skips it (it's a comment),
     // but the user can hit Up-arrow to recall the command, remove the
     // `#`, and run it. Multi-line hints would need bracketed-paste
     // escapes to keep zle from collapsing the two `\r`s into one
     // input row; a single line dodges that entire problem.
     const hint = `# ${buildAgentResumeCommand(agent, candidate.uuid)}\r`;
-    void api.ptyWrite(sessionId, hint).catch((err: unknown) => {
-      console.error("[AgentResumeModal] failed to write cancel hint", err);
-    });
-    onDismiss();
-    ack();
+    try {
+      await api.ptyWrite(sessionId, hint);
+    } catch (writeError: unknown) {
+      // The hint is a convenience. The user's dismiss intent still has to
+      // clear the durable acknowledgement below, so only toast here.
+      showToast(
+        `${dt(t, "dialogs.agentResume.hintFailed")} ${errorMessage(writeError)}`,
+      );
+    }
+    if (await acknowledge()) {
+      onDismiss();
+      return;
+    }
+    setBusy(null);
   };
 
   return (
     <Modal
       open={true}
-      onClose={dismiss}
+      onClose={() => void dismiss()}
       variant="dialog"
       size="md"
       ariaLabelledBy={copy.ariaLabelledBy}
@@ -152,7 +225,7 @@ export function AgentResumeModal({
         titleId={copy.ariaLabelledBy}
         icon={<History size={14} className="text-accent" />}
         variant="dialog"
-        onClose={dismiss}
+        onClose={() => void dismiss()}
       />
       <div className="space-y-3 px-4 py-4 text-xs">
         <p className="text-fg-muted">{dt(t, copy.bodyKey)}</p>
@@ -175,23 +248,31 @@ export function AgentResumeModal({
         <CodeValue surface="elevated" tone="muted">
           {candidate.uuid}
         </CodeValue>
+        {error ? (
+          <Notice tone="danger" role="alert">
+            {error}
+          </Notice>
+        ) : null}
       </div>
       <ModalFooter>
         <Button
-          onClick={handleCancelWithHint}
+          onClick={() => void handleCancelWithHint()}
+          disabled={busy !== null}
           surface="panel"
         >
           {dt(t, "dialogs.common.cancel")}
         </Button>
         <Button
-          onClick={handleCopy}
+          onClick={() => void handleCopy()}
+          disabled={busy !== null}
           surface="panel"
         >
           <Copy size={12} />
           {dt(t, "dialogs.agentResume.copyId")}
         </Button>
         <Button
-          onClick={handleResume}
+          onClick={() => void handleResume()}
+          disabled={busy !== null}
           variant="primary"
         >
           <Play size={12} />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -942,7 +942,8 @@
       "preventSleepSyncFailedPrefix": "Could not apply the keep-awake setting:",
       "controlGuidePreferenceSaveFailed": "Couldn't save the control-session guide preference.",
       "notificationClickRegistrationFailedPrefix": "Could not enable notification click handling:",
-      "notificationClickActivationFailedPrefix": "Could not bring Acorn to the clicked notification:"
+      "notificationClickActivationFailedPrefix": "Could not bring Acorn to the clicked notification:",
+      "agentResumeProbeFailed": "Failed to check previous agent conversations:"
     }
   },
   "statusBar": {
@@ -2352,6 +2353,9 @@
       "bodyGrok": "There's a Grok conversation that was in progress in this session. You can pick it up where you left off, or just close this dialog to start fresh.",
       "sessionIdCopied": "Session ID copied.",
       "copyFailed": "Failed to copy session ID.",
+      "ackFailed": "Failed to remember that this conversation was dismissed:",
+      "resumeFailed": "Failed to send the resume command:",
+      "hintFailed": "Failed to add the resume hint:",
       "copyId": "Copy ID",
       "resume": "Resume",
       "lastUser": "User",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -942,7 +942,8 @@
       "preventSleepSyncFailedPrefix": "スリープ防止設定を適用できませんでした:",
       "controlGuidePreferenceSaveFailed": "コントロールセッションガイドの設定を保存できませんでした。",
       "notificationClickRegistrationFailedPrefix": "通知クリック処理を有効にできませんでした:",
-      "notificationClickActivationFailedPrefix": "クリックした通知から Acorn を開けませんでした:"
+      "notificationClickActivationFailedPrefix": "クリックした通知から Acorn を開けませんでした:",
+      "agentResumeProbeFailed": "以前のエージェント会話を確認できませんでした:"
     }
   },
   "statusBar": {
@@ -2352,6 +2353,9 @@
       "bodyGrok": "このセッションでは Grok の会話が進行中です。中断したところから再開することも、このダイアログを閉じて最初から始めることもできます。",
       "sessionIdCopied": "セッションIDがコピーされました。",
       "copyFailed": "セッションIDのコピーに失敗しました。",
+      "ackFailed": "この会話を閉じたことを記録できませんでした:",
+      "resumeFailed": "再開コマンドを送信できませんでした:",
+      "hintFailed": "再開ヒントを入力できませんでした:",
       "copyId": "IDをコピーする",
       "resume": "再開",
       "lastUser": "ユーザー",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -942,7 +942,8 @@
       "preventSleepSyncFailedPrefix": "잠자기 방지 설정을 적용하지 못했습니다:",
       "controlGuidePreferenceSaveFailed": "제어 세션 안내 설정을 저장하지 못했습니다.",
       "notificationClickRegistrationFailedPrefix": "알림 클릭 처리를 활성화하지 못했습니다:",
-      "notificationClickActivationFailedPrefix": "클릭한 알림으로 Acorn을 열지 못했습니다:"
+      "notificationClickActivationFailedPrefix": "클릭한 알림으로 Acorn을 열지 못했습니다:",
+      "agentResumeProbeFailed": "이전 에이전트 대화를 확인하지 못했습니다:"
     }
   },
   "statusBar": {
@@ -2352,6 +2353,9 @@
       "bodyGrok": "이 세션에 진행 중이던 Grok 대화가 있습니다. 이어서 진행하거나 이 대화상자를 닫고 새로 시작할 수 있습니다.",
       "sessionIdCopied": "세션 ID를 복사했습니다.",
       "copyFailed": "세션 ID를 복사하지 못했습니다.",
+      "ackFailed": "이 대화를 닫았다는 기록을 저장하지 못했습니다:",
+      "resumeFailed": "재개 명령을 보내지 못했습니다:",
+      "hintFailed": "재개 힌트를 입력하지 못했습니다:",
       "copyId": "ID 복사",
       "resume": "재개",
       "lastUser": "사용자",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -942,7 +942,8 @@
       "preventSleepSyncFailedPrefix": "无法应用防止睡眠设置：",
       "controlGuidePreferenceSaveFailed": "无法保存控制会话指南偏好设置。",
       "notificationClickRegistrationFailedPrefix": "无法启用通知点击处理：",
-      "notificationClickActivationFailedPrefix": "无法从点击的通知打开 Acorn："
+      "notificationClickActivationFailedPrefix": "无法从点击的通知打开 Acorn：",
+      "agentResumeProbeFailed": "无法检查之前的智能体对话："
     }
   },
   "statusBar": {
@@ -2352,6 +2353,9 @@
       "bodyGrok": "此会话中有未完成的 Grok 对话。您可以从上次中断处继续，或关闭此对话框重新开始。",
       "sessionIdCopied": "会话 ID 已复制。",
       "copyFailed": "无法复制会话 ID。",
+      "ackFailed": "无法记录此对话已关闭：",
+      "resumeFailed": "无法发送恢复命令：",
+      "hintFailed": "无法输入恢复提示：",
       "copyId": "复制 ID",
       "resume": "继续",
       "lastUser": "用户",

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -342,4 +342,68 @@ test.describe("agent resume modal", () => {
     expect(writes).toHaveLength(1);
     expect(writes[0].data).toBe(`# claude --resume ${CANDIDATE_UUID}\r`);
   });
+  test("surfaces resume candidate access errors instead of treating them as no conversation", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.handle("get_agent_resume_candidate", (args) => {
+      const input = (args ?? {}) as { kind?: string };
+      if (input.kind === "claude") {
+        throw new Error(
+          "failed to read /Users/tester/.acorn/agent-state/claude.id: Permission denied",
+        );
+      }
+      return null;
+    });
+
+    await page.goto("/");
+
+    await expect(
+      page.getByText(
+        "Failed to check previous agent conversations: failed to read /Users/tester/.acorn/agent-state/claude.id: Permission denied",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("dialog", { name: /Resume previous conversation/ }),
+    ).toHaveCount(0);
+  });
+
+  test("keeps the modal open when dismissal acknowledgement is denied", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.handle("get_agent_resume_candidate", (args) => {
+      const input = (args ?? {}) as { kind?: string };
+      if (input.kind !== "claude") return null;
+      // The handler is evaluated in the page, so the module-scope
+      // CANDIDATE_UUID is not in scope here.
+      return {
+        uuid: "deadbeef-1234-5678-9abc-def012345678",
+        lastActivityUnix: Math.floor(Date.now() / 1000) - 60,
+        preview: "Preview of the previous conversation",
+      };
+    });
+    await tauri.handle("pty_write", () => undefined);
+    await tauri.handle("acknowledge_agent_resume", () => {
+      throw new Error("agent state marker Permission denied");
+    });
+
+    await page.goto("/");
+
+    const modal = page.getByRole("dialog", {
+      name: /Resume previous conversation/,
+    });
+    await expect(modal).toBeVisible();
+    await modal.getByRole("button", { name: "Cancel" }).click();
+
+    await expect(modal).toBeVisible();
+    await expect(modal.getByRole("alert")).toContainText(
+      "Failed to remember that this conversation was dismissed: agent state marker Permission denied",
+    );
+    await expect(modal.getByRole("button", { name: "Cancel" })).toBeEnabled();
+  });
 });


### PR DESCRIPTION
## Summary

Final slice of #791, the frontend half. Every action in `AgentResumeModal` closed the modal unconditionally and fired `acknowledgeAgentResume` as `void api.acknowledgeAgentResume(...).catch(() => {})`. When that write failed, the host dropped the candidate from memory while nothing reached disk, so the very same UUID popped again at the next focus event with nothing explaining why. A failed `pty_write` behaved the same way: the modal closed and only a `console.error` recorded that the resume command was never sent.

Each action now awaits the writes it depends on and calls `onDismiss` only once they land. A failure keeps the modal open, renders the reason in a `role="alert"` notice, and re-enables the buttons so the action can be retried. The cancel hint keeps its best-effort status deliberately — it toasts on failure rather than blocking, because the acknowledgement is the write that actually has to persist for the user's dismissal to stick.

The boot-time candidate probe in `App.tsx` swallowed per-provider errors with `.catch(() => null)`, which rendered an unreadable agent state as "no previous conversation" for every affected session. Failures are now collected per provider, logged individually, and reported once via a toast.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Acknowledgement write denied on Cancel / Copy / dismiss | Modal closes, candidate re-pops later with no explanation | Modal stays open with the reason; buttons re-enabled |
| `pty_write` denied on Resume | Modal closes, command never sent, console-only | Modal stays open with the reason; no acknowledgement written |
| Clipboard write fails on Copy ID | Toast, modal closes and acknowledges anyway | Modal stays open, candidate left unacknowledged |
| Cancel hint write fails | Console-only | Toast; the acknowledgement still proceeds |
| Resume candidate probe throws | Session silently never offers its modal | Per-provider warning plus one toast |
| All writes succeed | Modal closes | Modal closes (unchanged) |

## Test plan

- [x] `pnpm exec vitest run src/components/AgentResumeModal.test.tsx` — 13 passed.
- [x] `pnpm run test` — 1454 passed (123 files).
- [x] `pnpm run typecheck`
- [x] `pnpm exec playwright test tests/e2e/agent-resume-modal.spec.ts` — 8 passed.
- [x] Negative control: reverting `AgentResumeModal.tsx` fails all four new unit tests (acknowledgement denied, resume write denied, clipboard denied, hint failure still acknowledges).

## Notes

Locale keys `dialogs.agentResume.ackFailed` / `resumeFailed` / `hintFailed` and `app.toast.agentResumeProbeFailed` are added to all four locales. The existing `copyFailed` string is reused with the underlying error appended.

Refs #791 — this completes the slices tracked in that PR's body. Slices 3 and 4 (`agent_resume`, `agent_resume_persister`, `agent_history`) had already landed on `main` via #834; slice 2 is #844.
