### PR TITLE
perf(terminal): skip full-viewport repaint during wheel-driven TUI scroll

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1416,6 +1416,25 @@ export function Terminal({
         repaintViewport();
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
+    // A TUI that owns the wheel (Claude Code's REPL) redraws the full frame
+    // per scroll tick; stacking the full-viewport refresh above on every one
+    // of those writes doubles the DOM renderer's work and starves the next
+    // wheel event on the UI thread. Skip the per-write refresh while a wheel
+    // burst is in flight — successive frames overwrite any stale cells, and
+    // the idle repaint rebuilds the final frame once the burst goes quiet.
+    // Capture phase so an xterm stopPropagation cannot hide the wheel.
+    const WHEEL_BURST_WINDOW_MS = 250;
+    let lastWheelAt = -Infinity;
+    const onWheelBurst = () => {
+      lastWheelAt = performance.now();
+    };
+    container.addEventListener("wheel", onWheelBurst, {
+      capture: true,
+      passive: true,
+    });
+    const inWheelBurst = () =>
+      applicationOwnsWheel(term) &&
+      performance.now() - lastWheelAt < WHEEL_BURST_WINDOW_MS;
 
     const writeToPty = (targetSessionId: string, data: string) => {
       void api.ptyWrite(targetSessionId, data).catch((err: unknown) => {
@@ -2814,7 +2833,7 @@ export function Terminal({
         if (isActiveRef.current) {
           // Hidden portal targets keep their xterm buffer current but do not
           // need DOM repaint work until TerminalHost moves them on-screen.
-          scheduleViewportFrameRepaint();
+          if (!inWheelBurst()) scheduleViewportFrameRepaint();
           scheduleViewportIdleRepaint();
         }
         // The sticky prompt is buffer-derived; keep it in sync with parsed
@@ -3248,6 +3267,7 @@ export function Terminal({
       }
       resizeObserver.disconnect();
       commandSizeSyncScheduler.dispose();
+      container.removeEventListener("wheel", onWheelBurst, true);
       container.removeEventListener("input", onInput, true);
       container.removeEventListener("keydown", onKeydown, true);
       container.removeEventListener("keypress", onKeypress, true);


### PR DESCRIPTION
## Why

#851/#857 cut the IPC round-trips on the TUI scroll path, but scrolling Claude Code's REPL still felt sluggish. The remaining cost is render-side: every parsed PTY write schedules a full-viewport `refresh(0, rows - 1)` (added in #185 to clear stale DOM cells), so during a wheel-driven TUI scroll each full-frame redraw from Claude is rendered twice — once incrementally by xterm and once as a complete row rebuild. On the DOM renderer that double work pins the UI thread and delays the next wheel event.

## What

While a wheel burst is in flight (last wheel event under 250ms ago and the foreground app owns the wheel), skip the per-write full-viewport repaint. Successive scroll frames overwrite any stale cells anyway, and the existing 120ms idle repaint still rebuilds the final frame once the burst goes quiet, so the stale-DOM cleanup from #185 is preserved.

The wheel listener runs on the capture phase (an xterm `stopPropagation` cannot hide it) and is passive. Scrollback scrolling, keyboard-driven redraws (e.g. the slash-command picker), and non-TUI output are untouched: the skip requires `applicationOwnsWheel`, which is false outside alt-screen/mouse-tracking apps.

## Testing

- [x] `tsc --noEmit`
- [x] `vitest run src/lib/terminalOutputWriter.test.ts src/lib/terminalWheelScroll.test.ts` — 17 passed
- [ ] Feel check scrolling Claude Code's REPL in the packaged app

https://claude.ai/code/session_016KYfv5B4r7EfdmNhrTwVRc
