### PR TITLE
feat(notifications): focus the session behind a clicked notification

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "ignore",
  "nix 0.31.3",
  "notify",
+ "notify-rust",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -258,7 +259,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -269,7 +270,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1107,7 +1108,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1305,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2588,14 +2589,16 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -2695,7 +2698,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2782,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.17.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -2818,7 +2821,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3112,7 +3115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3678,7 +3681,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4034,7 +4037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4633,7 +4636,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5070,7 +5073,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5110,7 +5113,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5628,7 +5631,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -119,6 +119,11 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-notification = "2"
+# Posted directly (not through the plugin) so a click on the banner can be
+# observed and routed back to the session that raised it.
+# 4.18 is the first release whose response API covers macOS and Windows as
+# well as Linux; the notification plugin's own `^4.11` resolves to it too.
+notify-rust = "4.18"
 tauri-plugin-single-instance = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod fs_explorer;
 mod git_ops;
 mod graph_runs;
 mod ipc;
+mod notifications;
 mod persistence;
 mod power_assertion;
 mod project_settings;
@@ -775,6 +776,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            notifications::notify_session,
             commands::load_status,
             commands::list_sessions,
             commands::create_session,

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -1,0 +1,139 @@
+//! Desktop notifications that can route the user back to a session.
+//!
+//! `tauri-plugin-notification` delivers desktop notifications fire-and-forget:
+//! its desktop implementation maps title, body, icon and sound onto
+//! `notify-rust` and returns, never reading the `extra` payload and never
+//! observing what the user does with the banner. Click routing there is a
+//! mobile-only feature, gated behind a `register_listener` command the desktop
+//! plugin does not register.
+//!
+//! `notify-rust` itself does expose the response on every desktop backend, so
+//! this module posts the notification directly and waits for it. A click on the
+//! body arrives as `NotificationResponse::Default` and is forwarded to the
+//! frontend as [`NOTIFICATION_CLICKED_EVENT`] carrying the originating session
+//! id, which the UI turns into "focus that session".
+
+use notify_rust::NotificationResponse;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Runtime};
+
+use crate::error::AppError;
+
+/// Event emitted when the user activates a session notification.
+pub const NOTIFICATION_CLICKED_EVENT: &str = "notification://clicked";
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationClicked {
+    pub session_id: String,
+}
+
+/// Bundle identity the OS should attribute the notification to.
+///
+/// macOS posts through `mac-notification-sys`, which needs a bundle id it can
+/// resolve; an unbundled dev binary has none, so development builds borrow
+/// Terminal's the same way the notification plugin does. Windows needs the
+/// AppUserModelID to match the installed shortcut for activation callbacks to
+/// come back to us at all.
+#[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
+fn notification_identity(identifier: &str) -> String {
+    if cfg!(target_os = "macos") && tauri::is_dev() {
+        "com.apple.Terminal".to_string()
+    } else {
+        identifier.to_string()
+    }
+}
+
+/// Posts a session notification and forwards a click back to the frontend.
+///
+/// The wait is blocking — every backend parks until the user acts or the banner
+/// closes — so it runs on its own thread. On macOS the wait additionally relies
+/// on the main run loop being pumped, which is true for as long as the app is
+/// alive; if the app exits first the thread dies with it and the click is
+/// simply never delivered.
+#[tauri::command]
+pub fn notify_session<R: Runtime>(
+    app: AppHandle<R>,
+    title: String,
+    body: String,
+    session_id: Option<String>,
+) -> Result<(), AppError> {
+    let identity = notification_identity(&app.config().identifier);
+
+    std::thread::Builder::new()
+        .name("acorn-notification".to_string())
+        .spawn(move || {
+            #[cfg(target_os = "macos")]
+            {
+                // Only the first call in a process takes effect; the plugin may
+                // have claimed it already for a permission probe, and either
+                // way the value is the same.
+                let _ = notify_rust::set_application(&identity);
+            }
+
+            let mut notification = notify_rust::Notification::new();
+            notification.summary(&title).body(&body);
+            #[cfg(windows)]
+            notification.app_id(&identity);
+
+            let handle = match notification.show() {
+                Ok(handle) => handle,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to post session notification");
+                    return;
+                }
+            };
+
+            // Without a session to return to there is nothing to wait for, and
+            // parking a thread on a banner nobody can act on would leak one
+            // thread per notification.
+            let Some(session_id) = session_id else {
+                return;
+            };
+
+            if let Err(error) = handle.wait_for_response(move |response: &NotificationResponse| {
+                if !response.is_default_action() {
+                    return;
+                }
+                if let Err(error) = app.emit(
+                    NOTIFICATION_CLICKED_EVENT,
+                    NotificationClicked { session_id },
+                ) {
+                    tracing::warn!(%error, "failed to deliver notification click");
+                }
+            }) {
+                tracing::debug!(%error, "notification closed without a response");
+            }
+        })
+        .map_err(AppError::Io)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_builds_post_as_the_app_itself() {
+        // `tauri::is_dev()` is false under `cargo test` for a release-shaped
+        // build, and every non-macOS target keeps the identifier regardless.
+        if cfg!(target_os = "macos") && tauri::is_dev() {
+            assert_eq!(
+                notification_identity("io.im-ian.acorn"),
+                "com.apple.Terminal"
+            );
+        } else {
+            assert_eq!(notification_identity("io.im-ian.acorn"), "io.im-ian.acorn");
+        }
+    }
+
+    #[test]
+    fn click_payload_names_the_session_in_the_shape_the_frontend_reads() {
+        let payload = NotificationClicked {
+            session_id: "session-1".to_string(),
+        };
+        let json = serde_json::to_string(&payload).expect("serialize");
+        assert_eq!(json, r#"{"sessionId":"session-1"}"#);
+    }
+}

