### PR TITLE
fix(sidebar): keep worktree actions on source workspaces

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2053,11 +2053,18 @@ function projectSessionCreateMenuForWorkspace(
   return PROJECT_SESSION_CREATE_MENU.filter((item) => {
     if (item.type === "separator") return true;
     if (!includeTerminal && item.action.id === "terminal") return false;
-    if (isWorktreeWorkspace(folder) && item.action.id === "isolated") {
+    if (
+      !canCreateWorktreeSessionInWorkspace(folder) &&
+      item.action.id === "isolated"
+    ) {
       return false;
     }
     return true;
   });
+}
+
+function canCreateWorktreeSessionInWorkspace(folder: ProjectFolder): boolean {
+  return !isWorktreeWorkspace(folder);
 }
 
 function isSessionRowDragId(id: string): boolean {
@@ -3109,7 +3116,7 @@ function ProjectFolderView({
                 <Plus size={12} />
               </button>
             </Tooltip>
-            {isDefaultProjectFolder(folder) ? (
+            {canCreateWorktreeSessionInWorkspace(folder) ? (
               <Tooltip
                 label={sidebarText(
                   t,

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -5010,7 +5010,7 @@ test.describe("sidebar: project lifecycle", () => {
     ).toBeVisible();
   });
 
-  test("primary and source root headers create worktree sessions in their repositories", async ({
+  test("primary and source workspace headers create worktree sessions in their repositories", async ({
     page,
     tauri,
   }) => {
@@ -5062,6 +5062,34 @@ test.describe("sidebar: project lifecycle", () => {
       w.__sessions = [...(w.__sessions ?? []), created];
       return created;
     });
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn-workspaces",
+        JSON.stringify({
+          state: {
+            projectFolders: {
+              "/tmp/acorn": [
+                {
+                  id: "/tmp/acorn",
+                  repoPath: "/tmp/acorn",
+                  name: "Default",
+                  cwdPath: "/tmp/acorn",
+                  position: 0,
+                },
+                {
+                  id: "project-folder:/tmp/acorn:scratch",
+                  repoPath: "/tmp/acorn",
+                  name: "scratch",
+                  cwdPath: "/tmp/acorn",
+                  position: 1,
+                },
+              ],
+            },
+          },
+          version: 4,
+        }),
+      );
+    });
 
     await page.goto("/");
 
@@ -5087,6 +5115,17 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(createSourceWorktreeSessionButton).toBeVisible();
     await createSourceWorktreeSessionButton.click();
 
+    const sourceWorkspaceHeader = page.locator(
+      'aside [data-sidebar-workspace-id="project-folder:/tmp/acorn:scratch"]',
+    );
+    await sourceWorkspaceHeader.hover();
+    const createSourceWorkspaceWorktreeSessionButton =
+      sourceWorkspaceHeader.getByRole("button", {
+        name: "New worktree session in this workspace",
+      });
+    await expect(createSourceWorkspaceWorktreeSessionButton).toBeVisible();
+    await createSourceWorkspaceWorktreeSessionButton.click();
+
     await expect
       .poll(async () =>
         page.evaluate(
@@ -5101,6 +5140,11 @@ test.describe("sidebar: project lifecycle", () => {
       .toEqual([
         expect.objectContaining({
           repoPath: "/tmp/demo",
+          isolated: true,
+          kind: "regular",
+        }),
+        expect.objectContaining({
+          repoPath: "/tmp/acorn",
           isolated: true,
           kind: "regular",
         }),


### PR DESCRIPTION
## Summary
Keeps direct worktree-session creation available anywhere a source workspace can legitimately create one.

1. **Shared eligibility** — use one workspace capability check for both the inline worktree button and the workspace create menu instead of tying the button to the default-folder id.
2. **Regression coverage** — exercise a multi-root project with its primary root, source root, and a non-default logical workspace under that source; verify every eligible header creates against the correct repository.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Source root and logical source workspaces | The menu could offer worktree creation while the inline branch button disappeared for non-default workspace ids | The inline button and menu use the same eligibility rule |
| Existing worktree-backed workspaces | Worktree creation stays hidden | Unchanged |
| Session repository targeting | Source sessions target their source repository | Unchanged and covered by E2E |

## Design notes

- Eligibility follows workspace meaning: a root-backed workspace can create a worktree session, while a workspace already bound to another worktree does not expose that action.
- The rule depends on the repository and working-directory relationship, not incidental default-folder identity. A Git worktree registered directly as a source root remains eligible because that source root is its repository workspace.

## Follow-up (not in this PR)

- Consolidate project-header, Kanban, and Canvas session-create entry points under the same shared action policy in a separate structural change.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test -- src/lib/projectFolders.test.ts src/lib/sidebarProjectItems.test.ts src/lib/sessionCreation.test.ts` — 123 files / 1,450 tests pass
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts` — 59 tests pass
- [x] `pnpm exec playwright test tests/e2e/sidebar.spec.ts --grep "primary and source workspace headers create worktree sessions"` — passes after rebasing onto current `origin/main`
- [x] `pnpm run build` — production frontend build passes
- [x] `git diff --check` — passes
