### PR TITLE
chore(release): v1.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.32.1",
+  "version": "1.33.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.32.1"
+version = "1.33.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.32.1"
+version = "1.33.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.32.1",
+  "version": "1.33.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.33.0 from `main`, publishing the 69 commits merged since v1.32.1 — a broad error-handling hardening sweep, three new features, and a local trust-boundary security pass.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.32.1 to 1.33.0.
2. **Release scope** — 58 fixes, 3 features (#850 notification focus, #835 safe control-session self close, #781 bulk worktree deletion), 1 security hardening pass (#833), plus rustfmt gating (#840, #842) and dependency group bumps.
3. **Publication path** — builds both macOS architectures and the Windows x64 NSIS updater pair, then publishes a three-platform `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Error handling | A large sweep converts silently-swallowed filesystem, Git, clipboard, IPC, and notification access failures into surfaced, actionable errors instead of empty or "absent" states. |
| Notifications | Clicking a notification focuses the session behind it; desktop no longer registers a mobile-only click listener. |
| Worktrees / projects | Unused worktrees can be deleted in bulk; unreadable worktree registrations fail closed rather than reading as absent. |
| Terminal | Wheel scrolling emits one report per scrolled line, with a configurable scroll speed. |
| Daemon | Authenticated cross-version handshakes are restored. |
| Security | Local trust boundaries and release delivery are hardened (#833). |
| Updater | Publishes a minor update for both macOS architectures and Windows x64. |

## Design notes

- 1.33.0 is a minor release because it adds three user-visible features on top of the fix sweep, without changing compatibility contracts.
- This PR changes version metadata only; every change it publishes was reviewed and merged independently.
- Release notes are generated from changelog-labelled merged PRs. This version PR carries `skip-changelog` so it is excluded from them.

## Follow-up (not in this PR)

- Push annotated tag `v1.33.0` after merge.
- Verify macOS and Windows artifacts, updater signatures, `latest.json`, the Latest pointer, and release-note identity.

## Test plan

- [x] `pnpm install --frozen-lockfile` — succeeds.
- [x] `pnpm run typecheck` — passes.
- [x] `node scripts/validate-release-version.mjs v1.33.0` — all four version sources match.
- [x] `node scripts/validate-release-version.mjs --assert-newer v1.33.0 v1.32.1` — minor ordering passes.
- [x] Locked Cargo metadata reports Acorn `1.33.0`.
- [x] Release-focused Vitest (`scripts/`) — 4 files, 30 tests pass.
- [x] `git diff --check` — passes.
- [x] `main` CI at the release commit (11692792) — green: 7 checks passed. PR #852 CI — 7 checks passed.
