### PR TITLE
fix(notifications): stop asking desktop for a mobile-only click listener

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -43,7 +43,6 @@
     },
     "notification:allow-is-permission-granted",
     "notification:allow-request-permission",
-    "notification:allow-notify",
-    "notification:allow-register-listener"
+    "notification:allow-notify"
   ]
 }

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -39,6 +39,15 @@ import { useAppStore } from "../store";
 
 const originalOpenSessionSurface = useAppStore.getState().openSessionSurface;
 
+// `startNotificationClickHandler` only registers on the mobile builds that
+// implement the plugin's `register_listener` command, so the click tests have
+// to look like one.
+function pretendMobilePlatform(): void {
+  vi.spyOn(navigator, "userAgent", "get").mockReturnValue(
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36",
+  );
+}
+
 const BASE_SESSION: Session = {
   id: "session-1",
   name: "Agent",
@@ -70,6 +79,9 @@ describe("notifications", () => {
   beforeEach(() => {
     resetNotificationsForTests();
     vi.clearAllMocks();
+    // Drop any platform spy a previous test installed so each case starts on
+    // the real (desktop) navigator.
+    vi.restoreAllMocks();
     mocks.isPermissionGranted.mockResolvedValue(true);
     mocks.requestPermission.mockResolvedValue("granted");
     mocks.show.mockResolvedValue(undefined);
@@ -186,6 +198,7 @@ describe("notifications", () => {
   });
 
   it("opens the destination session surface when a system notification is clicked", async () => {
+    pretendMobilePlatform();
     const unregister = vi.fn();
     mocks.onAction.mockResolvedValue({ unregister });
     const openSessionSurface = vi.fn(() => true);
@@ -228,7 +241,18 @@ describe("notifications", () => {
     expect(unregister).toHaveBeenCalled();
   });
 
+  it("skips click-listener registration on desktop, where the command does not exist", async () => {
+    const onFailure = vi.fn();
+
+    const dispose = await startNotificationClickHandler(onFailure);
+
+    expect(mocks.onAction).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+    expect(() => dispose()).not.toThrow();
+  });
+
   it("reports click-listener registration failures without rejecting", async () => {
+    pretendMobilePlatform();
     mocks.onAction.mockRejectedValueOnce(new Error("listener denied"));
     const onFailure = vi.fn();
 
@@ -242,6 +266,7 @@ describe("notifications", () => {
   });
 
   it("keeps activity unread when the clicked notification cannot activate the window", async () => {
+    pretendMobilePlatform();
     mocks.onAction.mockResolvedValue({ unregister: vi.fn() });
     mocks.show.mockRejectedValueOnce(new Error("window access denied"));
     const onFailure = vi.fn();

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -276,6 +276,19 @@ async function fire(
 
 export type NotificationClickFailureStage = "registration" | "activation";
 
+/**
+ * Whether this platform implements the notification click listener. Only the
+ * mobile builds of tauri-plugin-notification register the `register_listener`
+ * command that `onAction` calls.
+ */
+export function notificationClickListenerSupported(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return (
+    /Android/i.test(navigator.userAgent) ||
+    /iP(hone|od|ad)/.test(navigator.platform)
+  );
+}
+
 type NotificationClickFailureHandler = (
   stage: NotificationClickFailureStage,
   error: unknown,
@@ -297,6 +310,16 @@ type NotificationClickFailureHandler = (
 export async function startNotificationClickHandler(
   onFailure?: NotificationClickFailureHandler,
 ): Promise<() => void> {
+  // `onAction` invokes the plugin's `register_listener` command, which
+  // tauri-plugin-notification only implements for Android and iOS — its
+  // desktop invoke handler exposes `notify`, `request_permission` and
+  // `is_permission_granted` and nothing else. Asking for it anyway is refused
+  // by the ACL, which surfaced as a startup toast the user cannot act on, so
+  // skip a registration that has never been able to succeed here.
+  if (!notificationClickListenerSupported()) {
+    return () => {};
+  }
+
   let disposed = false;
   const reportFailure = (
     stage: NotificationClickFailureStage,

--- a/src/lib/tauriCapabilities.test.ts
+++ b/src/lib/tauriCapabilities.test.ts
@@ -45,10 +45,15 @@ describe("Tauri core capability", () => {
         "fs:allow-open",
         "fs:allow-read",
         "fs:allow-write",
-        "notification:allow-register-listener",
       ]),
     );
     expect(defaultCapability.permissions).not.toContain("fs:default");
+    // `register_listener` only exists in the mobile builds of
+    // tauri-plugin-notification, so granting it on desktop bought nothing and
+    // the refused call surfaced as a startup toast.
+    expect(defaultCapability.permissions).not.toContain(
+      "notification:allow-register-listener",
+    );
     expect(defaultCapability.permissions).not.toContain("notification:default");
     expect(defaultCapability.permissions).not.toContain("opener:default");
     expect(defaultCapability.permissions).not.toContain(


### PR DESCRIPTION
## Summary

Every launch popped a toast reading `Could not enable notification click handling: Command plugin:notification|registerListener not allowed by ACL`. The call behind it can never succeed on the platforms Acorn ships.

1. **Root cause — `onAction` is a mobile-only API.** `startNotificationClickHandler` calls `onAction` from `@tauri-apps/plugin-notification`, which invokes the `register_listener` command. In `tauri-plugin-notification` that command exists only in the Android and iOS implementations; the desktop plugin registers `notify`, `request_permission` and `is_permission_granted` and nothing else, so the ACL refuses the call.
2. **Fix — do not register where the command does not exist.** `notificationClickListenerSupported()` gates the registration, and the handler returns a no-op disposer on desktop instead of reporting a failure nobody can act on.
3. **Drop the grant that went with it.** `notification:allow-register-listener` was added alongside the tightened capability list, but it can never resolve to a real command in a desktop build, so it only widened the declared surface.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Startup | ACL-refusal toast on every launch | quiet |
| Notification delivery | works | works |
| Permission prompt | works | works |
| Click-to-focus session | never worked on desktop | unchanged; still available to a future mobile build |
| Declared capability surface | includes a command desktop cannot run | matches what desktop actually invokes |

## Design notes

The gate reads the platform from `navigator`, matching how the rest of the codebase does it (`FileExplorer`, `SettingsModal`, `main.tsx`) rather than pulling in `@tauri-apps/plugin-os` for one branch.

The registration path is kept rather than deleted. It is the correct implementation for a mobile build, and the failure was never in the handler itself — only in asking a platform that has no such command.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1458 passed across 124 files.
- [x] `src/lib/notifications.test.ts` — new case asserts desktop registers nothing and reports no failure; the existing click cases now declare a mobile platform so they still exercise the handler.
- [x] `src/lib/tauriCapabilities.test.ts` — asserts the mobile-only grant is gone.

## Notes

Unrelated to #848; that one restored the runtime stylesheets the terminal renders through. This is a separate toast with its own cause.
