### PR TITLE
fix(app): stop the startup shell CSS from disabling runtime stylesheets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,66 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Acorn</title>
-    <style>
-      html,
-      body,
-      #root {
-        width: 100%;
-        height: 100%;
-        margin: 0;
-      }
-
-      body {
-        background: #f4f1ea;
-        color: #24221f;
-        font-family: Inter, "SF Pro Text", system-ui, sans-serif;
-      }
-
-      .acorn-startup-fallback {
-        box-sizing: border-box;
-        display: grid;
-        min-height: 100%;
-        place-items: center;
-        padding: 24px;
-      }
-
-      .acorn-startup-fallback section {
-        box-sizing: border-box;
-        width: min(100%, 480px);
-        padding: 24px;
-        border: 1px solid #d7d1c6;
-        border-radius: 12px;
-        background: #fffdf8;
-      }
-
-      .acorn-startup-fallback h1 {
-        margin: 0;
-        font-size: 20px;
-      }
-
-      .acorn-startup-fallback p {
-        margin: 12px 0 0;
-        color: #686158;
-        font-size: 14px;
-        line-height: 1.6;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        body {
-          background: #1f2326;
-          color: #ededed;
-        }
-
-        .acorn-startup-fallback section {
-          border-color: #3a3f43;
-          background: #272b2f;
-        }
-
-        .acorn-startup-fallback p {
-          color: #a5aaad;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="/startup-fallback.css" />
   </head>
 
   <body>

--- a/public/startup-fallback.css
+++ b/public/startup-fallback.css
@@ -1,0 +1,72 @@
+/*
+ * Styles the pre-hydration shell in `index.html` so a failed bundle load still
+ * renders a readable message.
+ *
+ * This lives in `public/` and is linked rather than inlined on purpose. Tauri
+ * rewrites the configured CSP when `index.html` contains an inline <style>: it
+ * appends a `nonce-` source to `style-src` and stamps that nonce on the inline
+ * tag. Per CSP, a nonce source makes the browser ignore `'unsafe-inline'`, so
+ * every stylesheet injected at runtime without that nonce is blocked — which
+ * includes the <style> elements xterm.js creates for terminal font metrics and
+ * the ANSI palette. A linked stylesheet is covered by `style-src 'self'` and
+ * leaves the configured policy untouched.
+ */
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: #f4f1ea;
+  color: #24221f;
+  font-family: Inter, "SF Pro Text", system-ui, sans-serif;
+}
+
+.acorn-startup-fallback {
+  box-sizing: border-box;
+  display: grid;
+  min-height: 100%;
+  place-items: center;
+  padding: 24px;
+}
+
+.acorn-startup-fallback section {
+  box-sizing: border-box;
+  width: min(100%, 480px);
+  padding: 24px;
+  border: 1px solid #d7d1c6;
+  border-radius: 12px;
+  background: #fffdf8;
+}
+
+.acorn-startup-fallback h1 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.acorn-startup-fallback p {
+  margin: 12px 0 0;
+  color: #686158;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #1f2326;
+    color: #ededed;
+  }
+
+  .acorn-startup-fallback section {
+    border-color: #3a3f43;
+    background: #272b2f;
+  }
+
+  .acorn-startup-fallback p {
+    color: #a5aaad;
+  }
+}

--- a/src/index-html-csp.test.ts
+++ b/src/index-html-csp.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import indexHtml from "../index.html?raw";
+
+describe("index.html", () => {
+  // Tauri appends a `nonce-` source to `style-src` when index.html carries an
+  // inline <style>. A nonce source makes the browser ignore 'unsafe-inline',
+  // which blocks every stylesheet injected at runtime — including the ones
+  // xterm.js creates for terminal font metrics and the ANSI palette. Keep the
+  // pre-hydration styles in a linked file so the configured CSP is what ships.
+  it("carries no inline <style>, so Tauri leaves style-src alone", () => {
+    expect(indexHtml).not.toMatch(/<style[\s>]/i);
+  });
+
+  it("links the startup fallback stylesheet instead", () => {
+    expect(indexHtml).toContain('href="/startup-fallback.css"');
+  });
+});


### PR DESCRIPTION
## Summary

The startup fallback shell shipped its CSS as an inline `<style>` in `index.html`, which silently turned off `'unsafe-inline'` for the whole app and broke terminal rendering in release builds.

1. **Root cause — Tauri rewrites `style-src` when `index.html` has an inline style.** `tauri-utils` stamps `__TAURI_STYLE_NONCE__` on every `<style>` tag it finds in the HTML, and `set_csp` then appends a matching `'nonce-…'` source to `style-src`. Per CSP, a nonce source makes the browser ignore `'unsafe-inline'`, so every stylesheet injected at runtime without that nonce is blocked.
2. **Impact — xterm.js publishes terminal styling through runtime `<style>` elements.** Font family, font size and the ANSI palette all arrive that way, so the terminal lost them: rows fell back to the inline `body` font (`Inter`, `16px`), block-drawing glyphs rendered as tofu, and `.xterm-fg-*` spans painted in the default colour.
3. **Fix — move the pre-hydration styles to a linked stylesheet.** `public/startup-fallback.css` is covered by the existing `style-src 'self'`, so no nonce is generated, the shipped policy is the configured one, and the fallback shell still renders when the bundle fails to load.
4. **Regression guard.** `src/index-html-csp.test.ts` fails if an inline `<style>` returns to `index.html` or the link is dropped.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Effective `style-src` | `'self' 'unsafe-inline' 'nonce-…'` — `'unsafe-inline'` ignored | `'self' 'unsafe-inline'` as configured |
| Terminal font | `Inter, "SF Pro Text", system-ui, sans-serif` at `16px` | configured stack at the configured size |
| ANSI colours | `.xterm-fg-*` spans present but unstyled | rendered |
| Box/block glyphs | tofu | rendered |
| Startup fallback shell | styled | styled |

## Design notes

Only release builds were affected. Vite serves `index.html` directly in development, so `set_csp` never runs there and dev sessions looked healthy — which is why the regression hid behind "works on my machine" for a while.

The alternative was `dangerousDisableAssetCspModification: ["style-src"]`, which keeps the inline style but opts the app out of Tauri's CSP hardening. Linking the stylesheet keeps that hardening intact and needs no configuration flag, so it wins on both counts.

`public/` is copied verbatim by Vite, so the linked file is a sibling of `index.html` in the bundle rather than a hashed asset. A failure that prevents the JS bundle from loading therefore does not prevent the fallback CSS from loading.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1457 passed across 124 files, including the new `index.html` guard.
- [x] Local production-profile build installed to `/Applications/Acorn.app`, then the live DOM was read back from the running webview: `.xterm-rows` computes to `Jetendard, "JetBrains Mono", "Monoplex KR", "Yeomil Mono", Menlo, monospace` at `11.5px` with `.xterm-fg-*` spans styled. Before the fix the same probe reported `Inter, "SF Pro Text", system-ui, sans-serif` at `16px` with zero styled colour spans.
- [x] The running app reported a `style-src-elem` CSP violation for every runtime `<style>` before the fix; no violation after it.
- [x] Startup fallback shell still renders with its own styling.

## Notes

The inline `<style>` arrived in #839, which added the startup fallback shell. Nothing about that feature is reverted here — only where its CSS lives.
