### PR TITLE
fix(terminal): keep agent overlay TUIs painting in the embedded xterm

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/protocol.rs
+++ b/src-tauri/crates/acorn-daemon/src/protocol.rs
@@ -29,7 +29,7 @@ pub const PROTOCOL_VERSION_MAJOR: u32 = 1;
 /// Minor version of the protocol. Bumped when adding optional fields or
 /// non-breaking new variants. Reported in the handshake purely for telemetry
 /// and feature detection — not used for compatibility gating.
-pub const PROTOCOL_VERSION_MINOR: u32 = 1;
+pub const PROTOCOL_VERSION_MINOR: u32 = 2;
 
 /// First frame on every fresh connection. Both daemon and client send their
 /// own `Hello`; either side may close the connection if the major version
@@ -137,6 +137,13 @@ pub enum ControlPayload {
         target_session_id: Uuid,
         cols: u16,
         rows: u16,
+        /// CSS-pixel window size from the xterm renderer. `0` means
+        /// unknown; overlay TUIs that read `TIOCGWINSZ` then cannot
+        /// size pixel-backed layout.
+        #[serde(default)]
+        pixel_width: u16,
+        #[serde(default)]
+        pixel_height: u16,
     },
     /// Read the tail of a session's scrollback ring. Returns up to
     /// `max_bytes` of the freshest output. Pure read — does not drain.
