### PR TITLE
perf(terminal): coalesce TUI scroll IPC so Claude CLI stays responsive

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -8777,7 +8777,7 @@ fn decode_base64(input: &str) -> Option<Vec<u8>> {
 }
 
 #[tauri::command]
-pub async fn pty_spawn<R: Runtime>(
+pub async fn pty_spawn<R: Runtime + 'static>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     session_id: String,
@@ -8813,7 +8813,7 @@ pub async fn pty_spawn<R: Runtime>(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn pty_spawn_blocking<R: Runtime>(
+fn pty_spawn_blocking<R: Runtime + 'static>(
     app: AppHandle<R>,
     state: AppState,
     session_id: String,
@@ -9094,7 +9094,7 @@ fn should_route_session_to_daemon(enabled: bool, daemon_session_id: Option<Uuid>
 /// 3. **No live session** — fresh daemon spawn, attach the stream,
 ///    persist `daemon_session_id` so the next restart hits case 2.
 #[allow(clippy::too_many_arguments)]
-fn spawn_via_daemon<R: Runtime>(
+fn spawn_via_daemon<R: Runtime + 'static>(
     app: &AppHandle<R>,
     state: &AppState,
     id: uuid::Uuid,
@@ -9309,29 +9309,39 @@ pub fn pty_unsubscribe_output(
 }
 
 #[tauri::command]
-pub fn pty_write(state: State<'_, AppState>, session_id: String, data: String) -> AppResult<()> {
+pub async fn pty_write(
+    state: State<'_, AppState>,
+    session_id: String,
+    data: String,
+) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let bytes = decode_b64(&data)?;
     // Terminal input is transport-only: keystrokes express user intent, not
     // confirmed agent lifecycle. Native hooks and runtime evidence own status.
     // Daemon-managed sessions route stdin through the control socket.
-    // Keystrokes are small; one RPC round-trip per keystroke is well
-    // under the typing-feedback threshold and avoids managing a second
-    // socket on the app side just for input. A stream attachment is the
-    // fast-path signal, but detached/re-attaching sessions can be alive in
-    // the daemon without an app-side output pump for a short window.
-    if daemon_session_alive_or_attached(&state, id) {
-        state
-            .daemon_bridge
-            .send_input(id, &bytes)
-            .map_err(|e| AppError::Pty(e.to_string()))?;
-    } else {
-        state
-            .pty
-            .write(&id, &bytes)
-            .map_err(|e| AppError::Pty(e.to_string()))?;
-    }
-    Ok(())
+    // A stream attachment is the fast-path signal, but detached/re-attaching
+    // sessions can be alive in the daemon without an app-side output pump
+    // for a short window. The write itself is blocking I/O (socket or PTY
+    // master); run it off the UI thread so a TUI wheel burst cannot stall
+    // WKWebView eval of the matching output.
+    let state = state.inner().clone();
+    let lock = state.pty_write_lock(id);
+    run_blocking("pty_write", move || {
+        let _write_order = lock.lock();
+        if daemon_session_alive_or_attached(&state, id) {
+            state
+                .daemon_bridge
+                .send_input(id, &bytes)
+                .map_err(|e| AppError::Pty(e.to_string()))?;
+        } else {
+            state
+                .pty
+                .write(&id, &bytes)
+                .map_err(|e| AppError::Pty(e.to_string()))?;
+        }
+        Ok(())
+    })
+    .await
 }
 
 #[tauri::command]
@@ -13171,11 +13181,11 @@ mod tests {
             // but the transport byte still must not mutate session lifecycle.
             ("control-c", "Aw=="),
         ] {
-            super::pty_write(
+            tauri::async_runtime::block_on(super::pty_write(
                 app.state::<AppState>(),
                 session.id.to_string(),
                 data.to_string(),
-            )
+            ))
             .unwrap_or_else(|error| panic!("write {label} to PTY: {error}"));
             assert_eq!(
                 state
@@ -13187,7 +13197,8 @@ mod tests {
             );
         }
 
-        state.pty.kill(&session.id).expect("kill test PTY");
+        // Ctrl-C above may already have reaped `cat`; ignore ESRCH.
+        let _ = state.pty.kill(&session.id);
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9326,8 +9326,8 @@ pub async fn pty_write(
     // WKWebView eval of the matching output.
     let state = state.inner().clone();
     let lock = state.pty_write_lock(id);
+    let _write_order = lock.lock().await;
     run_blocking("pty_write", move || {
-        let _write_order = lock.lock();
         if daemon_session_alive_or_attached(&state, id) {
             state
                 .daemon_bridge
@@ -9389,6 +9389,7 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
         }
         if result.is_ok() {
             state.ipc_session_capabilities.lock().remove(&id);
+            state.pty_write_locks.remove(&id);
         }
         return result;
     }
@@ -9398,6 +9399,7 @@ pub fn pty_kill(state: State<'_, AppState>, session_id: String) -> AppResult<()>
         .map_err(|e| AppError::Pty(e.to_string()));
     if result.is_ok() {
         state.ipc_session_capabilities.lock().remove(&id);
+        state.pty_write_locks.remove(&id);
     }
     result
 }

--- a/src-tauri/src/daemon_stream.rs
+++ b/src-tauri/src/daemon_stream.rs
@@ -152,7 +152,7 @@ struct ExitPayload {
 ///
 /// `replay_scrollback` defaults to true so a tab reopened after Acorn
 /// restart sees the last screen contents the daemon recorded.
-pub fn attach<R: Runtime>(
+pub fn attach<R: Runtime + 'static>(
     app: AppHandle<R>,
     registry: Arc<StreamRegistry>,
     output_router: Arc<PtyOutputRouter>,
@@ -245,7 +245,7 @@ fn complete_attachment_spawn(
     }
 }
 
-fn pump_loop<R: Runtime>(
+fn pump_loop<R: Runtime + 'static>(
     app: AppHandle<R>,
     registry: Arc<StreamRegistry>,
     output_router: Arc<PtyOutputRouter>,

--- a/src-tauri/src/pty_output.rs
+++ b/src-tauri/src/pty_output.rs
@@ -87,22 +87,13 @@ impl PtyOutputRouter {
     }
 
     pub fn unsubscribe(&self, session_id: &Uuid, token: u64) {
-        let should_remove = self
-            .inner
+        // Token-matched remove only. Flushing here would send held bytes to a
+        // Channel the renderer already dropped, and a racing subscribe for
+        // the same session would lose the tail. The 8ms timer delivers to
+        // whoever is subscribed, or emit-fallback if no one is.
+        self.inner
             .channels
-            .get(session_id)
-            .map(|entry| entry.token == token)
-            .unwrap_or(false);
-        if !should_remove {
-            return;
-        }
-        let bytes = self.take_flush(session_id).1;
-        if !bytes.is_empty() {
-            if let Some(entry) = self.inner.channels.get(session_id) {
-                let _ = entry.channel.send(Response::new(bytes));
-            }
-        }
-        self.inner.channels.remove(session_id);
+            .remove_if(session_id, |_, sub| sub.token == token);
     }
 
     pub fn current_token(&self, session_id: &Uuid) -> Option<u64> {

--- a/src-tauri/src/pty_output.rs
+++ b/src-tauri/src/pty_output.rs
@@ -1,10 +1,21 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use serde::Serialize;
 use tauri::ipc::{Channel, Response};
 use tauri::{AppHandle, Emitter, Runtime};
 use uuid::Uuid;
+
+/// Daemon/in-process readers emit ~4KB frames. Each Channel send becomes a
+/// WKWebView `eval` (and a fetch round-trip above 1KB), so a TUI redraw burst
+/// would otherwise pin the UI thread. Idle sessions still lead with an
+/// immediate send so a keystroke echo is not delayed by the window.
+const MAX_BATCH_BYTES: usize = 64 * 1024;
+const FLUSH_DELAY: Duration = Duration::from_millis(8);
 
 #[derive(Serialize, Clone)]
 pub struct OutputPayload {
@@ -18,42 +29,127 @@ struct OutputSubscription {
 }
 
 #[derive(Default)]
-pub struct PtyOutputRouter {
+struct SessionOutputBatch {
+    buf: Vec<u8>,
+    event: String,
+    timer_armed: bool,
+}
+
+enum EnqueueEffect {
+    Dispatch {
+        bytes: Vec<u8>,
+        event: String,
+        arm_timer: bool,
+    },
+    Hold,
+}
+
+fn enqueue_output(batch: &mut SessionOutputBatch, event: &str, bytes: &[u8]) -> EnqueueEffect {
+    batch.event = event.to_string();
+    if !batch.timer_armed && batch.buf.is_empty() {
+        batch.timer_armed = true;
+        return EnqueueEffect::Dispatch {
+            bytes: bytes.to_vec(),
+            event: event.to_string(),
+            arm_timer: true,
+        };
+    }
+    batch.buf.extend_from_slice(bytes);
+    if batch.buf.len() >= MAX_BATCH_BYTES {
+        return EnqueueEffect::Dispatch {
+            bytes: std::mem::take(&mut batch.buf),
+            event: event.to_string(),
+            arm_timer: false,
+        };
+    }
+    EnqueueEffect::Hold
+}
+
+#[derive(Default)]
+struct Inner {
     next_token: AtomicU64,
     channels: DashMap<Uuid, OutputSubscription>,
+    batches: Mutex<HashMap<Uuid, SessionOutputBatch>>,
+}
+
+#[derive(Clone, Default)]
+pub struct PtyOutputRouter {
+    inner: Arc<Inner>,
 }
 
 impl PtyOutputRouter {
     pub fn subscribe(&self, session_id: Uuid, channel: Channel<Response>) -> u64 {
-        let token = self.next_token.fetch_add(1, Ordering::Relaxed) + 1;
-        self.channels
+        let token = self.inner.next_token.fetch_add(1, Ordering::Relaxed) + 1;
+        self.inner
+            .channels
             .insert(session_id, OutputSubscription { token, channel });
         token
     }
 
     pub fn unsubscribe(&self, session_id: &Uuid, token: u64) {
         let should_remove = self
+            .inner
             .channels
             .get(session_id)
             .map(|entry| entry.token == token)
             .unwrap_or(false);
-        if should_remove {
-            self.channels.remove(session_id);
+        if !should_remove {
+            return;
         }
+        let bytes = self.take_flush(session_id).1;
+        if !bytes.is_empty() {
+            if let Some(entry) = self.inner.channels.get(session_id) {
+                let _ = entry.channel.send(Response::new(bytes));
+            }
+        }
+        self.inner.channels.remove(session_id);
     }
 
     pub fn current_token(&self, session_id: &Uuid) -> Option<u64> {
-        self.channels.get(session_id).map(|entry| entry.token)
+        self.inner.channels.get(session_id).map(|entry| entry.token)
     }
 
-    pub fn send_or_emit<R: Runtime>(
+    pub fn send_or_emit<R: Runtime + 'static>(
         &self,
         app: &AppHandle<R>,
         event: &str,
         session_id: &Uuid,
         bytes: &[u8],
     ) {
-        if let Some(entry) = self.channels.get(session_id) {
+        if bytes.is_empty() {
+            return;
+        }
+        let effect = {
+            let mut batches = self.inner.batches.lock();
+            let batch = batches.entry(*session_id).or_default();
+            enqueue_output(batch, event, bytes)
+        };
+        match effect {
+            EnqueueEffect::Hold => {}
+            EnqueueEffect::Dispatch {
+                bytes,
+                event,
+                arm_timer,
+            } => {
+                self.dispatch(app, &event, session_id, &bytes);
+                if arm_timer {
+                    self.arm_flush(app.clone(), *session_id);
+                }
+            }
+        }
+    }
+
+    fn dispatch<R: Runtime>(
+        &self,
+        app: &AppHandle<R>,
+        event: &str,
+        session_id: &Uuid,
+        bytes: &[u8],
+    ) {
+        if bytes.is_empty() {
+            return;
+        }
+        if let Some(entry) = self.inner.channels.get(session_id) {
             let token = entry.token;
             let channel = entry.channel.clone();
             drop(entry);
@@ -71,6 +167,31 @@ impl PtyOutputRouter {
         if let Err(err) = app.emit(event, payload) {
             tracing::warn!(%session_id, error = %err, "failed to emit pty output");
         }
+    }
+
+    fn arm_flush<R: Runtime + 'static>(&self, app: AppHandle<R>, session_id: Uuid) {
+        let router = self.clone();
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(FLUSH_DELAY).await;
+            router.flush_session(&app, session_id);
+        });
+    }
+
+    fn flush_session<R: Runtime>(&self, app: &AppHandle<R>, session_id: Uuid) {
+        let (event, bytes) = self.take_flush(&session_id);
+        self.dispatch(app, &event, &session_id, &bytes);
+    }
+
+    fn take_flush(&self, session_id: &Uuid) -> (String, Vec<u8>) {
+        let mut batches = self.inner.batches.lock();
+        let Some(batch) = batches.get_mut(session_id) else {
+            return (String::new(), Vec::new());
+        };
+        batch.timer_armed = false;
+        let event = std::mem::take(&mut batch.event);
+        let bytes = std::mem::take(&mut batch.buf);
+        batches.remove(session_id);
+        (event, bytes)
     }
 }
 
@@ -186,5 +307,53 @@ mod tests {
         assert!(base64_decode("Zg=A").is_none());
         assert!(base64_decode("Zg=").is_none());
         assert!(base64_decode("not!").is_none());
+    }
+
+    #[test]
+    fn first_chunk_dispatches_immediately_and_opens_the_window() {
+        let mut batch = SessionOutputBatch::default();
+        match enqueue_output(&mut batch, "pty:output:a", b"hi") {
+            EnqueueEffect::Dispatch {
+                bytes,
+                event,
+                arm_timer,
+            } => {
+                assert_eq!(bytes, b"hi");
+                assert_eq!(event, "pty:output:a");
+                assert!(arm_timer);
+            }
+            EnqueueEffect::Hold => panic!("idle session should lead with a send"),
+        }
+        assert!(batch.timer_armed);
+        assert!(batch.buf.is_empty());
+    }
+
+    #[test]
+    fn chunks_inside_the_window_are_held_until_flush() {
+        let mut batch = SessionOutputBatch::default();
+        let _ = enqueue_output(&mut batch, "pty:output:a", b"a");
+        assert!(matches!(
+            enqueue_output(&mut batch, "pty:output:a", b"b"),
+            EnqueueEffect::Hold
+        ));
+        assert_eq!(batch.buf, b"b");
+    }
+
+    #[test]
+    fn oversized_hold_buffer_flushes_without_arming_another_timer() {
+        let mut batch = SessionOutputBatch::default();
+        let _ = enqueue_output(&mut batch, "pty:output:a", b"lead");
+        let payload = vec![b'x'; MAX_BATCH_BYTES];
+        match enqueue_output(&mut batch, "pty:output:a", &payload) {
+            EnqueueEffect::Dispatch {
+                bytes, arm_timer, ..
+            } => {
+                assert_eq!(bytes.len(), MAX_BATCH_BYTES);
+                assert!(!arm_timer);
+            }
+            EnqueueEffect::Hold => panic!("64KB catch-up should dispatch"),
+        }
+        assert!(batch.timer_armed);
+        assert!(batch.buf.is_empty());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use parking_lot::Mutex;
 
 use crate::daemon_bridge::DaemonBridge;
@@ -49,6 +50,9 @@ pub struct AppState {
     /// Raw-byte output channels registered by renderer terminals. PTY output
     /// falls back to the legacy base64 event path when no channel is active.
     pub pty_output: Arc<PtyOutputRouter>,
+    /// Serializes stdin writes per session so async `pty_write` tasks cannot
+    /// reorder keystrokes or mouse reports for the same PTY.
+    pub pty_write_locks: DashMap<Uuid, Arc<Mutex<()>>>,
     /// Set to false at boot if `persistence::load_sessions_with_status`
     /// reported a recoverable load failure (file existed but could not be
     /// read or parsed). Frontend reads this via `load_status` and skips the
@@ -124,12 +128,20 @@ pub struct AppState {
 }
 
 impl AppState {
+    pub fn pty_write_lock(&self, id: Uuid) -> Arc<Mutex<()>> {
+        self.pty_write_locks
+            .entry(id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     pub fn new() -> Self {
         Self {
             sessions: SessionStore::new(),
             projects: ProjectStore::new(),
             pty: PtyManager::new(),
             pty_output: Arc::new(PtyOutputRouter::default()),
+            pty_write_locks: DashMap::new(),
             sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             pending_session_removals: Arc::new(Mutex::new(HashMap::new())),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -51,8 +51,10 @@ pub struct AppState {
     /// falls back to the legacy base64 event path when no channel is active.
     pub pty_output: Arc<PtyOutputRouter>,
     /// Serializes stdin writes per session so async `pty_write` tasks cannot
-    /// reorder keystrokes or mouse reports for the same PTY.
-    pub pty_write_locks: DashMap<Uuid, Arc<Mutex<()>>>,
+    /// reorder keystrokes or mouse reports for the same PTY. Arc so
+    /// `AppState::clone` shares the map; a cloned DashMap would give each
+    /// invoke a private mutex.
+    pub pty_write_locks: Arc<DashMap<Uuid, Arc<tokio::sync::Mutex<()>>>>,
     /// Set to false at boot if `persistence::load_sessions_with_status`
     /// reported a recoverable load failure (file existed but could not be
     /// read or parsed). Frontend reads this via `load_status` and skips the
@@ -128,10 +130,10 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn pty_write_lock(&self, id: Uuid) -> Arc<Mutex<()>> {
+    pub fn pty_write_lock(&self, id: Uuid) -> Arc<tokio::sync::Mutex<()>> {
         self.pty_write_locks
             .entry(id)
-            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
     }
 
@@ -141,7 +143,7 @@ impl AppState {
             projects: ProjectStore::new(),
             pty: PtyManager::new(),
             pty_output: Arc::new(PtyOutputRouter::default()),
-            pty_write_locks: DashMap::new(),
+            pty_write_locks: Arc::new(DashMap::new()),
             sessions_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             projects_loaded_cleanly: Arc::new(AtomicBool::new(true)),
             pending_session_removals: Arc::new(Mutex::new(HashMap::new())),

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1177,8 +1177,8 @@ export function Terminal({
 
     const scheduleLiveCwdProbe = () => {
       if (disposed || liveCwdProbeTimer !== null) return;
-      // 5s, not 500ms: a streaming TUI keeps this timer armed continuously,
-      // and pty_cwd walks the whole process table.
+      // Streaming TUI output would re-arm this continuously; pty_cwd walks
+      // the process table.
       liveCwdProbeTimer = window.setTimeout(() => {
         liveCwdProbeTimer = null;
         if (disposed) return;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -60,7 +60,11 @@ import {
   TERMINAL_MOUSE_SELECT_THRESHOLD_PX,
   terminalMouseTrackingReleaseAction,
 } from "../lib/terminalMouseTracking";
-import { patchTerminalWheelScroll } from "../lib/terminalWheelScroll";
+import {
+  applicationOwnsWheel,
+  patchTerminalWheelScroll,
+} from "../lib/terminalWheelScroll";
+import { createPtyWriteCoalescer } from "../lib/ptyWriteCoalescer";
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
   TERMINAL_PASTE_EVENT,
@@ -1173,6 +1177,8 @@ export function Terminal({
 
     const scheduleLiveCwdProbe = () => {
       if (disposed || liveCwdProbeTimer !== null) return;
+      // 5s, not 500ms: a streaming TUI keeps this timer armed continuously,
+      // and pty_cwd walks the whole process table.
       liveCwdProbeTimer = window.setTimeout(() => {
         liveCwdProbeTimer = null;
         if (disposed) return;
@@ -1186,7 +1192,7 @@ export function Terminal({
           .catch((err: unknown) => {
             console.debug("[Terminal] pty_cwd probe failed", err);
           });
-      }, 500);
+      }, 5000);
     };
 
     let cursorApplicationOverride = false;
@@ -1411,14 +1417,18 @@ export function Terminal({
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
 
+    const ptyWriteCoalescer = createPtyWriteCoalescer(
+      (targetSessionId, data) => {
+        invoke("pty_write", {
+          sessionId: targetSessionId,
+          data: encodeStringToBase64(data),
+        }).catch((err: unknown) => {
+          console.error("[Terminal] pty_write failed", err);
+        });
+      },
+    );
     const writeToPty = (targetSessionId: string, data: string) => {
-      if (data.length === 0) return;
-      invoke("pty_write", {
-        sessionId: targetSessionId,
-        data: encodeStringToBase64(data),
-      }).catch((err: unknown) => {
-        console.error("[Terminal] pty_write failed", err);
-      });
+      ptyWriteCoalescer.enqueue(targetSessionId, data);
     };
     const sendToPty = (data: string) => {
       writeToPty(sessionId, data);
@@ -2843,7 +2853,10 @@ export function Terminal({
       createFolderPermissionOutputDetector();
     const handlePtyOutput = (bytes: Uint8Array) => {
       outputWriter.enqueue(bytes);
-      if (folderPermissionOutputDetector.push(bytes)) {
+      if (
+        !applicationOwnsWheel(term) &&
+        folderPermissionOutputDetector.push(bytes)
+      ) {
         window.dispatchEvent(new Event(FOLDER_PERMISSION_RECHECK_EVENT));
       }
       // Output is queued for the buffer — schedule a debounced save so the new
@@ -3207,6 +3220,7 @@ export function Terminal({
 
     return () => {
       disposed = true;
+      ptyWriteCoalescer.flush();
       const detachingForReuse = consumeTerminalDetaching(sessionId);
       unsubSettings();
       hideLinkTooltip(true);

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -68,6 +68,15 @@ describe("permission warmup gate", () => {
     ).toBe(true);
   });
 
+  it("still detects a failure sitting at the end of a large CSI burst", () => {
+    const detector = createFolderPermissionOutputDetector();
+    const csi = "\u001b[38;5;81m";
+    const prefix = csi.repeat(400);
+    const message =
+      "Error: The current working directory must be readable to jthefloor to run brew.\r\n";
+    expect(detector.push(bytes(prefix + message))).toBe(true);
+  });
+
   it("ignores unrelated permission errors", () => {
     const detector = createFolderPermissionOutputDetector();
 

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -36,6 +36,9 @@ export const FOLDER_PERMISSION_RECHECK_EVENT =
 
 const ANSI_CSI_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
 const MAX_PERMISSION_OUTPUT_TAIL = 512;
+// Permission failures are short ASCII lines. TUI frames are kilobytes of CSI;
+// inspecting only the tail keeps the detector off the redraw hot path.
+const MAX_PERMISSION_INSPECT_BYTES = 1024;
 const BREW_UNREADABLE_CWD =
   /the current working directory must be readable to [^\r\n]+ to run brew\./i;
 const CODEX_PERMISSION_FAILURE =
@@ -50,7 +53,11 @@ export function createFolderPermissionOutputDetector(): {
   return {
     push(bytes) {
       if (bytes.byteLength === 0) return false;
-      const output = (tail + decoder.decode(bytes, { stream: true })).replace(
+      const slice =
+        bytes.byteLength > MAX_PERMISSION_INSPECT_BYTES
+          ? bytes.subarray(bytes.byteLength - MAX_PERMISSION_INSPECT_BYTES)
+          : bytes;
+      const output = (tail + decoder.decode(slice, { stream: true })).replace(
         ANSI_CSI_SEQUENCE,
         "",
       );

--- a/src/lib/ptyWriteCoalescer.test.ts
+++ b/src/lib/ptyWriteCoalescer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createPtyWriteCoalescer } from "./ptyWriteCoalescer";
+
+describe("createPtyWriteCoalescer", () => {
+  it("joins writes to the same session into one callback", () => {
+    const sent: Array<[string, string]> = [];
+    const scheduled: Array<() => void> = [];
+    const coalescer = createPtyWriteCoalescer(
+      (sessionId, data) => sent.push([sessionId, data]),
+      (callback) => {
+        scheduled.push(callback);
+      },
+    );
+
+    coalescer.enqueue("a", "x");
+    coalescer.enqueue("a", "y");
+    coalescer.enqueue("b", "z");
+    expect(sent).toEqual([]);
+    expect(scheduled).toHaveLength(1);
+
+    scheduled[0]();
+    expect(sent).toEqual([
+      ["a", "xy"],
+      ["b", "z"],
+    ]);
+  });
+
+  it("ignores empty payloads and can flush without a scheduled turn", () => {
+    const sent: Array<[string, string]> = [];
+    const coalescer = createPtyWriteCoalescer((sessionId, data) =>
+      sent.push([sessionId, data]),
+    );
+
+    coalescer.enqueue("a", "");
+    coalescer.flush();
+    expect(sent).toEqual([]);
+
+    coalescer.enqueue("a", "hi");
+    coalescer.flush();
+    expect(sent).toEqual([["a", "hi"]]);
+  });
+});

--- a/src/lib/ptyWriteCoalescer.ts
+++ b/src/lib/ptyWriteCoalescer.ts
@@ -1,0 +1,40 @@
+/**
+ * Join stdin writes that land in the same turn into one `pty_write`.
+ *
+ * Wheel-driven TUI mouse reports arrive as many tiny `onData` payloads;
+ * each invoke is a Tauri IPC hop. One microtask later they are a single
+ * write, which also lets the child see the burst as one stdin read.
+ */
+export function createPtyWriteCoalescer(
+  write: (sessionId: string, data: string) => void,
+  schedule: (callback: () => void) => void = queueMicrotask,
+): { enqueue: (sessionId: string, data: string) => void; flush: () => void } {
+  const pending = new Map<string, string[]>();
+  let scheduled = false;
+
+  const drain = () => {
+    scheduled = false;
+    if (pending.size === 0) return;
+    const entries = Array.from(pending.entries());
+    pending.clear();
+    for (const [sessionId, chunks] of entries) {
+      write(sessionId, chunks.join(""));
+    }
+  };
+
+  return {
+    enqueue(sessionId, data) {
+      if (data.length === 0) return;
+      const chunks = pending.get(sessionId);
+      if (chunks) {
+        chunks.push(data);
+      } else {
+        pending.set(sessionId, [data]);
+      }
+      if (scheduled) return;
+      scheduled = true;
+      schedule(drain);
+    },
+    flush: drain,
+  };
+}

--- a/src/lib/terminalWheelScroll.ts
+++ b/src/lib/terminalWheelScroll.ts
@@ -22,11 +22,10 @@ interface XtermWheelInternals {
 // xterm still encodes the report (or the arrow key), so the active mouse
 // protocol, the modifier bits and the cell coordinates stay its job.
 const APP_WHEEL_TRACKING_MODES = new Set(["vt200", "drag", "any"]);
-// Trackpad momentum carries hundreds of pixels per event; each reported line
-// is one `pty_write` IPC round trip, so cap the burst. Scaled by the scroll
-// speed so raising the setting still raises the ceiling.
-// ponytail: per-report writes are fine at this cap; coalesce `writeToPty` into
-// a microtask if PTY IPC ever shows up in a profile.
+// Trackpad momentum carries hundreds of pixels per event. Writes coalesce
+// into one pty_write per microtask; the cap still bounds how many reports
+// the TUI sees in that burst so a flick cannot queue a backlog. Scaled by
+// the scroll speed so raising the setting still raises the ceiling.
 const MAX_LINES_PER_EVENT = 8;
 // Replayed events must survive xterm's own pixel→line conversion: at least one
 // line for the current cell height and `scrollSensitivity`, and above its 50px
@@ -75,7 +74,7 @@ export function wheelScrollLineCount({
 }
 
 /** Whether the foreground application, not the viewport, owns the wheel. */
-function applicationOwnsWheel(term: XTerm): boolean {
+export function applicationOwnsWheel(term: XTerm): boolean {
   return (
     APP_WHEEL_TRACKING_MODES.has(term.modes.mouseTrackingMode) ||
     term.buffer.active.type === "alternate"

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -152,6 +152,20 @@ async function getWrites(page: Page): Promise<string[]> {
   );
 }
 
+function countToken(writes: string[], token: string): number {
+  const joined = writes.join("");
+  if (token.length === 0) return 0;
+  let n = 0;
+  let from = 0;
+  while (from < joined.length) {
+    const i = joined.indexOf(token, from);
+    if (i < 0) break;
+    n += 1;
+    from = i + token.length;
+  }
+  return n;
+}
+
 async function emitPtyOutput(page: Page, text: string): Promise<void> {
   await expect
     .poll(() =>
@@ -487,7 +501,7 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     ]);
 
     const writes = await getWrites(page);
-    const syllableCount = writes.filter((w) => w === "한").length;
+    const syllableCount = countToken(writes, "한");
     expect(syllableCount).toBe(1);
     // And the syllable never coalesces into a doubled-up chunk either.
     expect(writes.join("")).not.toContain("한한");
@@ -513,7 +527,7 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     ]);
 
     const writes = await getWrites(page);
-    expect(writes.filter((w) => w === "한").length).toBe(1);
+    expect(countToken(writes, "한")).toBe(1);
     expect(writes.join("")).toBe("한 ");
     expect(writes.join("")).not.toContain("한한");
   });
@@ -546,7 +560,7 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     ]);
 
     const writes = await getWrites(page);
-    expect(writes.filter((w) => w === "안").length).toBe(1);
+    expect(countToken(writes, "안")).toBe(1);
   });
 
   test("Shift keydown mid-composition does not flush — ssang-jamo 있 stays joined", async ({
@@ -719,8 +733,8 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     ]);
 
     const writes = await getWrites(page);
-    expect(writes.filter((w) => w === "안").length).toBe(1);
-    expect(writes.filter((w) => w === "녕").length).toBe(1);
+    expect(countToken(writes, "안")).toBe(1);
+    expect(countToken(writes, "녕")).toBe(1);
     // Order matters — 안 must arrive before 녕.
     const joined = writes.join("");
     expect(joined.indexOf("안")).toBeLessThan(joined.indexOf("녕"));
@@ -775,8 +789,8 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     ]);
 
     const writes = await getWrites(page);
-    expect(writes.filter((w) => w === "있").length).toBe(1);
-    expect(writes.filter((w) => w === "안").length).toBe(1);
+    expect(countToken(writes, "있")).toBe(1);
+    expect(countToken(writes, "안")).toBe(1);
     const joined = writes.join("");
     // Critical: the post-space composition's textarea-tail slice would
     // re-emit "있" if sentPrefix wasn't reset by the prior commit.
@@ -844,8 +858,8 @@ test.describe("terminal: IME (PR #104 regression)", () => {
 
     const writes = await getWrites(page);
     // The two Hangul syllables on the IME path must each commit exactly once.
-    expect(writes.filter((w) => w === "있").length).toBe(1);
-    expect(writes.filter((w) => w === "한").length).toBe(1);
+    expect(countToken(writes, "있")).toBe(1);
+    expect(countToken(writes, "한")).toBe(1);
     // sentPrefix-regression markers: the next Hangul commit must not drag
     // the ASCII prefix into its emit, and must not re-emit "있".
     expect(writes).not.toContain("Abc한");


### PR DESCRIPTION
## Why

Scrolling inside Claude CLI (and other alt-screen TUIs) froze Acorn. The wheel is app-owned, not xterm viewport scroll. Each tick was:

1. up to 8 mouse reports → 8 `pty_write` IPCs, often on the UI thread via a blocking daemon RPC
2. a full TUI redraw coming back as 4KB PTY frames, each becoming a WKWebView Channel `eval` (and a fetch round-trip above 1KB)
3. extra JS work on that firehose (CSI-stripping permission detector, 2 Hz whole-process `pty_cwd`)

## What

- Coalesce PTY **output** in the app: leading-edge send for keystroke echo, then 8ms / 64KB catch-up window. Daemon protocol unchanged.
- Make `pty_write` async + `spawn_blocking`, serialized per session so reports cannot reorder.
- Join stdin writes that land in the same turn into one `pty_write` (microtask coalescer).
- Skip the permission-string detector while a TUI owns the pointer; only inspect the last 1KB of a chunk otherwise.
- Probe live cwd every 5s instead of 500ms.

Left alone on purpose: DOM renderer (IME), `MAX_LINES_PER_EVENT` (native-equivalent reporting), per-write `term.refresh`.

## Test plan

- [x] `pnpm exec vitest run src/lib/ptyWriteCoalescer.test.ts src/lib/permissionWarmup.test.ts src/lib/terminalWheelScroll.test.ts`
- [x] `pnpm run typecheck`
- [x] `cargo test --lib pty_output`
- [x] `cargo test --lib pty_write_does_not_infer`
- [ ] Scroll a long Claude Code conversation in Acorn: app chrome stays live, wheel still moves about one report per line
- [ ] Type in a normal shell: echo still feels immediate (leading-edge output flush)