### PR TITLE
fix(terminal): forward TUI clicks while right-click paste is on

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -56,6 +56,10 @@ import {
   type ConversationNavigationDirection,
 } from "../lib/terminalConversation";
 import { patchTerminalMouseCoordinateScale } from "../lib/terminalMouseScale";
+import {
+  TERMINAL_MOUSE_SELECT_THRESHOLD_PX,
+  terminalMouseTrackingReleaseAction,
+} from "../lib/terminalMouseTracking";
 import { patchTerminalWheelScroll } from "../lib/terminalWheelScroll";
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
@@ -2161,20 +2165,19 @@ export function Terminal({
     const isMouseTrackingActive = (): boolean =>
       term.modes.mouseTrackingMode !== "none";
 
-    // Left-drag-to-select inside a mouse-tracking TUI (claude, vim). Those apps
-    // enable mouse tracking, so xterm hands every left drag to the app instead
-    // of selecting — that is why a plain drag selects nothing there while it
-    // works in a normal shell. A native DOM selection is no help: claude
-    // repaints constantly, and each repaint rebuilds the DOM rows and destroys
-    // an in-progress browser selection. xterm's own selection is coordinate
-    // based and survives repaints, so we drive *that*: a confirmed drag is
-    // replayed to xterm with the platform force modifier set, which makes xterm
-    // select even while mouse tracking is on (`macOptionClickForcesSelection`).
-    // A plain click (no drag) is replayed without the modifier so the app still
-    // receives the click; wheel is never touched, so scrolling still reaches
-    // the app. Gated on the setting, so other apps are unaffected unless opted
-    // in.
-    const LEFT_DRAG_THRESHOLD_PX = 3;
+    // Left-drag-to-select inside a mouse-tracking TUI (claude, vim, grok).
+    // Those apps enable mouse tracking, so xterm hands every left drag to the
+    // app instead of selecting — that is why a plain drag selects nothing there
+    // while it works in a normal shell. A native DOM selection is no help:
+    // the app repaints constantly, and each repaint rebuilds the DOM rows and
+    // destroys an in-progress browser selection. xterm's own selection is
+    // coordinate based and survives repaints, so we drive *that*: a confirmed
+    // drag is replayed to xterm with the platform force modifier set, which
+    // makes xterm select even while mouse tracking is on
+    // (`macOptionClickForcesSelection`). A press that produces no selected
+    // text is replayed without the modifier so the app still receives the
+    // click. Wheel is never touched, so scrolling still reaches the app.
+    // Gated on the setting, so other apps are unaffected unless opted in.
     // The modifier xterm honors to force a selection while mouse tracking is on:
     // Option on macOS (with `macOptionClickForcesSelection`), Shift elsewhere.
     const forceSelectModifier: MouseEventInit = IS_MAC
@@ -2194,6 +2197,7 @@ export function Terminal({
       x: number;
       y: number;
       modifiers: MouseEventInit;
+      detail: number;
     } | null = null;
     let leftDragSelecting = false;
     let replayingMouse = false;
@@ -2204,8 +2208,10 @@ export function Terminal({
       y: number,
       extra: MouseEventInit,
     ) => {
-      const target =
-        container.ownerDocument.elementFromPoint(x, y) ?? container;
+      // Mouse-protocol and selection listeners are on xterm's root. Dispatch
+      // there so a helper-textarea or canvas hit from elementFromPoint cannot
+      // miss them.
+      const target = term.element ?? container;
       replayingMouse = true;
       try {
         target.dispatchEvent(
@@ -2223,6 +2229,22 @@ export function Terminal({
       } finally {
         replayingMouse = false;
       }
+    };
+
+    const replayTrackingClick = (start: {
+      x: number;
+      y: number;
+      modifiers: MouseEventInit;
+    }) => {
+      if (term.hasSelection()) term.clearSelection();
+      dispatchSyntheticMouse("mousedown", start.x, start.y, {
+        ...start.modifiers,
+        buttons: 1,
+      });
+      dispatchSyntheticMouse("mouseup", start.x, start.y, {
+        ...start.modifiers,
+        buttons: 0,
+      });
     };
 
     const onTerminalMouseDown = (e: MouseEvent) => {
@@ -2256,6 +2278,7 @@ export function Terminal({
           x: e.clientX,
           y: e.clientY,
           modifiers: eventModifiers(e),
+          detail: e.detail,
         };
         leftDragSelecting = false;
         e.preventDefault();
@@ -2308,8 +2331,10 @@ export function Terminal({
       }
       if (leftDragSelecting) return;
       const moved =
-        Math.abs(e.clientX - pendingLeftDrag.x) > LEFT_DRAG_THRESHOLD_PX ||
-        Math.abs(e.clientY - pendingLeftDrag.y) > LEFT_DRAG_THRESHOLD_PX;
+        Math.abs(e.clientX - pendingLeftDrag.x) >
+          TERMINAL_MOUSE_SELECT_THRESHOLD_PX ||
+        Math.abs(e.clientY - pendingLeftDrag.y) >
+          TERMINAL_MOUSE_SELECT_THRESHOLD_PX;
       if (!moved) {
         e.stopImmediatePropagation();
         return;
@@ -2328,26 +2353,26 @@ export function Terminal({
       const start = pendingLeftDrag;
       pendingLeftDrag = null;
       if (leftDragSelecting) {
-        // The real mouseup flows through to xterm, which finalizes the
-        // selection it has been extending.
+        // Let the real mouseup finalize xterm's selection, then keep it only
+        // when it contains text (or was a multi-click word/line select).
+        // Otherwise replay as a TUI click.
         leftDragSelecting = false;
+        queueMicrotask(() => {
+          if (disposed) return;
+          const action = terminalMouseTrackingReleaseAction({
+            selecting: true,
+            selectedTextLength: term.getSelection().length,
+            clickCount: start.detail,
+          });
+          if (action === "keep-selection") return;
+          replayTrackingClick(start);
+        });
         return;
       }
-      // No drag — a plain click. Clear any standing selection so a click
-      // deselects (xterm leaves its selection in place while mouse tracking is
-      // on), then swallow the real mouseup and replay the click without the
-      // force modifier (but with the user's real modifiers) so xterm reports
-      // it to the app.
-      if (term.hasSelection()) term.clearSelection();
+      // No drag — a plain click. Swallow the real mouseup and replay without
+      // the force modifier so xterm reports it to the app.
       e.stopImmediatePropagation();
-      dispatchSyntheticMouse("mousedown", start.x, start.y, {
-        ...start.modifiers,
-        buttons: 1,
-      });
-      dispatchSyntheticMouse("mouseup", start.x, start.y, {
-        ...start.modifiers,
-        buttons: 0,
-      });
+      replayTrackingClick(start);
     };
     container.ownerDocument.addEventListener("mousemove", onTerminalMouseMove, true);
     container.ownerDocument.addEventListener("mouseup", onTerminalMouseUp, true);

--- a/src/lib/terminalMouseTracking.test.ts
+++ b/src/lib/terminalMouseTracking.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { terminalMouseTrackingReleaseAction } from "./terminalMouseTracking";
+
+describe("terminalMouseTrackingReleaseAction", () => {
+  it("replays a press that never started a selection as a click", () => {
+    expect(
+      terminalMouseTrackingReleaseAction({
+        selecting: false,
+        selectedTextLength: 0,
+        clickCount: 1,
+      }),
+    ).toBe("click");
+  });
+
+  it("replays an empty selection after a jitter-drag as a click", () => {
+    expect(
+      terminalMouseTrackingReleaseAction({
+        selecting: true,
+        selectedTextLength: 0,
+        clickCount: 1,
+      }),
+    ).toBe("click");
+  });
+
+  it("keeps any pasteable selection, including one character", () => {
+    expect(
+      terminalMouseTrackingReleaseAction({
+        selecting: true,
+        selectedTextLength: 1,
+        clickCount: 1,
+      }),
+    ).toBe("keep-selection");
+    expect(
+      terminalMouseTrackingReleaseAction({
+        selecting: true,
+        selectedTextLength: 12,
+        clickCount: 1,
+      }),
+    ).toBe("keep-selection");
+  });
+
+  it("keeps double-click word select even when it is empty", () => {
+    expect(
+      terminalMouseTrackingReleaseAction({
+        selecting: true,
+        selectedTextLength: 0,
+        clickCount: 2,
+      }),
+    ).toBe("keep-selection");
+  });
+});

--- a/src/lib/terminalMouseTracking.ts
+++ b/src/lib/terminalMouseTracking.ts
@@ -1,0 +1,25 @@
+/** Minimum pointer travel before a press is treated as a select-drag. */
+export const TERMINAL_MOUSE_SELECT_THRESHOLD_PX = 8;
+
+export type TerminalMouseTrackingReleaseAction = "click" | "keep-selection";
+
+/**
+ * Decide whether a mouse-tracking press should go to the TUI or stay as a
+ * local selection for right-click paste.
+ *
+ * A trackpad click often jitters past the drag threshold without covering a
+ * second cell, so xterm ends with an empty selection. Overlay close buttons
+ * live in one cell; that press must still replay as a click. Any selected
+ * text — including a one-character drag — is kept for paste. Double/triple
+ * click is always a word/line select.
+ */
+export function terminalMouseTrackingReleaseAction(args: {
+  selecting: boolean;
+  selectedTextLength: number;
+  clickCount: number;
+}): TerminalMouseTrackingReleaseAction {
+  if (!args.selecting) return "click";
+  if (args.clickCount >= 2) return "keep-selection";
+  if (args.selectedTextLength > 0) return "keep-selection";
+  return "click";
+}

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -430,15 +430,14 @@ async function disableTerminalUnicodeSpaceNormalization(
 
 async function enableTerminalRightClickPasteSelection(
   page: Page,
+  extraTerminal: Record<string, unknown> = {},
 ): Promise<void> {
-  await page.addInitScript(() => {
+  await page.addInitScript((terminal) => {
     window.localStorage.setItem(
       "acorn:settings:v1",
-      JSON.stringify({
-        terminal: { rightClickPasteSelection: true },
-      }),
+      JSON.stringify({ terminal }),
     );
-  });
+  }, { rightClickPasteSelection: true, ...extraTerminal });
 }
 
 async function seedTerminalCursorStyle(
@@ -453,19 +452,32 @@ async function seedTerminalCursorStyle(
   }, cursorStyle);
 }
 
-async function rightClickSelectedTerminalText(
+async function dragSelectTerminalText(
   page: Page,
   text: string,
+  direction: "ltr" | "rtl" = "ltr",
 ): Promise<void> {
   const textRect = await terminalTextRect(page, text);
   expect(textRect).not.toBeNull();
   const y = (textRect!.top + textRect!.bottom) / 2;
-  await page.mouse.move(textRect!.left + 2, y);
+  const from =
+    direction === "ltr" ? textRect!.left + 2 : textRect!.left + textRect!.width - 2;
+  const to =
+    direction === "ltr" ? textRect!.left + textRect!.width - 2 : textRect!.left + 2;
+  await page.mouse.move(from, y);
   await page.mouse.down();
-  await page.mouse.move(textRect!.left + textRect!.width - 2, y, {
-    steps: 8,
-  });
+  await page.mouse.move(to, y, { steps: 8 });
   await page.mouse.up();
+}
+
+async function rightClickSelectedTerminalText(
+  page: Page,
+  text: string,
+): Promise<void> {
+  await dragSelectTerminalText(page, text);
+  const textRect = await terminalTextRect(page, text);
+  expect(textRect).not.toBeNull();
+  const y = (textRect!.top + textRect!.bottom) / 2;
   await page.mouse.click(textRect!.left + 10, y, { button: "right" });
 }
 
@@ -1587,6 +1599,337 @@ test.describe("terminal: spawn", () => {
         ),
       )
       .toContain("run-selected");
+  });
+
+  test("forwards a TUI click while right-click paste selection is enabled", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toMatch(/\x1b\[<0;\d+;\d+M/);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toMatch(/\x1b\[<0;\d+;\d+m/);
+  });
+
+  test("forwards a slightly jittered TUI click instead of keeping a 1-cell selection", async ({
+    page,
+    tauri,
+  }) => {
+    // Large cells so a >8px wobble can still land in the same glyph and hit
+    // the post-takeover empty-selection replay, not only the no-drag path.
+    await enableTerminalRightClickPasteSelection(page, { fontSize: 24 });
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    const x = screenBox!.x + 12;
+    const y = screenBox!.y + 10;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    // Past the 8px takeover, still inside one 24px cell — must stay a click.
+    await page.mouse.move(x + 1, y + 10);
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toMatch(/\x1b\[<0;\d+;\d+M/);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toMatch(/\x1b\[<0;\d+;\d+m/);
+  });
+
+  test("drag-select inside a TUI does not send a click to the app", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+    await dragSelectTerminalText(page, "run-selected");
+
+    expect(
+      await page.evaluate(() =>
+        ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+          .join(""),
+      ),
+    ).not.toMatch(/\x1b\[<0;\d+;\d+M/);
+  });
+
+  test("right-to-left drag-select still pastes on right-click while a TUI holds mouse tracking", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+    await dragSelectTerminalText(page, "run-selected", "rtl");
+    const textRect = await terminalTextRect(page, "run-selected");
+    expect(textRect).not.toBeNull();
+    await page.mouse.click(textRect!.left + 10, (textRect!.top + textRect!.bottom) / 2, {
+      button: "right",
+    });
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __ptyWrites?: string[] }).__ptyWrites,
+        ),
+      )
+      .toContain("run-selected");
+  });
+
+  test("a click after drag-select still reaches the TUI", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as {
+        __contextPasteChannelId?: number;
+      };
+      w.__contextPasteChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __contextPasteChannelId?: number })
+              .__contextPasteChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "run-selected\r\n",
+    );
+    await expect(page.locator(".xterm")).toContainText("run-selected");
+    await emitSubscribedPtyOutput(
+      page,
+      "__contextPasteChannelId",
+      "\x1b[?1000h\x1b[?1003h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    await dragSelectTerminalText(page, "run-selected");
+    await page.evaluate(() => {
+      (window as unknown as { __ptyWrites?: string[] }).__ptyWrites = [];
+    });
+
+    const screenBox = await page.locator(".xterm-screen").boundingBox();
+    expect(screenBox).not.toBeNull();
+    await page.mouse.click(screenBox!.x + 12, screenBox!.y + 10);
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toMatch(/\x1b\[<0;\d+;\d+M/);
   });
 
   test("does not write non-terminal selected text on terminal right-click", async ({


### PR DESCRIPTION
## Summary
- Right-click paste intercepts left clicks while a TUI has mouse tracking, so drag-select still works. Trackpad jitter was turning those presses into empty selections, which meant Grok overlay close buttons and prompt focus never arrived.
- Replay empty / below-threshold presses as SGR clicks, keep any pasteable selection (and double-click word/line select) for paste, and dispatch the replay on xterm's root.

## Test plan
- [x] `pnpm exec vitest run src/lib/terminalMouseTracking.test.ts`
- [x] Playwright: click, jittered click, drag-select does not click, LTR/RTL right-click paste, click after select
- [ ] In a local Acorn build: Grok overlay X, prompt click-to-focus, drag-select then right-click paste