### PR TITLE
fix(terminal): letter-spacing and normal-buffer regressions from the webgl burst

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1448,7 +1448,18 @@ export function Terminal({
         !terminalBackgroundActive(
           useSettings.getState().settings.appearance.background,
         ),
-      afterSwap: () => repaintViewport(),
+      afterSwap: () => {
+        // The cell-measurement patch (fractional letter-spacing, CJK cell
+        // width) lives on the renderer INSTANCE; every swap builds a fresh
+        // renderer that reverts to stock spacing until re-measured. Re-run
+        // the measurement fit so spacing survives the round-trip.
+        try {
+          fitTerminalRef.current?.();
+        } catch {
+          // Zero-size container mid-teardown; the ResizeObserver re-fits.
+        }
+        repaintViewport();
+      },
     });
     const onWheelBurst = () => {
       lastWheelAt = performance.now();

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1428,6 +1428,14 @@ export function Terminal({
     // Capture phase so an xterm stopPropagation cannot hide the wheel.
     const WHEEL_BURST_WINDOW_MS = 250;
     let lastWheelAt = -Infinity;
+    // Burst treatment is for ALT-SCREEN TUIs only (Claude Code's REPL):
+    // those repaint the whole frame per scroll tick, which is what the DOM
+    // renderer cannot keep up with. Normal-buffer overlay TUIs (Grok) send
+    // small deltas the DOM renderer consumes at display cadence — see the
+    // delta control in tests/e2e/terminal-scroll-perf.spec.ts — so they keep
+    // the stock render path: no renderer swap, no skipped repaints.
+    const altScreenOwnsWheel = () =>
+      term.buffer.active.type === "alternate" && applicationOwnsWheel(term);
     // GPU renderer for the burst window only. The DOM renderer stays the
     // resting state for IME correctness (composition view anchoring, the
     // span-cloning tail view); the WebGL addon takes over while a TUI that
@@ -1441,7 +1449,7 @@ export function Terminal({
         return addon;
       },
       isEligible: () =>
-        applicationOwnsWheel(term) &&
+        altScreenOwnsWheel() &&
         !composing &&
         // The WebGL renderer paints an opaque background; keep the DOM
         // renderer when the terminal background is see-through.
@@ -1463,14 +1471,14 @@ export function Terminal({
     });
     const onWheelBurst = () => {
       lastWheelAt = performance.now();
-      if (applicationOwnsWheel(term)) webglBurst.noteWheel();
+      if (altScreenOwnsWheel()) webglBurst.noteWheel();
     };
     container.addEventListener("wheel", onWheelBurst, {
       capture: true,
       passive: true,
     });
     const inWheelBurst = () =>
-      applicationOwnsWheel(term) &&
+      altScreenOwnsWheel() &&
       performance.now() - lastWheelAt < WHEEL_BURST_WINDOW_MS;
 
     const writeToPty = (targetSessionId: string, data: string) => {

--- a/tests/e2e/terminal-scroll-perf.spec.ts
+++ b/tests/e2e/terminal-scroll-perf.spec.ts
@@ -500,4 +500,90 @@ test.describe("terminal: TUI scroll perf probe", () => {
     await page.waitForTimeout(100);
     expect(await readSpacing()).toBe(before);
   });
+
+  // Grok-style overlay TUIs run on the NORMAL buffer with mouse tracking
+  // (no ?1049). They redraw in small deltas the DOM renderer handles at
+  // display cadence, so the burst machinery (WebGL swap, skipped repaints)
+  // must stay out of their way entirely: no canvas, no scrollback growth,
+  // no doubled frame.
+  test("normal-buffer TUI (grok-like) keeps the stock render path", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+    // Mouse tracking only — the buffer stays normal.
+    await emitPtyOutput(page, "\x1b[?1002h\x1b[?1006h\x1b[2J\x1b[H");
+    await page.waitForTimeout(100);
+
+    const frame = (n: number) => {
+      let out = "\x1b[H";
+      for (let r = 1; r <= 20; r++) {
+        out += `\x1b[${r};1H\x1b[3${(r + n) % 8}mgrok row ${r} tick ${n}\x1b[0m\x1b[K`;
+      }
+      return out;
+    };
+    await emitPtyOutput(page, frame(0));
+    await page.waitForTimeout(100);
+
+    const readState = () =>
+      page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>(".xterm-viewport");
+        const rows = document.querySelector<HTMLElement>(".xterm-rows");
+        const rowTexts = Array.from(
+          document.querySelectorAll(".xterm-rows > div"),
+        )
+          .map((el) => (el.textContent ?? "").trim())
+          .filter((t) => t.length > 0);
+        return {
+          scrollHeight: viewport?.scrollHeight ?? 0,
+          scrollTop: viewport?.scrollTop ?? 0,
+          canvas: !!document.querySelector(".xterm-screen canvas"),
+          domRowsVisible: rows
+            ? getComputedStyle(rows).display !== "none" &&
+              getComputedStyle(rows).visibility !== "hidden"
+            : false,
+          nonEmptyDomRows: rowTexts.length,
+          dupTicks: rowTexts.filter((t) => t.includes("grok row 1 tick"))
+            .length,
+        };
+      });
+
+    const before = await readState();
+    expect(before.canvas).toBe(false);
+
+    // Engage the burst and stream redraw frames like a scrolled TUI.
+    await page.evaluate(() => {
+      const screen = document.querySelector<HTMLElement>(".xterm-screen")!;
+      screen.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: 100,
+          deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    for (let n = 1; n <= 10; n++) {
+      await emitPtyOutput(page, frame(n));
+      await page.waitForTimeout(16);
+    }
+    const during = await readState();
+    await page.waitForTimeout(300);
+    const after = await readState();
+
+    console.log(
+      "[scroll-perf][grok]",
+      JSON.stringify({ before, during, after }),
+    );
+    // The burst renderer must not engage on the normal buffer.
+    expect(during.canvas).toBe(false);
+    expect(after.canvas).toBe(false);
+    // No redraw frame may leak into scrollback: the viewport must not grow.
+    expect(during.scrollHeight).toBe(before.scrollHeight);
+    expect(after.scrollHeight).toBe(before.scrollHeight);
+    // Exactly one copy of the frame, live in the DOM rows throughout.
+    expect(during.domRowsVisible).toBe(true);
+    expect(after.dupTicks).toBeLessThanOrEqual(1);
+  });
 });

--- a/tests/e2e/terminal-scroll-perf.spec.ts
+++ b/tests/e2e/terminal-scroll-perf.spec.ts
@@ -1,4 +1,4 @@
-import { test, type Page } from "./support";
+import { expect, test, type Page } from "./support";
 import type { TauriMock } from "./support";
 
 // Diagnostic probe for the TUI scroll pipeline (#851/#857/#859 follow-up).
@@ -440,5 +440,64 @@ test.describe("terminal: TUI scroll perf probe", () => {
       };
     });
     console.log("[scroll-perf][webgl]", JSON.stringify(result));
+  });
+
+  // Regression gate: the cell-measurement patch (fractional letter-spacing,
+  // CJK width heuristic) lives on the renderer INSTANCE. A WebGL burst swap
+  // builds a fresh DOM renderer on the way back; without re-patching, the
+  // row container's letter-spacing silently reverts after the first scroll
+  // and stays wrong until the next resize.
+  test("letter-spacing survives a webgl burst round-trip", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { letterSpacing: 0.5 } }),
+      );
+    });
+    await seed(tauri);
+    await activateTerminal(page);
+    await enterTuiMode(page);
+    await emitPtyOutput(page, "\x1b[1;1Hhello letter spacing");
+    await page.waitForTimeout(200);
+
+    const readSpacing = () =>
+      page.evaluate(() => {
+        const rows = document.querySelector<HTMLElement>(".xterm-rows");
+        return rows ? rows.style.letterSpacing : null;
+      });
+    const before = await readSpacing();
+    // The fractional 0.5px configuration must have engaged the patch —
+    // otherwise this test would pass vacuously.
+    expect(before).not.toBeNull();
+    expect(before).not.toBe("");
+
+    // One wheel notch → WebGL engages; wait past the 1.5s quiet window so
+    // the DOM renderer comes back.
+    await page.evaluate(() => {
+      const screen = document.querySelector<HTMLElement>(".xterm-screen")!;
+      screen.dispatchEvent(
+        new WheelEvent("wheel", {
+          deltaY: 100,
+          deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    await expect
+      .poll(() => page.evaluate(() => !!document.querySelector(".xterm-screen canvas")))
+      .toBe(true);
+    await expect
+      .poll(
+        () => page.evaluate(() => !!document.querySelector(".xterm-screen canvas")),
+        { timeout: 5_000 },
+      )
+      .toBe(false);
+
+    await page.waitForTimeout(100);
+    expect(await readSpacing()).toBe(before);
   });
 });


### PR DESCRIPTION
## Why

Two follow-up regressions from #861 surfaced in the preview build:

1. **Letter-spacing shifts after scrolling.** The cell-measurement patch (fractional letter-spacing, CJK cell width heuristic in `terminal-cjk-cell-width-addon.ts`) installs itself on the renderer *instance* — and every burst swap builds a fresh renderer that comes up with stock spacing, staying wrong until the next resize. Reproduced before fixing: with `letterSpacing: 0.5` configured, the row container's spacing was `0.510174px` before a burst round-trip and `1.01017px` after.
2. **Grok-style overlay TUIs render doubled frames while scrolling.** Normal-buffer TUIs redraw in small deltas the DOM renderer already consumes at display cadence (the delta control in the perf probe runs a 320ms stream in 511ms vs 1071ms for full frames), so the burst machinery buys them nothing and only adds renderer-swap surface.

## What

- Re-run the cell-measurement fit in the burst controller's `afterSwap`, so both directions of the swap re-install the patch on whichever renderer is live (a no-op on the WebGL side, which has no width cache).
- Gate both burst behaviors — the WebGL renderer swap and the skipped per-write viewport repaints — on the **alternate buffer** being active. Full-repaint alt-screen TUIs (Claude Code's REPL), where the win was measured, keep the special path; normal-buffer overlay TUIs (Grok) keep the stock DOM render pipeline byte-for-byte.

## Testing

- [x] New regression test: burst round-trip asserts row-container letter-spacing is byte-identical after (red before the fix, green after)
- [x] New grok-like probe: normal-buffer TUI with mouse tracking never engages the canvas, no scrollback growth, single frame copy
- [x] `tsc --noEmit`; Chromium e2e terminal IME + scroll perf suites — 21 passed
- [ ] Feel check in the packaged preview app (Claude scroll still fast, Grok doubling gone, spacing stable)

https://claude.ai/code/session_016KYfv5B4r7EfdmNhrTwVRc
