### PR TITLE
fix(terminal): restore link clicks inside mouse-tracking TUIs

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -254,6 +254,7 @@ const MODIFIER_LINK_LABEL = IS_MAC ? "Command-click" : "Ctrl-click";
 
 interface TerminalRenderInternals {
   _core?: {
+    screenElement?: HTMLElement;
     linkifier?: {
       currentLink?: {
         link?: {
@@ -2223,22 +2224,29 @@ export function Terminal({
     let leftDragSelecting = false;
     let replayingMouse = false;
 
+    // xterm splits its mouse listeners across two elements: the mouse protocol
+    // and the selection service listen on the root, the linkifier listens on
+    // the screen element below it. DOM events never travel downwards, so the
+    // dispatch target picks the audience: the root reaches protocol and
+    // selection, the screen element reaches those two (by bubbling) plus the
+    // linkifier. A click replay must reach the linkifier or terminal links go
+    // dead; a force-select replay must not, or selecting a link's text opens
+    // it.
+    const mouseReplayTarget = (audience: "app" | "app-and-links"): EventTarget => {
+      const root = term.element ?? container;
+      if (audience === "app") return root;
+      return (
+        (term as unknown as TerminalRenderInternals)._core?.screenElement ?? root
+      );
+    };
+
     const dispatchSyntheticMouse = (
       type: "mousedown" | "mouseup",
       x: number,
       y: number,
       extra: MouseEventInit,
+      target: EventTarget,
     ) => {
-      // xterm splits its mouse listeners across two elements: the mouse
-      // protocol and selection sit on the root (`.xterm`), the linkifier sits
-      // on the screen element below it (`.xterm-screen`). Dispatch on the
-      // screen element — it fires there in the target phase and still bubbles
-      // to the root, so all three see the replay. Dispatching on the root
-      // instead would skip the linkifier (bubbling never descends) and kill
-      // link clicks; elementFromPoint could land on a helper textarea or
-      // canvas outside both.
-      const target =
-        term.element?.querySelector(".xterm-screen") ?? term.element ?? container;
       replayingMouse = true;
       try {
         target.dispatchEvent(
@@ -2264,14 +2272,21 @@ export function Terminal({
       modifiers: MouseEventInit;
     }) => {
       if (term.hasSelection()) term.clearSelection();
-      dispatchSyntheticMouse("mousedown", start.x, start.y, {
-        ...start.modifiers,
-        buttons: 1,
-      });
-      dispatchSyntheticMouse("mouseup", start.x, start.y, {
-        ...start.modifiers,
-        buttons: 0,
-      });
+      const target = mouseReplayTarget("app-and-links");
+      dispatchSyntheticMouse(
+        "mousedown",
+        start.x,
+        start.y,
+        { ...start.modifiers, buttons: 1 },
+        target,
+      );
+      dispatchSyntheticMouse(
+        "mouseup",
+        start.x,
+        start.y,
+        { ...start.modifiers, buttons: 0 },
+        target,
+      );
     };
 
     const onTerminalMouseDown = (e: MouseEvent) => {
@@ -2316,12 +2331,18 @@ export function Terminal({
         // finalize it, just like a drag.
         if (e.detail >= 2) {
           leftDragSelecting = true;
-          dispatchSyntheticMouse("mousedown", e.clientX, e.clientY, {
-            ...eventModifiers(e),
-            ...forceSelectModifier,
-            buttons: 1,
-            detail: e.detail,
-          });
+          dispatchSyntheticMouse(
+            "mousedown",
+            e.clientX,
+            e.clientY,
+            {
+              ...eventModifiers(e),
+              ...forceSelectModifier,
+              buttons: 1,
+              detail: e.detail,
+            },
+            mouseReplayTarget("app"),
+          );
         }
       }
     };
@@ -2369,11 +2390,17 @@ export function Terminal({
       // Drag confirmed: open an xterm force-selection anchored at the press
       // point. Subsequent real moves are left alone so xterm extends it.
       leftDragSelecting = true;
-      dispatchSyntheticMouse("mousedown", pendingLeftDrag.x, pendingLeftDrag.y, {
-        ...pendingLeftDrag.modifiers,
-        ...forceSelectModifier,
-        buttons: 1,
-      });
+      dispatchSyntheticMouse(
+        "mousedown",
+        pendingLeftDrag.x,
+        pendingLeftDrag.y,
+        {
+          ...pendingLeftDrag.modifiers,
+          ...forceSelectModifier,
+          buttons: 1,
+        },
+        mouseReplayTarget("app"),
+      );
     };
     const onTerminalMouseUp = (e: MouseEvent) => {
       if (!pendingLeftDrag) return;
@@ -2382,9 +2409,13 @@ export function Terminal({
       if (leftDragSelecting) {
         // Let the real mouseup finalize xterm's selection, then keep it only
         // when it contains text (or was a multi-click word/line select).
-        // Otherwise replay as a TUI click.
+        // Otherwise replay as a TUI click. A timer, not a microtask: this runs
+        // in a capture-phase listener, and the browser drains microtasks
+        // between listener callbacks, so a microtask replay would prime the
+        // linkifier while the same mouseup is still bubbling toward it — the
+        // link would then activate twice for one press.
         leftDragSelecting = false;
-        queueMicrotask(() => {
+        window.setTimeout(() => {
           if (disposed) return;
           const action = terminalMouseTrackingReleaseAction({
             selecting: true,
@@ -2393,7 +2424,7 @@ export function Terminal({
           });
           if (action === "keep-selection") return;
           replayTrackingClick(start);
-        });
+        }, 0);
         return;
       }
       // No drag — a plain click. Swallow the real mouseup and replay without

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2229,10 +2229,16 @@ export function Terminal({
       y: number,
       extra: MouseEventInit,
     ) => {
-      // Mouse-protocol and selection listeners are on xterm's root. Dispatch
-      // there so a helper-textarea or canvas hit from elementFromPoint cannot
-      // miss them.
-      const target = term.element ?? container;
+      // xterm splits its mouse listeners across two elements: the mouse
+      // protocol and selection sit on the root (`.xterm`), the linkifier sits
+      // on the screen element below it (`.xterm-screen`). Dispatch on the
+      // screen element — it fires there in the target phase and still bubbles
+      // to the root, so all three see the replay. Dispatching on the root
+      // instead would skip the linkifier (bubbling never descends) and kill
+      // link clicks; elementFromPoint could land on a helper textarea or
+      // canvas outside both.
+      const target =
+        term.element?.querySelector(".xterm-screen") ?? term.element ?? container;
       replayingMouse = true;
       try {
         target.dispatchEvent(

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1749,6 +1749,149 @@ test.describe("terminal: spawn", () => {
       .toMatch(/\x1b\[<0;\d+;\d+m/);
   });
 
+  test("a jittered click on a terminal link opens it exactly once", async ({
+    page,
+    tauri,
+  }) => {
+    // The takeover fires the force-select mousedown on the wobble and the
+    // click replay on release. Only the replay may reach xterm's linkifier —
+    // if the force-select press primed it too, the passed-through real mouseup
+    // would activate the link a second time and open two browser tabs.
+    await enableTerminalRightClickPasteSelection(page, { fontSize: 24 });
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as { __linkClickChannelId?: number };
+      w.__linkClickChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("open_external_url", (args) => {
+      const { url } = args as { url: string };
+      const w = window as unknown as { __openedUrls?: string[] };
+      w.__openedUrls = [...(w.__openedUrls ?? []), url];
+      return true;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /^shell main · Ready$/ }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __linkClickChannelId?: number })
+              .__linkClickChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText = "https://example.com/acorn";
+    await emitSubscribedPtyOutput(
+      page,
+      "__linkClickChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+    await emitSubscribedPtyOutput(
+      page,
+      "__linkClickChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    const linkRect = await terminalTextRect(page, linkText);
+    expect(linkRect).not.toBeNull();
+    const x = linkRect!.left + 10;
+    const y = (linkRect!.top + linkRect!.bottom) / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    // Past the 8px takeover threshold, still inside one 24px cell.
+    await page.mouse.move(x + 1, y + 10);
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            ((window as unknown as { __openedUrls?: string[] }).__openedUrls ??
+              []).length,
+        ),
+      )
+      .toBe(1);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __openedUrls?: string[] }).__openedUrls,
+      ),
+    ).toEqual([linkText]);
+  });
+
+  test("drag-selecting a terminal link inside a TUI does not open it", async ({
+    page,
+    tauri,
+  }) => {
+    await enableTerminalRightClickPasteSelection(page);
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as { __linkDragChannelId?: number };
+      w.__linkDragChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("open_external_url", (args) => {
+      const { url } = args as { url: string };
+      const w = window as unknown as { __openedUrls?: string[] };
+      w.__openedUrls = [...(w.__openedUrls ?? []), url];
+      return true;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /^shell main · Ready$/ }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __linkDragChannelId?: number })
+              .__linkDragChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText = "https://example.com/acorn";
+    await emitSubscribedPtyOutput(
+      page,
+      "__linkDragChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+    await emitSubscribedPtyOutput(
+      page,
+      "__linkDragChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    // Drag, then right-click: the paste proves the drag kept a selection, so a
+    // missing open cannot be mistaken for a drag that never selected anything.
+    await rightClickSelectedTerminalText(page, linkText);
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          ((window as unknown as { __ptyWrites?: string[] }).__ptyWrites ?? [])
+            .join(""),
+        ),
+      )
+      .toContain(linkText);
+    expect(
+      await page.evaluate(
+        () =>
+          ((window as unknown as { __openedUrls?: string[] }).__openedUrls ?? [])
+            .length,
+      ),
+    ).toBe(0);
+  });
+
   test("drag-select inside a TUI does not send a click to the app", async ({
     page,
     tauri,
@@ -2723,6 +2866,8 @@ test.describe("terminal: spawn", () => {
     });
     await tauri.handle("fs_file_exists", (args) => {
       const { path } = args as { path: string };
+      const w = window as unknown as { __fsFileExistsCalls?: string[] };
+      w.__fsFileExistsCalls = [...(w.__fsFileExistsCalls ?? []), path];
       return path === "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx";
     });
     await tauri.handle("fs_read_file", (args) => {
@@ -2775,7 +2920,16 @@ test.describe("terminal: spawn", () => {
     const x = linkRect!.left + 10;
     const y = (linkRect!.top + linkRect!.bottom) / 2;
     await page.mouse.move(x, y);
-    await page.waitForTimeout(30);
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            (window as unknown as { __fsFileExistsCalls?: string[] })
+              .__fsFileExistsCalls ?? []
+          ).includes("/tmp/demo/src/components/FolderPermissionWarmupModal.tsx"),
+        ),
+      )
+      .toBe(true);
     await page.mouse.click(x, y);
 
     await expect(
@@ -2783,6 +2937,9 @@ test.describe("terminal: spawn", () => {
         name: /FolderPermissionWarmupModal\.tsx Close tab/,
       }),
     ).toBeVisible();
+    await expect(page.locator('[data-acorn-target-line="true"]')).toContainText(
+      "target line 78",
+    );
   });
 
   test("opens file-only terminal links in the code viewer", async ({

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -2682,6 +2682,109 @@ test.describe("terminal: spawn", () => {
     );
   });
 
+  test("opens terminal file links while a TUI holds mouse tracking", async ({
+    page,
+    tauri,
+  }) => {
+    // Right-click paste takes the real left press/release over inside a
+    // mouse-tracking TUI and replays a synthetic pair. The replay has to land
+    // on xterm's screen element: the linkifier listens there, while the mouse
+    // protocol and selection listen on the root above it.
+    await enableTerminalRightClickPasteSelection(page);
+    await tauri.respond("list_projects", [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-term",
+        name: "shell",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      },
+    ]);
+    await tauri.handle("pty_spawn", () => null);
+    await tauri.handle("pty_cwd", () => "/tmp/demo");
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as { __trackingLinkChannelId?: number };
+      w.__trackingLinkChannelId = channel.id;
+      return 1;
+    });
+    await tauri.handle("fs_file_exists", (args) => {
+      const { path } = args as { path: string };
+      return path === "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx";
+    });
+    await tauri.handle("fs_read_file", (args) => {
+      const { path } = args as { path: string };
+      if (path !== "/tmp/demo/src/components/FolderPermissionWarmupModal.tsx") {
+        throw new Error(`unexpected path: ${path}`);
+      }
+      const lines = Array.from(
+        { length: 100 },
+        (_, index) => `line ${index + 1}`,
+      );
+      lines[77] = "target line 78";
+      return {
+        content: lines.join("\n"),
+        size: 1024,
+        truncated: false,
+        binary: false,
+      };
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: /^shell main · Ready$/ }).click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __trackingLinkChannelId?: number })
+              .__trackingLinkChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const linkText = "src/components/FolderPermissionWarmupModal.tsx:78";
+    await emitSubscribedPtyOutput(
+      page,
+      "__trackingLinkChannelId",
+      `${linkText}\r\n`,
+    );
+    await expect(page.locator(".xterm")).toContainText(linkText);
+    await emitSubscribedPtyOutput(
+      page,
+      "__trackingLinkChannelId",
+      "\x1b[?1000h\x1b[?1006h",
+      1,
+    );
+    await expect(page.locator(".xterm.enable-mouse-events")).toBeAttached();
+
+    const linkRect = await terminalTextRect(page, linkText);
+    expect(linkRect).not.toBeNull();
+    const x = linkRect!.left + 10;
+    const y = (linkRect!.top + linkRect!.bottom) / 2;
+    await page.mouse.move(x, y);
+    await page.waitForTimeout(30);
+    await page.mouse.click(x, y);
+
+    await expect(
+      page.getByRole("button", {
+        name: /FolderPermissionWarmupModal\.tsx Close tab/,
+      }),
+    ).toBeVisible();
+  });
+
   test("opens file-only terminal links in the code viewer", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary

Terminal links stopped opening on click inside any TUI that holds mouse tracking (Claude Code, vim, codex, …) whenever the right-click-paste-selection setting is on. Regression from #856.

## Changes

- Route the synthetic click replay at xterm's screen element and the force-select replay at its root.
- Defer the empty-selection click replay with a timer instead of a microtask.

xterm splits its mouse listeners across two elements: the mouse protocol (`bindMouse`) and `SelectionService` register on the root, while `Linkifier` registers on the screen element one level below it. DOM events never descend, so the dispatch target decides the audience. #856 moved every replay from `elementFromPoint(x, y)` to the root, which left the linkifier blind — and since the takeover already swallows the real `mousedown`/`mouseup` at capture phase, nothing was left to activate the link.

Only the click replay is routed at the screen element. Routing the force-select replay there too would activate a link whenever its text was drag-selected, so that one stays on the root where just the selection service and mouse protocol see it.

The empty-selection replay (the trackpad-jitter path #856 added) also had to move off `queueMicrotask`. The release handler runs in a capture-phase listener and Chromium drains microtasks between listener callbacks, so the replay primed the linkifier while the same `mouseup` was still bubbling toward it and the link activated twice — two browser tabs for one press. A timer lands it after the real event completes.

## Test plan

- [x] `opens terminal file links while a TUI holds mouse tracking` — fails on the pre-fix code (no code-viewer tab opens), passes with the fix.
- [x] `a jittered click on a terminal link opens it exactly once` — reverting the timer gives 2 opens.
- [x] `drag-selecting a terminal link inside a TUI does not open it` — routing force-select at the screen element gives 3 opens.
- [x] All 54 terminal e2e tests pass.
- [x] `tsc --noEmit` clean.

Known gap, not addressed here: double-clicking a link still activates it twice, which is also what upstream xterm does outside a tracking TUI. The three new tests repeat the session/pty/fs mock setup their siblings already carry; extracting a shared seeding helper would touch four unrelated tests and belongs in its own change.

## Changelog category

fix
