### PR TITLE
fix(terminal): keep PTY byte order and restore permission detection

### DIFF
--- a/src-tauri/src/pty_output.rs
+++ b/src-tauri/src/pty_output.rs
@@ -16,6 +16,9 @@ use uuid::Uuid;
 /// immediate send so a keystroke echo is not delayed by the window.
 const MAX_BATCH_BYTES: usize = 64 * 1024;
 const FLUSH_DELAY: Duration = Duration::from_millis(8);
+/// Remounts leave a brief gap with no Channel. Hold bytes this many flushes
+/// before falling back to `emit`, which nobody is listening to during that gap.
+const MAX_VACANT_RETRIES: u8 = 6;
 
 #[derive(Serialize, Clone)]
 pub struct OutputPayload {
@@ -33,6 +36,7 @@ struct SessionOutputBatch {
     buf: Vec<u8>,
     event: String,
     timer_armed: bool,
+    vacant_retries: u8,
 }
 
 enum EnqueueEffect {
@@ -45,12 +49,14 @@ enum EnqueueEffect {
 }
 
 fn enqueue_output(batch: &mut SessionOutputBatch, event: &str, bytes: &[u8]) -> EnqueueEffect {
-    batch.event = event.to_string();
+    if batch.event.is_empty() {
+        batch.event = event.to_string();
+    }
     if !batch.timer_armed && batch.buf.is_empty() {
         batch.timer_armed = true;
         return EnqueueEffect::Dispatch {
             bytes: bytes.to_vec(),
-            event: event.to_string(),
+            event: batch.event.clone(),
             arm_timer: true,
         };
     }
@@ -58,7 +64,7 @@ fn enqueue_output(batch: &mut SessionOutputBatch, event: &str, bytes: &[u8]) -> 
     if batch.buf.len() >= MAX_BATCH_BYTES {
         return EnqueueEffect::Dispatch {
             bytes: std::mem::take(&mut batch.buf),
-            event: event.to_string(),
+            event: batch.event.clone(),
             arm_timer: false,
         };
     }
@@ -70,6 +76,9 @@ struct Inner {
     next_token: AtomicU64,
     channels: DashMap<Uuid, OutputSubscription>,
     batches: Mutex<HashMap<Uuid, SessionOutputBatch>>,
+    /// Held around take_flush + Channel send so a reader lead-edge cannot
+    /// overtake a timer flush of earlier bytes.
+    dispatch: DashMap<Uuid, Arc<Mutex<()>>>,
 }
 
 #[derive(Clone, Default)]
@@ -110,6 +119,8 @@ impl PtyOutputRouter {
         if bytes.is_empty() {
             return;
         }
+        let dispatch = self.dispatch_lock(*session_id);
+        let _order = dispatch.lock();
         let effect = {
             let mut batches = self.inner.batches.lock();
             let batch = batches.entry(*session_id).or_default();
@@ -122,42 +133,97 @@ impl PtyOutputRouter {
                 event,
                 arm_timer,
             } => {
-                self.dispatch(app, &event, session_id, &bytes);
-                if arm_timer {
+                self.deliver(app, &event, session_id, bytes, arm_timer);
+            }
+        }
+    }
+
+    fn dispatch_lock(&self, session_id: Uuid) -> Arc<Mutex<()>> {
+        self.inner
+            .dispatch
+            .entry(session_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    fn try_channel(&self, session_id: &Uuid, bytes: &[u8]) -> bool {
+        let Some(entry) = self.inner.channels.get(session_id) else {
+            return false;
+        };
+        let token = entry.token;
+        let channel = entry.channel.clone();
+        drop(entry);
+        if channel.send(Response::new(bytes.to_vec())).is_ok() {
+            return true;
+        }
+        self.unsubscribe(session_id, token);
+        false
+    }
+
+    fn deliver<R: Runtime + 'static>(
+        &self,
+        app: &AppHandle<R>,
+        event: &str,
+        session_id: &Uuid,
+        bytes: Vec<u8>,
+        arm_timer: bool,
+    ) {
+        if bytes.is_empty() {
+            return;
+        }
+        if self.try_channel(session_id, &bytes) {
+            self.clear_vacant_retries(session_id);
+            if arm_timer {
+                self.arm_flush(app.clone(), *session_id);
+            }
+            return;
+        }
+        match self.requeue_front(*session_id, event, &bytes) {
+            Some(need_arm) => {
+                if need_arm {
                     self.arm_flush(app.clone(), *session_id);
+                }
+            }
+            None => {
+                let payload = OutputPayload {
+                    data: base64_encode(&bytes),
+                };
+                if let Err(err) = app.emit(event, payload) {
+                    tracing::warn!(%session_id, error = %err, "failed to emit pty output");
                 }
             }
         }
     }
 
-    fn dispatch<R: Runtime>(
-        &self,
-        app: &AppHandle<R>,
-        event: &str,
-        session_id: &Uuid,
-        bytes: &[u8],
-    ) {
-        if bytes.is_empty() {
+    fn clear_vacant_retries(&self, session_id: &Uuid) {
+        let mut batches = self.inner.batches.lock();
+        let Some(batch) = batches.get_mut(session_id) else {
             return;
-        }
-        if let Some(entry) = self.inner.channels.get(session_id) {
-            let token = entry.token;
-            let channel = entry.channel.clone();
-            drop(entry);
-
-            if channel.send(Response::new(bytes.to_vec())).is_ok() {
-                return;
-            }
-
-            self.unsubscribe(session_id, token);
-        }
-
-        let payload = OutputPayload {
-            data: base64_encode(bytes),
         };
-        if let Err(err) = app.emit(event, payload) {
-            tracing::warn!(%session_id, error = %err, "failed to emit pty output");
+        batch.vacant_retries = 0;
+        if batch.buf.is_empty() && !batch.timer_armed {
+            batches.remove(session_id);
         }
+    }
+
+    /// Put bytes back at the front of the session batch. `Some(need_arm)`
+    /// means they are held; `None` means the vacant-channel budget is spent.
+    fn requeue_front(&self, session_id: Uuid, event: &str, bytes: &[u8]) -> Option<bool> {
+        let mut batches = self.inner.batches.lock();
+        let batch = batches.entry(session_id).or_default();
+        if batch.vacant_retries >= MAX_VACANT_RETRIES {
+            return None;
+        }
+        batch.vacant_retries += 1;
+        if batch.event.is_empty() {
+            batch.event = event.to_string();
+        }
+        let mut combined = bytes.to_vec();
+        combined.append(&mut batch.buf);
+        batch.buf = combined;
+        let need_arm = !batch.timer_armed;
+        batch.timer_armed = true;
+        Some(need_arm)
     }
 
     fn arm_flush<R: Runtime + 'static>(&self, app: AppHandle<R>, session_id: Uuid) {
@@ -168,9 +234,11 @@ impl PtyOutputRouter {
         });
     }
 
-    fn flush_session<R: Runtime>(&self, app: &AppHandle<R>, session_id: Uuid) {
+    fn flush_session<R: Runtime + 'static>(&self, app: &AppHandle<R>, session_id: Uuid) {
+        let dispatch = self.dispatch_lock(session_id);
+        let _order = dispatch.lock();
         let (event, bytes) = self.take_flush(&session_id);
-        self.dispatch(app, &event, &session_id, &bytes);
+        self.deliver(app, &event, &session_id, bytes, false);
     }
 
     fn take_flush(&self, session_id: &Uuid) -> (String, Vec<u8>) {
@@ -181,7 +249,17 @@ impl PtyOutputRouter {
         batch.timer_armed = false;
         let event = std::mem::take(&mut batch.event);
         let bytes = std::mem::take(&mut batch.buf);
-        batches.remove(session_id);
+        let vacant = batch.vacant_retries;
+        if bytes.is_empty() {
+            batches.remove(session_id);
+            return (event, bytes);
+        }
+        // Keep vacant_retries on an empty leftover entry so deliver's
+        // requeue can see the budget. Stash it on a fresh placeholder.
+        *batch = SessionOutputBatch {
+            vacant_retries: vacant,
+            ..SessionOutputBatch::default()
+        };
         (event, bytes)
     }
 }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -64,7 +64,7 @@ import {
   applicationOwnsWheel,
   patchTerminalWheelScroll,
 } from "../lib/terminalWheelScroll";
-import { createPtyWriteCoalescer } from "../lib/ptyWriteCoalescer";
+
 import { UI_SCALE_CHANGED_EVENT } from "../lib/layoutEvents";
 import {
   TERMINAL_PASTE_EVENT,
@@ -1417,18 +1417,10 @@ export function Terminal({
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
 
-    const ptyWriteCoalescer = createPtyWriteCoalescer(
-      (targetSessionId, data) => {
-        invoke("pty_write", {
-          sessionId: targetSessionId,
-          data: encodeStringToBase64(data),
-        }).catch((err: unknown) => {
-          console.error("[Terminal] pty_write failed", err);
-        });
-      },
-    );
     const writeToPty = (targetSessionId: string, data: string) => {
-      ptyWriteCoalescer.enqueue(targetSessionId, data);
+      void api.ptyWrite(targetSessionId, data).catch((err: unknown) => {
+        console.error("[Terminal] pty_write failed", err);
+      });
     };
     const sendToPty = (data: string) => {
       writeToPty(sessionId, data);
@@ -3220,7 +3212,7 @@ export function Terminal({
 
     return () => {
       disposed = true;
-      ptyWriteCoalescer.flush();
+      void api.flushPtyWrite(sessionId);
       const detachingForReuse = consumeTerminalDetaching(sessionId);
       unsubSettings();
       hideLinkTooltip(true);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
+import {
+  enqueuePtyWrite,
+  flushPtyWrite as flushQueuedPtyWrite,
+} from "./ptyWriteCoalescer";
 import type {
   AcornIpcStatus,
   AddProjectSourceResult,
@@ -1177,8 +1181,10 @@ export const api = {
    * on the shell's line buffer untouched.
    */
   ptyWrite(sessionId: string, data: string): Promise<void> {
-    const encoded = encodeStringToBase64(data);
-    return invoke<void>("pty_write", { sessionId, data: encoded });
+    return enqueuePtyWrite(sessionId, data);
+  },
+  flushPtyWrite(sessionId?: string): Promise<void> {
+    return flushQueuedPtyWrite(sessionId);
   },
   fsListDir(
     path: string,
@@ -1340,15 +1346,6 @@ export interface FsPrepareAssetResult {
 export interface FsLineDiffEntry {
   line: number;
   kind: "added" | "modified" | "deleted";
-}
-
-function encodeStringToBase64(input: string): string {
-  const bytes = new TextEncoder().encode(input);
-  let binary = "";
-  for (let i = 0; i < bytes.length; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
 }
 
 /** Which user-invoked agent a resume candidate belongs to. */

--- a/src/lib/permissionWarmup.test.ts
+++ b/src/lib/permissionWarmup.test.ts
@@ -77,6 +77,15 @@ describe("permission warmup gate", () => {
     expect(detector.push(bytes(prefix + message))).toBe(true);
   });
 
+  it("still detects a failure sitting at the start of a large CSI burst", () => {
+    const detector = createFolderPermissionOutputDetector();
+    const csi = "\u001b[38;5;81m";
+    const suffix = csi.repeat(400);
+    const message =
+      "Error: The current working directory must be readable to jthefloor to run brew.\r\n";
+    expect(detector.push(bytes(message + suffix))).toBe(true);
+  });
+
   it("ignores unrelated permission errors", () => {
     const detector = createFolderPermissionOutputDetector();
 

--- a/src/lib/permissionWarmup.ts
+++ b/src/lib/permissionWarmup.ts
@@ -36,9 +36,6 @@ export const FOLDER_PERMISSION_RECHECK_EVENT =
 
 const ANSI_CSI_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
 const MAX_PERMISSION_OUTPUT_TAIL = 512;
-// Permission failures are short ASCII lines. TUI frames are kilobytes of CSI;
-// inspecting only the tail keeps the detector off the redraw hot path.
-const MAX_PERMISSION_INSPECT_BYTES = 1024;
 const BREW_UNREADABLE_CWD =
   /the current working directory must be readable to [^\r\n]+ to run brew\./i;
 const CODEX_PERMISSION_FAILURE =
@@ -53,11 +50,7 @@ export function createFolderPermissionOutputDetector(): {
   return {
     push(bytes) {
       if (bytes.byteLength === 0) return false;
-      const slice =
-        bytes.byteLength > MAX_PERMISSION_INSPECT_BYTES
-          ? bytes.subarray(bytes.byteLength - MAX_PERMISSION_INSPECT_BYTES)
-          : bytes;
-      const output = (tail + decoder.decode(slice, { stream: true })).replace(
+      const output = (tail + decoder.decode(bytes, { stream: true })).replace(
         ANSI_CSI_SEQUENCE,
         "",
       );

--- a/src/lib/ptyWriteCoalescer.test.ts
+++ b/src/lib/ptyWriteCoalescer.test.ts
@@ -2,41 +2,70 @@ import { describe, expect, it } from "vitest";
 import { createPtyWriteCoalescer } from "./ptyWriteCoalescer";
 
 describe("createPtyWriteCoalescer", () => {
-  it("joins writes to the same session into one callback", () => {
+  it("joins writes to the same session into one callback", async () => {
     const sent: Array<[string, string]> = [];
     const scheduled: Array<() => void> = [];
     const coalescer = createPtyWriteCoalescer(
-      (sessionId, data) => sent.push([sessionId, data]),
+      (sessionId, data) => {
+        sent.push([sessionId, data]);
+      },
       (callback) => {
         scheduled.push(callback);
       },
     );
 
-    coalescer.enqueue("a", "x");
-    coalescer.enqueue("a", "y");
-    coalescer.enqueue("b", "z");
+    void coalescer.enqueue("a", "x");
+    void coalescer.enqueue("a", "y");
+    void coalescer.enqueue("b", "z");
     expect(sent).toEqual([]);
-    expect(scheduled).toHaveLength(1);
+    expect(scheduled.length).toBeGreaterThan(0);
 
     scheduled[0]();
+    await coalescer.flush();
     expect(sent).toEqual([
       ["a", "xy"],
       ["b", "z"],
     ]);
   });
 
-  it("ignores empty payloads and can flush without a scheduled turn", () => {
+  it("ignores empty payloads and can flush without a scheduled turn", async () => {
     const sent: Array<[string, string]> = [];
-    const coalescer = createPtyWriteCoalescer((sessionId, data) =>
-      sent.push([sessionId, data]),
-    );
+    const coalescer = createPtyWriteCoalescer((sessionId, data) => {
+      sent.push([sessionId, data]);
+    });
 
-    coalescer.enqueue("a", "");
-    coalescer.flush();
+    await coalescer.enqueue("a", "");
+    await coalescer.flush();
     expect(sent).toEqual([]);
 
-    coalescer.enqueue("a", "hi");
-    coalescer.flush();
+    void coalescer.enqueue("a", "hi");
+    await coalescer.flush();
     expect(sent).toEqual([["a", "hi"]]);
+  });
+
+  it("sends a later burst only after the previous write settles", async () => {
+    const sent: string[] = [];
+    let releaseFirst = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let writes = 0;
+    const coalescer = createPtyWriteCoalescer(async (_sessionId, data) => {
+      writes += 1;
+      if (writes === 1) await firstGate;
+      sent.push(data);
+    });
+
+    const first = coalescer.enqueue("a", "x");
+    void coalescer.flush("a");
+    const second = coalescer.enqueue("a", "y");
+    void coalescer.flush("a");
+    await Promise.resolve();
+    expect(sent).toEqual([]);
+
+    releaseFirst();
+    await first;
+    await second;
+    expect(sent).toEqual(["x", "y"]);
   });
 });

--- a/src/lib/ptyWriteCoalescer.ts
+++ b/src/lib/ptyWriteCoalescer.ts
@@ -1,40 +1,108 @@
+import { invoke } from "@tauri-apps/api/core";
+
 /**
- * Join stdin writes that land in the same turn into one `pty_write`.
+ * Join stdin writes that land in the same turn into one `pty_write`, then
+ * send those bursts in submission order per session.
  *
  * Wheel-driven TUI mouse reports arrive as many tiny `onData` payloads;
  * each invoke is a Tauri IPC hop. One microtask later they are a single
- * write, which also lets the child see the burst as one stdin read.
+ * write. A per-session promise chain keeps the next burst from overtaking
+ * an in-flight invoke, which async Tauri commands do not otherwise order.
  */
 export function createPtyWriteCoalescer(
-  write: (sessionId: string, data: string) => void,
+  write: (sessionId: string, data: string) => Promise<void> | void,
   schedule: (callback: () => void) => void = queueMicrotask,
-): { enqueue: (sessionId: string, data: string) => void; flush: () => void } {
-  const pending = new Map<string, string[]>();
+): {
+  enqueue: (sessionId: string, data: string) => Promise<void>;
+  flush: (sessionId?: string) => Promise<void>;
+} {
+  type SessionPipe = {
+    pending: string[];
+    chain: Promise<void>;
+  };
+  const pipes = new Map<string, SessionPipe>();
   let scheduled = false;
 
-  const drain = () => {
-    scheduled = false;
-    if (pending.size === 0) return;
-    const entries = Array.from(pending.entries());
-    pending.clear();
-    for (const [sessionId, chunks] of entries) {
-      write(sessionId, chunks.join(""));
+  const pipeFor = (sessionId: string): SessionPipe => {
+    let pipe = pipes.get(sessionId);
+    if (!pipe) {
+      pipe = { pending: [], chain: Promise.resolve() };
+      pipes.set(sessionId, pipe);
     }
+    return pipe;
+  };
+
+  const drain = (sessionId: string) => {
+    const pipe = pipes.get(sessionId);
+    if (!pipe || pipe.pending.length === 0) return;
+    const data = pipe.pending.join("");
+    pipe.pending = [];
+    pipe.chain = pipe.chain.then(() => Promise.resolve(write(sessionId, data)));
+  };
+
+  const drainAll = () => {
+    scheduled = false;
+    for (const sessionId of Array.from(pipes.keys())) drain(sessionId);
   };
 
   return {
     enqueue(sessionId, data) {
-      if (data.length === 0) return;
-      const chunks = pending.get(sessionId);
-      if (chunks) {
-        chunks.push(data);
-      } else {
-        pending.set(sessionId, [data]);
+      if (data.length === 0) return Promise.resolve();
+      const pipe = pipeFor(sessionId);
+      pipe.pending.push(data);
+      if (!scheduled) {
+        scheduled = true;
+        schedule(drainAll);
       }
-      if (scheduled) return;
-      scheduled = true;
-      schedule(drain);
+      return pipe.chain.then(() => {
+        // After the already-queued chain, this payload is in `pending` or
+        // already folded into the next chained write by drainAll.
+        return pipe.chain;
+      });
     },
-    flush: drain,
+    flush(sessionId) {
+      if (sessionId) {
+        drain(sessionId);
+        return pipes.get(sessionId)?.chain ?? Promise.resolve();
+      }
+      drainAll();
+      return Promise.all(
+        Array.from(pipes.values()).map((pipe) => pipe.chain),
+      ).then(() => undefined);
+    },
   };
+}
+
+function encodeStringToBase64(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+let defaultCoalescer: ReturnType<typeof createPtyWriteCoalescer> | undefined;
+
+function defaultPtyWriteCoalescer() {
+  if (!defaultCoalescer) {
+    defaultCoalescer = createPtyWriteCoalescer((sessionId, data) =>
+      invoke<void>("pty_write", {
+        sessionId,
+        data: encodeStringToBase64(data),
+      }),
+    );
+  }
+  return defaultCoalescer;
+}
+
+export function enqueuePtyWrite(
+  sessionId: string,
+  data: string,
+): Promise<void> {
+  return defaultPtyWriteCoalescer().enqueue(sessionId, data);
+}
+
+export function flushPtyWrite(sessionId?: string): Promise<void> {
+  return defaultPtyWriteCoalescer().flush(sessionId);
 }


### PR DESCRIPTION
Follow-up to #857 from a second Claude Code review.

## Bugs

1. **Permission detector** only inspected the last 1KB of a chunk. Output coalescing makes chunks up to 64KB, so brew/codex errors at the head of a burst were missed. Scan the full chunk again; alt-screen/mouse-tracking still skips the TUI hot path.
2. **Output reorder:** the 8ms timer released the batch lock before Channel send, so a reader lead-edge could dispatch later bytes first. Per-session dispatch lock around take_flush + send.
3. **Remount gap:** no Channel → immediate `emit` that nobody hears. Requeue for ~50ms so a replacement subscriber can attach.
4. **stdin order:** async `pty_write` tasks can acquire the mutex out of invoke order. All writes go through `api.ptyWrite` with a per-session promise chain.

## Test plan

- [x] vitest permission + coalescer
- [x] `pnpm run typecheck`
- [x] `cargo test --lib pty_output`
- [ ] CI E2E (IME shard)