--- a/src/lib/notifications.test.ts
+++ b/src/lib/notifications.test.ts
@@ -3,9 +3,9 @@ import type { Session } from "./types";
 
 const mocks = vi.hoisted(() => ({
   isPermissionGranted: vi.fn<() => Promise<boolean>>(),
-  onAction: vi.fn(),
   requestPermission: vi.fn<() => Promise<NotificationPermission>>(),
-  sendNotification: vi.fn(),
+  invoke: vi.fn(),
+  listen: vi.fn(),
   show: vi.fn<() => Promise<void>>(),
   unminimize: vi.fn<() => Promise<void>>(),
   setFocus: vi.fn<() => Promise<void>>(),
@@ -13,9 +13,15 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/plugin-notification", () => ({
   isPermissionGranted: mocks.isPermissionGranted,
-  onAction: mocks.onAction,
   requestPermission: mocks.requestPermission,
-  sendNotification: mocks.sendNotification,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
 }));
 
 vi.mock("@tauri-apps/api/window", () => ({
@@ -39,14 +45,14 @@ import { useAppStore } from "../store";
 
 const originalOpenSessionSurface = useAppStore.getState().openSessionSurface;
 
-// `startNotificationClickHandler` only registers on the mobile builds that
-// implement the plugin's `register_listener` command, so the click tests have
-// to look like one.
-function pretendMobilePlatform(): void {
-  vi.spyOn(navigator, "userAgent", "get").mockReturnValue(
-    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36",
-  );
+// `@tauri-apps/api/core` is mocked module-wide, so the store's own commands land
+// on the same spy. Assert against the notification command alone.
+function notifyCalls(): Array<Record<string, unknown>> {
+  return mocks.invoke.mock.calls
+    .filter(([command]) => command === "notify_session")
+    .map(([, payload]) => payload as Record<string, unknown>);
 }
+
 
 const BASE_SESSION: Session = {
   id: "session-1",
@@ -84,6 +90,8 @@ describe("notifications", () => {
     vi.restoreAllMocks();
     mocks.isPermissionGranted.mockResolvedValue(true);
     mocks.requestPermission.mockResolvedValue("granted");
+    mocks.invoke.mockResolvedValue(undefined);
+    mocks.listen.mockResolvedValue(vi.fn());
     mocks.show.mockResolvedValue(undefined);
     mocks.unminimize.mockResolvedValue(undefined);
     mocks.setFocus.mockResolvedValue(undefined);
@@ -127,13 +135,13 @@ describe("notifications", () => {
     });
     await flushPromises();
 
-    expect(mocks.sendNotification).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(notifyCalls()).toEqual([
+      {
         title: "acorn — Agent",
         body: "Awaiting your next input.",
-        extra: { sessionId: "session-1" },
-      }),
-    );
+        sessionId: "session-1",
+      },
+    ]);
     dispose();
   });
 
@@ -154,7 +162,7 @@ describe("notifications", () => {
     await flushPromises();
 
     expect(mocks.isPermissionGranted).toHaveBeenCalledTimes(1);
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
 
     useAppStore.setState({
       sessions: [
@@ -175,7 +183,7 @@ describe("notifications", () => {
     await flushPromises();
 
     expect(mocks.isPermissionGranted).toHaveBeenCalledTimes(2);
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(notifyCalls()).toHaveLength(1);
     dispose();
   });
 
@@ -186,7 +194,7 @@ describe("notifications", () => {
 
     await expect(sendTestNotification()).resolves.toBe("error");
     expect(mocks.requestPermission).not.toHaveBeenCalled();
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
   });
 
   it("keeps an explicit permission denial distinct from probe errors", async () => {
@@ -194,13 +202,12 @@ describe("notifications", () => {
     mocks.requestPermission.mockResolvedValueOnce("denied");
 
     await expect(sendTestNotification()).resolves.toBe("denied");
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
   });
 
   it("opens the destination session surface when a system notification is clicked", async () => {
-    pretendMobilePlatform();
-    const unregister = vi.fn();
-    mocks.onAction.mockResolvedValue({ unregister });
+    const unlisten = vi.fn();
+    mocks.listen.mockResolvedValue(unlisten);
     const openSessionSurface = vi.fn(() => true);
     useAppStore.setState({
       openSessionSurface,
@@ -220,13 +227,16 @@ describe("notifications", () => {
     });
 
     const dispose = await startNotificationClickHandler();
-    const handleAction = mocks.onAction.mock.calls[0]?.[0] as
-      | ((notification: { extra?: Record<string, unknown> }) => void)
+    expect(mocks.listen).toHaveBeenCalledWith(
+      "notification://clicked",
+      expect.any(Function),
+    );
+    const handleClick = mocks.listen.mock.calls[0]?.[1] as
+      | ((event: { payload: { sessionId: string } }) => void)
       | undefined;
-    expect(handleAction).toBeDefined();
-    if (!handleAction) throw new Error("notification action handler missing");
+    if (!handleClick) throw new Error("notification click handler missing");
 
-    handleAction({ extra: { sessionId: "session-1" } });
+    handleClick({ payload: { sessionId: "session-1" } });
     await flushPromises();
 
     expect(openSessionSurface).toHaveBeenCalledWith("session-1", {
@@ -238,22 +248,29 @@ describe("notifications", () => {
     expect(useAppStore.getState().sessionNotifications).toEqual([]);
 
     dispose();
-    expect(unregister).toHaveBeenCalled();
+    expect(unlisten).toHaveBeenCalled();
   });
 
-  it("skips click-listener registration on desktop, where the command does not exist", async () => {
-    const onFailure = vi.fn();
+  it("ignores a click event that names no session", async () => {
+    mocks.listen.mockResolvedValue(vi.fn());
+    const openSessionSurface = vi.fn(() => true);
+    useAppStore.setState({ openSessionSurface });
 
-    const dispose = await startNotificationClickHandler(onFailure);
+    const dispose = await startNotificationClickHandler();
+    const handleClick = mocks.listen.mock.calls[0]?.[1] as
+      | ((event: { payload: { sessionId?: string } }) => void)
+      | undefined;
+    if (!handleClick) throw new Error("notification click handler missing");
 
-    expect(mocks.onAction).not.toHaveBeenCalled();
-    expect(onFailure).not.toHaveBeenCalled();
-    expect(() => dispose()).not.toThrow();
+    handleClick({ payload: {} });
+    await flushPromises();
+
+    expect(openSessionSurface).not.toHaveBeenCalled();
+    dispose();
   });
 
   it("reports click-listener registration failures without rejecting", async () => {
-    pretendMobilePlatform();
-    mocks.onAction.mockRejectedValueOnce(new Error("listener denied"));
+    mocks.listen.mockRejectedValueOnce(new Error("listener denied"));
     const onFailure = vi.fn();
 
     const dispose = await startNotificationClickHandler(onFailure);
@@ -266,8 +283,7 @@ describe("notifications", () => {
   });
 
   it("keeps activity unread when the clicked notification cannot activate the window", async () => {
-    pretendMobilePlatform();
-    mocks.onAction.mockResolvedValue({ unregister: vi.fn() });
+    mocks.listen.mockResolvedValue(vi.fn());
     mocks.show.mockRejectedValueOnce(new Error("window access denied"));
     const onFailure = vi.fn();
     const openSessionSurface = vi.fn(() => true);
@@ -288,12 +304,12 @@ describe("notifications", () => {
       ],
     });
     const dispose = await startNotificationClickHandler(onFailure);
-    const handleAction = mocks.onAction.mock.calls[0]?.[0] as
-      | ((notification: { extra?: Record<string, unknown> }) => void)
+    const handleClick = mocks.listen.mock.calls[0]?.[1] as
+      | ((event: { payload: { sessionId: string } }) => void)
       | undefined;
-    if (!handleAction) throw new Error("notification action handler missing");
+    if (!handleClick) throw new Error("notification click handler missing");
 
-    handleAction({ extra: { sessionId: "session-1" } });
+    handleClick({ payload: { sessionId: "session-1" } });
     await flushPromises();
 
     expect(openSessionSurface).toHaveBeenCalledWith("session-1", {
@@ -324,7 +340,7 @@ describe("notifications", () => {
     });
     await flushPromises();
 
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
     dispose();
   });
 
@@ -383,7 +399,7 @@ describe("notifications", () => {
     });
     await flushPromises();
 
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
     expect(useAppStore.getState().sessionNotifications).toEqual([]);
 
     useAppStore.getState().setSessionSilenced("session-1", false);
@@ -405,7 +421,7 @@ describe("notifications", () => {
     });
     await flushPromises();
 
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(notifyCalls()).toHaveLength(1);
     expect(useAppStore.getState().sessionNotifications).toMatchObject([
       {
         sessionId: "session-1",
@@ -570,7 +586,7 @@ describe("notifications", () => {
     useAppStore.setState({ activeSessionId: "session-1" });
 
     expect(useAppStore.getState().sessionNotifications).toHaveLength(0);
-    expect(mocks.sendNotification).not.toHaveBeenCalled();
+    expect(notifyCalls()).toEqual([]);
     disposeActivity();
     disposeFocusedRead();
   });

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,9 +1,9 @@
 import {
   isPermissionGranted,
-  onAction,
   requestPermission,
-  sendNotification,
 } from "@tauri-apps/plugin-notification";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAppStore } from "../store";
 import { useSettings } from "./settings";
@@ -264,10 +264,10 @@ async function fire(
   const ok = await ensurePermission();
   if (!ok || useAppStore.getState().silencedSessionIds[session.id]) return;
   try {
-    sendNotification({
+    await postNotification({
       title: `${projectNameFor(session)} — ${session.name}`,
       body: STATUS_SENTENCE[next],
-      extra: { sessionId: session.id },
+      sessionId: session.id,
     });
   } catch (err) {
     console.error("[notifications] sendNotification failed", err);
@@ -276,17 +276,31 @@ async function fire(
 
 export type NotificationClickFailureStage = "registration" | "activation";
 
+/** Event the backend emits when the user activates a session notification. */
+export const NOTIFICATION_CLICKED_EVENT = "notification://clicked";
+
+interface NotificationClickedPayload {
+  sessionId: string;
+}
+
 /**
- * Whether this platform implements the notification click listener. Only the
- * mobile builds of tauri-plugin-notification register the `register_listener`
- * command that `onAction` calls.
+ * Posts a notification through Acorn's own command rather than the plugin.
+ *
+ * The plugin's desktop path is fire-and-forget — it never reads `extra` and
+ * never reports what the user did with the banner — so a click could not be
+ * routed anywhere. `notify_session` keeps the session id on the Rust side and
+ * emits {@link NOTIFICATION_CLICKED_EVENT} when the banner is activated.
  */
-export function notificationClickListenerSupported(): boolean {
-  if (typeof navigator === "undefined") return false;
-  return (
-    /Android/i.test(navigator.userAgent) ||
-    /iP(hone|od|ad)/.test(navigator.platform)
-  );
+async function postNotification(input: {
+  title: string;
+  body: string;
+  sessionId: string | null;
+}): Promise<void> {
+  await invoke("notify_session", {
+    title: input.title,
+    body: input.body,
+    sessionId: input.sessionId,
+  });
 }
 
 type NotificationClickFailureHandler = (
@@ -295,31 +309,20 @@ type NotificationClickFailureHandler = (
 ) => void;
 
 /**
- * Registers a listener that fires when the user clicks a session-status
- * notification we sent. Each notification carries the originating session id
- * in its `extra` payload so the handler can route focus directly to that
- * session — bringing the app window forward, switching workspaces if the
- * session lives in a different project, and selecting the tab.
+ * Listens for the backend's notification-click event and routes focus to the
+ * session that raised the notification — bringing the app window forward,
+ * switching workspaces if the session lives in a different project, and
+ * selecting the tab.
  *
- * Returns a cleanup function. Designed to run once at app boot. The Tauri
- * plugin only delivers click events while a listener is attached, so the
- * caller must keep this registration alive for the lifetime of the app.
- * Registration and window-activation failures are reported through
- * `onFailure`; activation failures intentionally leave inbox activity unread.
+ * Returns a cleanup function. Designed to run once at app boot; the backend
+ * only emits while a listener is attached, so the caller must keep this
+ * registration alive for the lifetime of the app. Registration and
+ * window-activation failures are reported through `onFailure`; activation
+ * failures intentionally leave inbox activity unread.
  */
 export async function startNotificationClickHandler(
   onFailure?: NotificationClickFailureHandler,
 ): Promise<() => void> {
-  // `onAction` invokes the plugin's `register_listener` command, which
-  // tauri-plugin-notification only implements for Android and iOS — its
-  // desktop invoke handler exposes `notify`, `request_permission` and
-  // `is_permission_granted` and nothing else. Asking for it anyway is refused
-  // by the ACL, which surfaced as a startup toast the user cannot act on, so
-  // skip a registration that has never been able to succeed here.
-  if (!notificationClickListenerSupported()) {
-    return () => {};
-  }
-
   let disposed = false;
   const reportFailure = (
     stage: NotificationClickFailureStage,
@@ -336,46 +339,47 @@ export async function startNotificationClickHandler(
     }
   };
 
-  let listener: Awaited<ReturnType<typeof onAction>>;
-  try {
-    listener = await onAction((notification) => {
-      if (disposed) return;
-      const sessionId =
-        typeof notification.extra?.sessionId === "string"
-          ? notification.extra.sessionId
-          : null;
-      if (!sessionId) return;
-
-      void (async () => {
+  const focusSession = async (sessionId: string): Promise<void> => {
+    try {
+      const opened = useAppStore
+        .getState()
+        .openSessionSurface(sessionId, { centerInCanvas: true });
+      const win = getCurrentWindow();
+      const restoreAttempts = [
+        () => win.show(),
+        () => win.unminimize(),
+        () => win.setFocus(),
+      ];
+      const restoreFailures: unknown[] = [];
+      for (const run of restoreAttempts) {
         try {
-          const opened = useAppStore
-            .getState()
-            .openSessionSurface(sessionId, { centerInCanvas: true });
-          const win = getCurrentWindow();
-          const restoreAttempts = [
-            () => win.show(),
-            () => win.unminimize(),
-            () => win.setFocus(),
-          ];
-          const restoreFailures: unknown[] = [];
-          for (const run of restoreAttempts) {
-            try {
-              await run();
-            } catch (error) {
-              restoreFailures.push(error);
-            }
-          }
-          if (disposed) return;
-          if (restoreFailures.length > 0) {
-            reportFailure("activation", restoreFailures[0]);
-            return;
-          }
-          if (opened) markSessionNotificationsRead(sessionId);
+          await run();
         } catch (error) {
-          reportFailure("activation", error);
+          restoreFailures.push(error);
         }
-      })();
-    });
+      }
+      if (disposed) return;
+      if (restoreFailures.length > 0) {
+        reportFailure("activation", restoreFailures[0]);
+        return;
+      }
+      if (opened) markSessionNotificationsRead(sessionId);
+    } catch (error) {
+      reportFailure("activation", error);
+    }
+  };
+
+  let unlisten: () => void;
+  try {
+    unlisten = await listen<NotificationClickedPayload>(
+      NOTIFICATION_CLICKED_EVENT,
+      (event) => {
+        if (disposed) return;
+        const sessionId = event.payload?.sessionId;
+        if (typeof sessionId !== "string" || !sessionId) return;
+        void focusSession(sessionId);
+      },
+    );
   } catch (error) {
     reportFailure("registration", error);
     return () => {
@@ -384,7 +388,7 @@ export async function startNotificationClickHandler(
   }
   return () => {
     disposed = true;
-    listener.unregister();
+    unlisten();
   };
 }
 
@@ -402,9 +406,10 @@ export async function sendTestNotification(): Promise<"sent" | "denied" | "error
   try {
     const ok = await refreshPermission();
     if (!ok) return "denied";
-    sendNotification({
+    await postNotification({
       title: "Acorn — test notification",
       body: "If you can see this, system notifications are working.",
+      sessionId: null,
     });
     return "sent";
   } catch (err) {


### PR DESCRIPTION
## Summary

Clicking a session notification did nothing on any platform Acorn ships. This routes the click back to the session that raised it.

1. **Root cause — the plugin's desktop path is fire-and-forget.** `tauri-plugin-notification` maps title, body, icon and sound onto notify-rust and returns. It never reads the `extra` payload and never observes what the user does with the banner, so there was neither a click to react to nor a session id to react with. Click routing exists only in its mobile builds, behind a `register_listener` command the desktop plugin does not register.
2. **Post the notification from Acorn instead.** The new `notify_session` command keeps the session id on the Rust side, shows the notification through notify-rust, and waits for the banner's response on a dedicated thread. A body activation arrives as `NotificationResponse::Default` and is emitted to the frontend as `notification://clicked`.
3. **Reuse the existing focus path.** The frontend listens for that event and runs what the mobile handler used to: open the session surface, restore and focus the window, mark the activity read. Activation failures still leave the inbox unread.
4. **One notify-rust for the whole tree.** 4.18 is the first release whose response API covers macOS and Windows as well as Linux, so one code path serves all three. The plugin's own `^4.11` resolves to the same version.

## Expected impact

| Area | Before | After |
| --- | --- | --- |
| Click a session notification | nothing happens | window restores and the session tab is selected |
| Notification delivery | plugin `sendNotification` | Acorn's `notify_session`, same notify-rust backend |
| Permission probe / prompt | plugin | plugin, unchanged |
| Session id on the wire | dropped by the desktop plugin | held in Rust, returned with the click |
| Threads per notification | none | one while a banner with a session is on screen |

## Design notes

The wait blocks on every backend, so it runs on its own thread rather than the async runtime. On macOS the wait also relies on the main run loop being pumped, which holds for as long as the app is alive; if the app exits first the thread goes with it and the click is simply never delivered.

A notification without a session id — the Settings test notification — skips the wait entirely. Parking a thread on a banner that has nowhere to return to would leak one thread per notification.

The bundle identity is resolved once per call: macOS dev builds borrow Terminal's identifier the way the plugin does, since an unbundled binary has none, and Windows needs the AppUserModelID to match the installed shortcut for activation to come back at all.

## Follow-up (not in this PR)

Action buttons ("Open", "Silence") are reachable from the same response type but need product decisions about which actions belong on a status notification.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1458 passed across 124 files, including the rewritten click tests.
- [x] `cargo test -p acorn notifications` — 3 passed.
- [x] `cargo fmt --check` — clean.
- [x] Local production-profile build installed to `/Applications/Acorn.app`: the Settings test notification is delivered, and activating a session-status banner brings the window forward and selects that session.

## Notes

The click path is verified by hand on macOS. Windows and Linux share the same code and are covered by CI's build and E2E jobs, but their banner activation has not been exercised on real hardware here.