@@ -185,11 +192,17 @@ pub struct SpawnSpec {
     /// (which is the user-login environment captured at daemon spawn).
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
-    /// Initial window size. `0` falls back to `80x24`.
+    /// Initial window size. `0` cols/rows fall back to `80x24`. Pixel
+    /// fields of `0` mean "unknown"; overlay TUIs then skip pixel-backed
+    /// layout until a later resize supplies them.
     #[serde(default)]
     pub cols: u16,
     #[serde(default)]
     pub rows: u16,
+    #[serde(default)]
+    pub pixel_width: u16,
+    #[serde(default)]
+    pub pixel_height: u16,
     /// Session classification (regular / control). Mirrors the
     /// `SessionKind` enum in `acorn_session`. The daemon preserves it
     /// in metadata so reattach can re-augment the env on respawn.
@@ -409,7 +422,14 @@ pub enum StreamFrame {
     /// PTY stdin bytes (client → daemon).
     Input { data_b64: String },
     /// Resize (client → daemon).
-    Resize { cols: u16, rows: u16 },
+    Resize {
+        cols: u16,
+        rows: u16,
+        #[serde(default)]
+        pixel_width: u16,
+        #[serde(default)]
+        pixel_height: u16,
+    },
     /// PTY child exited (daemon → client). After this frame the daemon
     /// closes the stream; further input is dropped.
     Exit { code: Option<i32> },
@@ -507,6 +527,48 @@ mod tests {
         let s = serde_json::to_string(&f).unwrap();
         let parsed: StreamFrame = serde_json::from_str(&s).unwrap();
         assert_eq!(parsed, f);
+    }
+
+    #[test]
+    fn resize_payloads_default_missing_pixel_fields() {
+        let id = Uuid::new_v4();
+        let control: ControlPayload = serde_json::from_value(serde_json::json!({
+            "kind": "resize",
+            "target_session_id": id,
+            "cols": 80,
+            "rows": 24
+        }))
+        .unwrap();
+        match control {
+            ControlPayload::Resize {
+                cols,
+                rows,
+                pixel_width,
+                pixel_height,
+                ..
+            } => {
+                assert_eq!((cols, rows, pixel_width, pixel_height), (80, 24, 0, 0));
+            }
+            other => panic!("expected resize, got {other:?}"),
+        }
+
+        let frame: StreamFrame = serde_json::from_value(serde_json::json!({
+            "kind": "resize",
+            "cols": 101,
+            "rows": 37
+        }))
+        .unwrap();
+        match frame {
+            StreamFrame::Resize {
+                cols,
+                rows,
+                pixel_width,
+                pixel_height,
+            } => {
+                assert_eq!((cols, rows, pixel_width, pixel_height), (101, 37, 0, 0));
+            }
+            other => panic!("expected resize, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/crates/acorn-daemon/src/pty.rs
+++ b/src-tauri/crates/acorn-daemon/src/pty.rs
@@ -37,6 +37,16 @@ use super::session::{DaemonSession, SessionRegistry};
 
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
+
+fn pty_window_size(cols: u16, rows: u16, pixel_width: u16, pixel_height: u16) -> PtySize {
+    PtySize {
+        cols: if cols == 0 { DEFAULT_COLS } else { cols },
+        rows: if rows == 0 { DEFAULT_ROWS } else { rows },
+        pixel_width,
+        pixel_height,
+    }
+}
+
 const READ_BUFFER_SIZE: usize = 4096;
 
 /// Tuple returned by `PtyManager::spawn`. The pid is surfaced separately
@@ -163,20 +173,7 @@ impl PtyManager {
             });
         }
 
-        let size = PtySize {
-            cols: if spec.cols == 0 {
-                DEFAULT_COLS
-            } else {
-                spec.cols
-            },
-            rows: if spec.rows == 0 {
-                DEFAULT_ROWS
-            } else {
-                spec.rows
-            },
-            pixel_width: 0,
-            pixel_height: 0,
-        };
+        let size = pty_window_size(spec.cols, spec.rows, spec.pixel_width, spec.pixel_height);
 
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -311,7 +308,14 @@ impl PtyManager {
         writer.flush()
     }
 
-    pub fn resize(&self, id: &Uuid, cols: u16, rows: u16) -> std::io::Result<()> {
+    pub fn resize(
+        &self,
+        id: &Uuid,
+        cols: u16,
+        rows: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> std::io::Result<()> {
         let handle = self
             .handles
             .get(id)
@@ -319,12 +323,7 @@ impl PtyManager {
             .ok_or_else(|| {
                 std::io::Error::new(std::io::ErrorKind::NotFound, format!("no pty for {id}"))
             })?;
-        let size = PtySize {
-            cols: if cols == 0 { DEFAULT_COLS } else { cols },
-            rows: if rows == 0 { DEFAULT_ROWS } else { rows },
-            pixel_width: 0,
-            pixel_height: 0,
-        };
+        let size = pty_window_size(cols, rows, pixel_width, pixel_height);
         // Bind MutexGuard to a local so it drops before `handle` does —
         // returning the chain directly leaves the guard alive past
         // `handle`'s end-of-scope, which the borrow checker rejects.
@@ -533,6 +532,8 @@ mod tests {
             env: HashMap::new(),
             cols: 80,
             rows: 24,
+            pixel_width: 0,
+            pixel_height: 0,
             kind: crate::protocol::SessionKind::Regular,
             repo_path: None,
             branch: None,
@@ -662,7 +663,7 @@ mod tests {
         spec.args = vec!["-NoLogo".to_string(), "-NoProfile".to_string()];
 
         manager.spawn(spec, registry).unwrap();
-        manager.resize(&id, 101, 37).unwrap();
+        manager.resize(&id, 101, 37, 0, 0).unwrap();
 
         // Interactive PowerShell asks the terminal for its cursor position
         // before presenting the first prompt. xterm.js answers this DSR in the

--- a/src-tauri/crates/acorn-daemon/src/server.rs
+++ b/src-tauri/crates/acorn-daemon/src/server.rs
@@ -401,7 +401,12 @@ impl Daemon {
                 target_session_id,
                 cols,
                 rows,
-            } => match self.pty.resize(&target_session_id, cols, rows) {
+                pixel_width,
+                pixel_height,
+            } => match self
+                .pty
+                .resize(&target_session_id, cols, rows, pixel_width, pixel_height)
+            {
                 Ok(()) => ControlResult::Ack,
                 Err(err) => ControlResult::Error {
                     code: io_error_to_code(&err),
@@ -598,8 +603,19 @@ impl Daemon {
                                 let _ = pty_for_input.write(&session_id, &b);
                             }
                         }
-                        StreamFrame::Resize { cols, rows } => {
-                            let _ = pty_for_input.resize(&session_id, cols, rows);
+                        StreamFrame::Resize {
+                            cols,
+                            rows,
+                            pixel_width,
+                            pixel_height,
+                        } => {
+                            let _ = pty_for_input.resize(
+                                &session_id,
+                                cols,
+                                rows,
+                                pixel_width,
+                                pixel_height,
+                            );
                         }
                         StreamFrame::ClientNote { .. } => {} // telemetry-only
                         _ => {} // daemon-bound frames from client are ignored

--- a/src-tauri/crates/acorn-pty/src/lib.rs
+++ b/src-tauri/crates/acorn-pty/src/lib.rs
@@ -28,6 +28,16 @@ use uuid::Uuid;
 
 const DEFAULT_COLS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
+
+fn pty_window_size(cols: u16, rows: u16, pixel_width: u16, pixel_height: u16) -> PtySize {
+    PtySize {
+        cols: if cols == 0 { DEFAULT_COLS } else { cols },
+        rows: if rows == 0 { DEFAULT_ROWS } else { rows },
+        pixel_width,
+        pixel_height,
+    }
+}
+
 const READ_BUFFER_SIZE: usize = 4096;
 
 /// Hard cap on the per-session in-memory tail buffer used by the
@@ -159,7 +169,9 @@ impl PtyManager {
 
     /// Spawn a new PTY-backed process for the given session.
     ///
-    /// `cols`/`rows` of 0 fall back to 80x24.
+    /// `cols`/`rows` of 0 fall back to 80x24. Pixel dimensions of 0 mean
+    /// unknown; overlay TUIs that read `TIOCGWINSZ` then wait for a later
+    /// resize that supplies real CSS-pixel sizes.
     ///
     /// `env_applier` is called once with the freshly built `CommandBuilder`,
     /// before spawn. The host crate uses it to layer Acorn's render-capability
@@ -167,6 +179,7 @@ impl PtyManager {
     /// `CommandBuilder`'s base — keeping that policy in the host crate (it
     /// depends on `crate::shell_env`) without dragging those modules into
     /// the pty crate.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn<R, F>(
         &self,
         app: AppHandle<R>,
@@ -178,6 +191,8 @@ impl PtyManager {
         env_applier: F,
         cols: u16,
         rows: u16,
+        pixel_width: u16,
+        pixel_height: u16,
     ) -> PtyResult<()>
     where
         R: Runtime,
@@ -189,12 +204,7 @@ impl PtyManager {
             )));
         }
 
-        let size = PtySize {
-            cols: if cols == 0 { DEFAULT_COLS } else { cols },
-            rows: if rows == 0 { DEFAULT_ROWS } else { rows },
-            pixel_width: 0,
-            pixel_height: 0,
-        };
+        let size = pty_window_size(cols, rows, pixel_width, pixel_height);
 
         let pty_system = native_pty_system();
         let pair = pty_system
@@ -296,18 +306,20 @@ impl PtyManager {
     }
 
     /// Resize the PTY window.
-    pub fn resize(&self, session_id: &Uuid, cols: u16, rows: u16) -> PtyResult<()> {
+    pub fn resize(
+        &self,
+        session_id: &Uuid,
+        cols: u16,
+        rows: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> PtyResult<()> {
         let handle = self
             .handles
             .get(session_id)
             .ok_or_else(|| PtyError::Other(format!("no pty for session {session_id}")))?
             .clone();
-        let size = PtySize {
-            cols: if cols == 0 { DEFAULT_COLS } else { cols },
-            rows: if rows == 0 { DEFAULT_ROWS } else { rows },
-            pixel_width: 0,
-            pixel_height: 0,
-        };
+        let size = pty_window_size(cols, rows, pixel_width, pixel_height);
         handle
             .master
             .lock()

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8785,6 +8785,8 @@ pub async fn pty_spawn<R: Runtime>(
     env: Option<HashMap<String, String>>,
     cols: Option<u16>,
     rows: Option<u16>,
+    pixel_width: Option<u16>,
+    pixel_height: Option<u16>,
     replay_scrollback: Option<bool>,
     output_token: Option<u64>,
 ) -> AppResult<()> {
@@ -8801,6 +8803,8 @@ pub async fn pty_spawn<R: Runtime>(
             env,
             cols,
             rows,
+            pixel_width,
+            pixel_height,
             replay_scrollback,
             output_token,
         )
@@ -8817,6 +8821,8 @@ fn pty_spawn_blocking<R: Runtime>(
     env: Option<HashMap<String, String>>,
     cols: Option<u16>,
     rows: Option<u16>,
+    pixel_width: Option<u16>,
+    pixel_height: Option<u16>,
     replay_scrollback: Option<bool>,
     output_token: Option<u64>,
 ) -> AppResult<()> {
@@ -9040,6 +9046,8 @@ fn pty_spawn_blocking<R: Runtime>(
             &effective_env,
             cols.unwrap_or(0),
             rows.unwrap_or(0),
+            pixel_width.unwrap_or(0),
+            pixel_height.unwrap_or(0),
             output_token,
             replay_scrollback.unwrap_or(true),
         )
@@ -9065,6 +9073,8 @@ fn pty_spawn_blocking<R: Runtime>(
             |cmd| crate::pty_env::apply_layered_env(cmd, effective_env),
             cols.unwrap_or(0),
             rows.unwrap_or(0),
+            pixel_width.unwrap_or(0),
+            pixel_height.unwrap_or(0),
         )
         .map_err(|e| AppError::Pty(e.to_string()))
 }
@@ -9083,6 +9093,7 @@ fn should_route_session_to_daemon(enabled: bool, daemon_session_id: Option<Uuid>
 ///    it already restored an xterm-rendered disk snapshot.
 /// 3. **No live session** — fresh daemon spawn, attach the stream,
 ///    persist `daemon_session_id` so the next restart hits case 2.
+#[allow(clippy::too_many_arguments)]
 fn spawn_via_daemon<R: Runtime>(
     app: &AppHandle<R>,
     state: &AppState,
@@ -9093,6 +9104,8 @@ fn spawn_via_daemon<R: Runtime>(
     env: &HashMap<String, String>,
     cols: u16,
     rows: u16,
+    pixel_width: u16,
+    pixel_height: u16,
     output_token: Option<u64>,
     replay_scrollback: bool,
 ) -> Result<(), String> {
@@ -9184,6 +9197,8 @@ fn spawn_via_daemon<R: Runtime>(
             env.clone(),
             cols,
             rows,
+            pixel_width,
+            pixel_height,
             kind,
             repo_path,
             branch,
@@ -9325,17 +9340,21 @@ pub fn pty_resize(
     session_id: String,
     cols: u16,
     rows: u16,
+    pixel_width: Option<u16>,
+    pixel_height: Option<u16>,
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
+    let pixel_width = pixel_width.unwrap_or(0);
+    let pixel_height = pixel_height.unwrap_or(0);
     if daemon_session_alive_or_attached(&state, id) {
         return state
             .daemon_bridge
-            .resize(id, cols, rows)
+            .resize(id, cols, rows, pixel_width, pixel_height)
             .map_err(|e| AppError::Pty(e.to_string()));
     }
     state
         .pty
-        .resize(&id, cols, rows)
+        .resize(&id, cols, rows, pixel_width, pixel_height)
         .map_err(|e| AppError::Pty(e.to_string()))
 }
 
@@ -13134,6 +13153,8 @@ mod tests {
                 |_| {},
                 80,
                 24,
+                0,
+                0,
             )
             .expect("spawn test PTY");
 
@@ -17303,6 +17324,8 @@ mod tests {
                 |_| {},
                 80,
                 24,
+                0,
+                0,
             )
             .expect("spawn peer PTY in linked worktree");
 

--- a/src-tauri/src/daemon_bridge.rs
+++ b/src-tauri/src/daemon_bridge.rs
@@ -516,6 +516,7 @@ impl DaemonBridge {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         &self,
         session_id: Uuid,
@@ -526,6 +527,8 @@ impl DaemonBridge {
         env: std::collections::HashMap<String, String>,
         cols: u16,
         rows: u16,
+        pixel_width: u16,
+        pixel_height: u16,
         kind: SessionKind,
         repo_path: Option<PathBuf>,
         branch: Option<String>,
@@ -541,6 +544,8 @@ impl DaemonBridge {
             env,
             cols,
             rows,
+            pixel_width,
+            pixel_height,
             kind,
             repo_path,
             branch,
@@ -579,11 +584,20 @@ impl DaemonBridge {
         }
     }
 
-    pub fn resize(&self, target: Uuid, cols: u16, rows: u16) -> BridgeResult<()> {
+    pub fn resize(
+        &self,
+        target: Uuid,
+        cols: u16,
+        rows: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> BridgeResult<()> {
         match Self::unpack_error(self.call(ControlPayload::Resize {
             target_session_id: target,
             cols,
             rows,
+            pixel_width,
+            pixel_height,
         })?)? {
             ControlResult::Ack => Ok(()),
             other => Err(unexpected(other)),

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -1494,6 +1494,8 @@ mod tests {
                 |_| {},
                 80,
                 24,
+                0,
+                0,
             )
             .expect("spawn unrelated PTY");
         let sibling_pid = state.pty.child_pid(&sibling.id).expect("unrelated pid");
@@ -1535,6 +1537,8 @@ mod tests {
                     |_| {},
                     80,
                     24,
+                    0,
+                    0,
                 )
                 .expect("spawn source PTY tree");
             state
@@ -1549,6 +1553,8 @@ mod tests {
                     |_| {},
                     80,
                     24,
+                    0,
+                    0,
                 )
                 .expect("spawn owned worker PTY");
 

--- a/src-tauri/src/pty_env.rs
+++ b/src-tauri/src/pty_env.rs
@@ -21,6 +21,13 @@ use portable_pty::CommandBuilder;
 pub const RENDER_CAPABILITY: &[(&str, &str)] =
     &[("TERM", "xterm-256color"), ("COLORTERM", "truecolor")];
 
+/// Identity this xterm.js PTY advertises after inherited host fingerprints
+/// are stripped. Agent TUIs special-case `TERM_PROGRAM=Apple_Terminal` /
+/// `iTerm.app` and emit sequences those emulators handle; Acorn is not
+/// them. A stable non-empty value keeps the child from inheriting the
+/// host emulator's name (and vscode shell-integration hooks in user rc).
+pub const TERMINAL_IDENTITY: &[(&str, &str)] = &[("TERM_PROGRAM", "Acorn")];
+
 const HOST_TERMINAL_ENV: &[&str] = &[
     "TERM_PROGRAM",
     "TERM_PROGRAM_VERSION",
@@ -132,6 +139,7 @@ pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>)
     }
 
     apply_render_capability_backstop(cmd);
+    apply_terminal_identity_backstop(cmd);
 }
 
 /// Refuse empty `TERM` / `COLORTERM`. Replays after every other layer
@@ -144,6 +152,17 @@ pub fn apply_layered_env(cmd: &mut CommandBuilder, env: HashMap<String, String>)
 /// falling back to plain output.
 pub fn apply_render_capability_backstop(cmd: &mut CommandBuilder) {
     for (k, v) in RENDER_CAPABILITY {
+        if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
+            cmd.env(k, v);
+        }
+    }
+}
+
+/// Stamp `TERM_PROGRAM=Acorn` when no caller override remains. Inherited
+/// host values are already stripped; without a replacement the child has
+/// no terminal identity of its own.
+pub fn apply_terminal_identity_backstop(cmd: &mut CommandBuilder) {
+    for (k, v) in TERMINAL_IDENTITY {
         if cmd.get_env(*k).map_or(true, |s| s.is_empty()) {
             cmd.env(k, v);
         }
@@ -215,8 +234,22 @@ mod tests {
         cmd.env("TERM_PROGRAM", "Apple_Terminal");
         cmd.env("TERM_SESSION_ID", "abc123");
         apply_layered_env(&mut cmd, HashMap::new());
-        assert_eq!(cmd.get_env("TERM_PROGRAM"), None);
+        assert_eq!(
+            cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
+            Some("Acorn"),
+        );
         assert_eq!(cmd.get_env("TERM_SESSION_ID"), None);
+    }
+
+    #[test]
+    fn layered_env_stamps_acorn_terminal_identity_by_default() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        apply_layered_env(&mut cmd, HashMap::new());
+        assert_eq!(
+            cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
+            Some("Acorn"),
+        );
     }
 
     #[test]
@@ -229,6 +262,18 @@ mod tests {
         assert_eq!(
             cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
             Some("AcornTest"),
+        );
+    }
+
+    #[test]
+    fn terminal_identity_backstop_overrides_empty_string() {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.env_clear();
+        cmd.env("TERM_PROGRAM", "");
+        apply_terminal_identity_backstop(&mut cmd);
+        assert_eq!(
+            cmd.get_env("TERM_PROGRAM").and_then(|s| s.to_str()),
+            Some("Acorn"),
         );
     }
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -41,6 +41,11 @@ import {
   repaintTerminalViewport,
 } from "../lib/terminalRepaint";
 import {
+  ptyPixelSize,
+  shouldForceCommandPtyResize,
+  xtversionReplyForParams,
+} from "../lib/terminalPtySize";
+import {
   createTerminalOutputWriter,
   type TerminalOutputWriter,
 } from "../lib/terminalOutputWriter";
@@ -783,6 +788,13 @@ export function Terminal({
       scrollSensitivity: initialSettings.terminal.scrollSpeed,
       cursorBlink: isFocusedPane,
       allowProposedApi: true,
+      // CSI 14/16/18 t (pixel and cell size). Overlay TUIs query these
+      // before drawing; xterm.js ignores them unless these flags are on.
+      windowOptions: {
+        getWinSizePixels: true,
+        getCellSizePixels: true,
+        getWinSizeChars: true,
+      },
       // Let Option+drag force a local selection even while a TUI has mouse
       // tracking on (`?1000`–`?1006`); the left-drag takeover relies on this to
       // replay a forced selection into xterm. Gated on the paste setting so a
@@ -1407,6 +1419,18 @@ export function Terminal({
     const sendToPty = (data: string) => {
       writeToPty(sessionId, data);
     };
+    // xterm.js does not answer CSI > 0 q (XTVERSION). Grok uses that
+    // probe to treat the emulator as xterm.js and keep overlay TUIs on
+    // the non-kitty path.
+    const xtversionParserDisposable = term.parser.registerCsiHandler(
+      { prefix: ">", final: "q" },
+      (params) => {
+        const reply = xtversionReplyForParams(params);
+        if (!reply) return false;
+        sendToPty(reply);
+        return true;
+      },
+    );
     const sendUserInputToPty = (data: string) => {
       if (data.length === 0) return;
       const state = useAppStore.getState();
@@ -2397,32 +2421,53 @@ export function Terminal({
       | {
           cols: number;
           rows: number;
+          pixelWidth: number;
+          pixelHeight: number;
         }
       | null = null;
+    const currentPtySize = () => {
+      const cols = term.cols;
+      const rows = term.rows;
+      const pixels = ptyPixelSize(cols, rows, terminalCellDims(term));
+      return {
+        cols,
+        rows,
+        pixelWidth: pixels.pixelWidth,
+        pixelHeight: pixels.pixelHeight,
+      };
+    };
     const sendPtyResize = (
       force = false,
-      size: { cols: number; rows: number } = {
-        cols: term.cols,
-        rows: term.rows,
-      },
+      size: {
+        cols: number;
+        rows: number;
+        pixelWidth: number;
+        pixelHeight: number;
+      } = currentPtySize(),
     ) => {
       if (!ptyReady || size.cols <= 0 || size.rows <= 0) return;
       if (
         !force &&
         lastPtyResize?.cols === size.cols &&
-        lastPtyResize.rows === size.rows
+        lastPtyResize.rows === size.rows &&
+        lastPtyResize.pixelWidth === size.pixelWidth &&
+        lastPtyResize.pixelHeight === size.pixelHeight
       ) {
         return;
       }
-      lastPtyResize = { cols: size.cols, rows: size.rows };
+      lastPtyResize = size;
       invoke("pty_resize", {
         sessionId,
         cols: size.cols,
         rows: size.rows,
+        pixelWidth: size.pixelWidth,
+        pixelHeight: size.pixelHeight,
       }).catch((err: unknown) => {
         if (
           lastPtyResize?.cols === size.cols &&
-          lastPtyResize.rows === size.rows
+          lastPtyResize.rows === size.rows &&
+          lastPtyResize.pixelWidth === size.pixelWidth &&
+          lastPtyResize.pixelHeight === size.pixelHeight
         ) {
           lastPtyResize = null;
         }
@@ -2434,10 +2479,11 @@ export function Terminal({
       if (!fit) return;
       repaintTerminalViewport({ container, fit, term });
       // Before a TUI starts, force one backend resize so commands launched
-      // from an already-open shell see the current pane size. Once a TUI has
-      // entered the alternate screen, avoid same-size SIGWINCH pulses; Claude
-      // Code's fullscreen renderer is sensitive to redundant resize redraws.
-      sendPtyResize(term.buffer.active.type !== "alternate");
+      // from an already-open shell see the current pane size. Once a TUI
+      // owns the viewport (alt-screen or mouse tracking), skip same-size
+      // SIGWINCH pulses — overlay TUIs such as `/usage show` redraw on
+      // that pulse and can fail to paint.
+      sendPtyResize(shouldForceCommandPtyResize(term));
     };
     const commandSizeSyncScheduler = createTerminalRepaintScheduler(
       syncViewportAndPtySize,
@@ -2577,7 +2623,13 @@ export function Terminal({
     window.addEventListener("acorn:terminal-clear", onClearRequested);
 
     const resizeDisposable = term.onResize(({ cols, rows }) => {
-      sendPtyResize(false, { cols, rows });
+      const pixels = ptyPixelSize(cols, rows, terminalCellDims(term));
+      sendPtyResize(false, {
+        cols,
+        rows,
+        pixelWidth: pixels.pixelWidth,
+        pixelHeight: pixels.pixelHeight,
+      });
     });
 
     // Debounce resize-driven `fit()` + SIGWINCH. Without this, dragging the
@@ -2642,8 +2694,7 @@ export function Terminal({
         // "no pty for session".
         //
         // Sessions always drop into the selected native shell on the backend.
-        const spawnCols = term.cols;
-        const spawnRows = term.rows;
+        const spawnSize = currentPtySize();
         const env: Record<string, string> = {};
         if (workspaceId) env.ACORN_WORKSPACE_ID = workspaceId;
         if (workspaceName) env.ACORN_WORKSPACE_NAME = workspaceName;
@@ -2652,8 +2703,10 @@ export function Terminal({
           sessionId,
           cwd,
           env,
-          cols: spawnCols,
-          rows: spawnRows,
+          cols: spawnSize.cols,
+          rows: spawnSize.rows,
+          pixelWidth: spawnSize.pixelWidth,
+          pixelHeight: spawnSize.pixelHeight,
           // Live daemon-backed attaches replay their raw ring as the source of
           // truth. Local snapshots are only restored for dead daemon sessions,
           // where there is no live ring to replay.
@@ -2669,7 +2722,7 @@ export function Terminal({
           return;
         }
         ptyReady = true;
-        lastPtyResize = { cols: spawnCols, rows: spawnRows };
+        lastPtyResize = spawnSize;
         commandSizeSyncScheduler.schedule();
         exited = false;
         // CommandRunDialog may have queued a one-shot command for this
@@ -3116,6 +3169,7 @@ export function Terminal({
       try { cursorStyleParserDisposable.dispose(); } catch { /* ignore */ }
       try { cursorSoftResetParserDisposable.dispose(); } catch { /* ignore */ }
       try { cursorFullResetParserDisposable.dispose(); } catch { /* ignore */ }
+      try { xtversionParserDisposable.dispose(); } catch { /* ignore */ }
       container.removeAttribute("data-acorn-cursor-application-override");
       container.classList.remove(COMPOSING_CLASS);
       try { fitAddon.dispose(); } catch { /* ignore */ }

--- a/src/lib/terminalPtySize.test.ts
+++ b/src/lib/terminalPtySize.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  XTVERSION_REPLY,
+  ptyPixelSize,
+  shouldForceCommandPtyResize,
+  xtversionReplyForParams,
+} from "./terminalPtySize";
+
+function term(type: string, mouseTrackingMode: string) {
+  return {
+    buffer: { active: { type } },
+    modes: { mouseTrackingMode },
+  };
+}
+
+describe("shouldForceCommandPtyResize", () => {
+  it("forces a same-size resize from a normal shell prompt", () => {
+    expect(shouldForceCommandPtyResize(term("normal", "none"))).toBe(true);
+  });
+
+  it("does not force once a TUI has entered the alternate screen", () => {
+    expect(shouldForceCommandPtyResize(term("alternate", "none"))).toBe(false);
+  });
+
+  it("does not force while a TUI has mouse tracking on the normal buffer", () => {
+    expect(shouldForceCommandPtyResize(term("normal", "any"))).toBe(false);
+    expect(shouldForceCommandPtyResize(term("normal", "vt200"))).toBe(false);
+    expect(shouldForceCommandPtyResize(term("normal", "drag"))).toBe(false);
+  });
+});
+
+describe("ptyPixelSize", () => {
+  it("multiplies cell size by the grid", () => {
+    expect(ptyPixelSize(80, 24, { width: 8.5, height: 17 })).toEqual({
+      pixelWidth: 680,
+      pixelHeight: 408,
+    });
+  });
+
+  it("returns zeros when cell metrics are missing or invalid", () => {
+    expect(ptyPixelSize(80, 24, null)).toEqual({
+      pixelWidth: 0,
+      pixelHeight: 0,
+    });
+    expect(ptyPixelSize(80, 24, { width: 0, height: 17 })).toEqual({
+      pixelWidth: 0,
+      pixelHeight: 0,
+    });
+    expect(ptyPixelSize(0, 24, { width: 8, height: 17 })).toEqual({
+      pixelWidth: 0,
+      pixelHeight: 0,
+    });
+  });
+
+  it("clamps to a u16", () => {
+    expect(ptyPixelSize(10_000, 10_000, { width: 20, height: 20 })).toEqual({
+      pixelWidth: 65535,
+      pixelHeight: 65535,
+    });
+  });
+});
+
+describe("xtversionReplyForParams", () => {
+  it("answers XTVERSION (CSI > 0 q) as xterm.js", () => {
+    expect(xtversionReplyForParams([0])).toBe(XTVERSION_REPLY);
+    expect(xtversionReplyForParams([])).toBe(XTVERSION_REPLY);
+  });
+
+  it("ignores other DA3-style version queries", () => {
+    expect(xtversionReplyForParams([1])).toBeNull();
+    expect(xtversionReplyForParams([[1]])).toBeNull();
+  });
+});

--- a/src/lib/terminalPtySize.ts
+++ b/src/lib/terminalPtySize.ts
@@ -1,0 +1,53 @@
+export const XTVERSION_REPLY = "\x1bP>|xterm.js\x1b\\";
+
+const U16_MAX = 65535;
+
+export function shouldForceCommandPtyResize(term: {
+  buffer: { active: { type: string } };
+  modes: { mouseTrackingMode: string };
+}): boolean {
+  // Force a same-size SIGWINCH only before a TUI starts, so a command
+  // launched from an already-open shell sees the current pane size.
+  // Alternate screen or mouse tracking means a TUI already owns the
+  // viewport; pulsing SIGWINCH then shreds overlay redraws.
+  return (
+    term.buffer.active.type !== "alternate" &&
+    term.modes.mouseTrackingMode === "none"
+  );
+}
+
+export function ptyPixelSize(
+  cols: number,
+  rows: number,
+  cell: { width: number; height: number } | null | undefined,
+): { pixelWidth: number; pixelHeight: number } {
+  if (
+    !cell ||
+    cell.width <= 0 ||
+    cell.height <= 0 ||
+    cols <= 0 ||
+    rows <= 0 ||
+    !Number.isFinite(cell.width) ||
+    !Number.isFinite(cell.height)
+  ) {
+    return { pixelWidth: 0, pixelHeight: 0 };
+  }
+  return {
+    pixelWidth: toU16(cols * cell.width),
+    pixelHeight: toU16(rows * cell.height),
+  };
+}
+
+export function xtversionReplyForParams(
+  params: (number | number[])[],
+): string | null {
+  const raw = params[0];
+  const code = Array.isArray(raw) ? raw[0] : (raw ?? 0);
+  if (code !== 0) return null;
+  return XTVERSION_REPLY;
+}
+
+function toU16(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(U16_MAX, Math.round(value));
+}


### PR DESCRIPTION
## Summary

Agent overlay TUIs such as Grok `/usage show` failed to paint inside Acorn's embedded xterm.js PTY.

- Stamp `TERM_PROGRAM=Acorn` after stripping inherited host fingerprints (do not impersonate vscode).
- Answer XTVERSION (`CSI > 0 q`) as `xterm.js` so Grok stays on the non-kitty overlay path.
- Enable xterm CSI 14/16/18 t window-size reports and pass CSS-pixel sizes through spawn/resize (in-process PTY and daemon protocol).
- Skip the Enter-key same-size SIGWINCH once a TUI already owns the viewport (alt-screen or mouse tracking).

## Test plan

- [x] `pnpm exec vitest run src/lib/terminalPtySize.test.ts`
- [x] `cargo test --lib pty_env`
- [x] `cargo test -p acorn-daemon protocol`
- [x] `pnpm exec tsc --noEmit`
- [x] `cargo check --workspace --all-targets`
- [ ] Manual: in Acorn, run Grok and confirm `/usage show` paints an overlay