### PR TITLE
fix(terminal): keep letter-spacing and overlay TUIs stable while scrolling

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -62,6 +62,7 @@ import {
   terminalMouseTrackingReleaseAction,
 } from "../lib/terminalMouseTracking";
 import {
+  altScreenOwnsWheel,
   applicationOwnsWheel,
   patchTerminalWheelScroll,
 } from "../lib/terminalWheelScroll";
@@ -1386,10 +1387,11 @@ export function Terminal({
     // stale. Forcing `refresh(0, rows-1)` rebuilds every visible row from
     // the buffer, which clears leftover characters and cursor blocks.
     //
-    // We run one rAF-throttled refresh after each parsed write for live
-    // interactive redraws (notably Claude's slash-command picker), plus
-    // an idle refresh after the burst goes quiet to catch interrupted
-    // final frames.
+    // One rAF-throttled refresh after each parsed write, plus an idle
+    // refresh after the burst goes quiet to catch interrupted final
+    // frames. Alt-screen wheel bursts skip both and rebuild once the
+    // burst window expires — a full refresh per scroll tick starves
+    // the next wheel event.
     const VIEWPORT_REPAINT_IDLE_MS = 120;
     let viewportRepaintTimer: number | null = null;
     let viewportRepaintFrame: number | null = null;
@@ -1419,29 +1421,15 @@ export function Terminal({
         repaintViewport();
       }, VIEWPORT_REPAINT_IDLE_MS);
     };
-    // A TUI that owns the wheel (Claude Code's REPL) redraws the full frame
-    // per scroll tick; stacking the full-viewport refresh above on every one
-    // of those writes doubles the DOM renderer's work and starves the next
-    // wheel event on the UI thread. Skip the per-write refresh while a wheel
-    // burst is in flight — successive frames overwrite any stale cells, and
-    // the idle repaint rebuilds the final frame once the burst goes quiet.
     // Capture phase so an xterm stopPropagation cannot hide the wheel.
     const WHEEL_BURST_WINDOW_MS = 250;
-    let lastWheelAt = -Infinity;
-    // Burst treatment is for ALT-SCREEN TUIs only (Claude Code's REPL):
-    // those repaint the whole frame per scroll tick, which is what the DOM
-    // renderer cannot keep up with. Normal-buffer overlay TUIs (Grok) send
-    // small deltas the DOM renderer consumes at display cadence — see the
-    // delta control in tests/e2e/terminal-scroll-perf.spec.ts — so they keep
-    // the stock render path: no renderer swap, no skipped repaints.
-    const altScreenOwnsWheel = () =>
-      term.buffer.active.type === "alternate" && applicationOwnsWheel(term);
+    let wheelBurstEndTimer: number | null = null;
+    const inAltScreenWheelBurst = () => wheelBurstEndTimer !== null;
     // GPU renderer for the burst window only. The DOM renderer stays the
     // resting state for IME correctness (composition view anchoring, the
     // span-cloning tail view); the WebGL addon takes over while a TUI that
     // owns the wheel is being scrolled, which is the one interaction where
-    // frames arrive faster than the DOM renderer can paint them — see
-    // tests/e2e/terminal-scroll-perf.spec.ts for the measurements.
+    // frames arrive faster than the DOM renderer can paint them.
     const webglBurst = createWebglBurstController({
       loadAddon: () => {
         const addon = new WebglAddon();
@@ -1449,7 +1437,7 @@ export function Terminal({
         return addon;
       },
       isEligible: () =>
-        altScreenOwnsWheel() &&
+        altScreenOwnsWheel(term) &&
         !composing &&
         // The WebGL renderer paints an opaque background; keep the DOM
         // renderer when the terminal background is see-through.
@@ -1457,10 +1445,7 @@ export function Terminal({
           useSettings.getState().settings.appearance.background,
         ),
       afterSwap: () => {
-        // The cell-measurement patch (fractional letter-spacing, CJK cell
-        // width) lives on the renderer INSTANCE; every swap builds a fresh
-        // renderer that reverts to stock spacing until re-measured. Re-run
-        // the measurement fit so spacing survives the round-trip.
+        // The cell-measurement patch lives on the renderer instance.
         try {
           fitTerminalRef.current?.();
         } catch {
@@ -1470,16 +1455,20 @@ export function Terminal({
       },
     });
     const onWheelBurst = () => {
-      lastWheelAt = performance.now();
-      if (altScreenOwnsWheel()) webglBurst.noteWheel();
+      if (!altScreenOwnsWheel(term)) return;
+      webglBurst.noteWheel();
+      if (wheelBurstEndTimer !== null) {
+        window.clearTimeout(wheelBurstEndTimer);
+      }
+      wheelBurstEndTimer = window.setTimeout(() => {
+        wheelBurstEndTimer = null;
+        scheduleViewportFrameRepaint();
+      }, WHEEL_BURST_WINDOW_MS);
     };
     container.addEventListener("wheel", onWheelBurst, {
       capture: true,
       passive: true,
     });
-    const inWheelBurst = () =>
-      altScreenOwnsWheel() &&
-      performance.now() - lastWheelAt < WHEEL_BURST_WINDOW_MS;
 
     const writeToPty = (targetSessionId: string, data: string) => {
       void api.ptyWrite(targetSessionId, data).catch((err: unknown) => {
@@ -2918,8 +2907,10 @@ export function Terminal({
         if (isActiveRef.current) {
           // Hidden portal targets keep their xterm buffer current but do not
           // need DOM repaint work until TerminalHost moves them on-screen.
-          if (!inWheelBurst()) scheduleViewportFrameRepaint();
-          scheduleViewportIdleRepaint();
+          if (!inAltScreenWheelBurst()) {
+            scheduleViewportFrameRepaint();
+            scheduleViewportIdleRepaint();
+          }
         }
         // The sticky prompt is buffer-derived; keep it in sync with parsed
         // output even when the terminal was hidden during the write.
@@ -3341,6 +3332,10 @@ export function Terminal({
       if (viewportRepaintFrame !== null) {
         cancelAnimationFrame(viewportRepaintFrame);
         viewportRepaintFrame = null;
+      }
+      if (wheelBurstEndTimer !== null) {
+        window.clearTimeout(wheelBurstEndTimer);
+        wheelBurstEndTimer = null;
       }
       cancelLinkTooltipHide();
       if (resizeTimer !== null) {

--- a/src/lib/terminal-cjk-cell-width-addon.test.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.test.ts
@@ -258,13 +258,15 @@ describe("terminal CJK cell width patch", () => {
     expect(rowFactory).not.toHaveProperty("defaultSpacing");
   });
 
-  it("restores xterm default letter spacing when no CJK calibration is needed", () => {
+  it("leaves xterm default letter spacing when no CJK calibration is needed", () => {
     const rowContainer = document.createElement("div");
-    const rowFactory = {};
+    const rowFactory = { defaultSpacing: 2 };
+    let defaultSpacingCalls = 0;
     const renderer = {
       _rowContainer: rowContainer,
       _rowFactory: rowFactory,
       _setDefaultSpacing: () => {
+        defaultSpacingCalls += 1;
         rowContainer.style.letterSpacing = "2px";
         Object.assign(rowFactory, { defaultSpacing: 2 });
       },
@@ -299,23 +301,31 @@ describe("terminal CJK cell width patch", () => {
     expect(renderer.dimensions.css.canvas.width).toBe(60);
     expect(rowContainer.style.letterSpacing).toBe("2px");
     expect(rowFactory).toMatchObject({ defaultSpacing: 2 });
+    expect(defaultSpacingCalls).toBe(0);
   });
 
-  it("keeps repeated automatic calibration stable when W measurement includes existing letter spacing", () => {
-    const rowContainer = document.createElement("div");
+  it("keeps repeated automatic calibration stable without clearing live letter spacing", () => {
+    const assignments: string[] = [];
+    const style = {
+      get letterSpacing() {
+        return this.value;
+      },
+      set letterSpacing(value: string) {
+        assignments.push(value);
+        this.value = value;
+      },
+      value: "",
+    };
     const rowFactory = {};
     const renderer = {
-      _rowContainer: rowContainer,
+      _rowContainer: { style } as unknown as HTMLElement,
       _rowFactory: rowFactory,
+      _setDefaultSpacing: undefined as undefined | (() => void),
       _widthCache: {
         clear: () => undefined,
         get: (chars: string, _bold: boolean | number, _italic: boolean | number) => {
           if (chars === "가" || chars === "あ" || chars === "汉" || chars === "漢") {
             return 8;
-          }
-          if (chars === "W") {
-            const spacing = Number.parseFloat(rowContainer.style.letterSpacing);
-            return 8 + (Number.isFinite(spacing) ? spacing : 0);
           }
           return 8;
         },
@@ -333,9 +343,18 @@ describe("terminal CJK cell width patch", () => {
     patchTerminalCellMeasurements(terminal);
 
     expect(renderer.dimensions.css.cell.width).toBe(4);
-    expect(renderer.dimensions.css.canvas.width).toBe(24);
-    expect(rowContainer.style.letterSpacing).toBe("-4px");
+    expect(style.letterSpacing).toBe("-4px");
     expect(rowFactory).toMatchObject({ defaultSpacing: -4 });
+    expect(assignments).toEqual(["-4px"]);
+
+    renderer.dimensions.css.cell.width = 8;
+    renderer.dimensions.css.canvas.width = 48;
+    renderer._setDefaultSpacing?.();
+
+    expect(renderer.dimensions.css.cell.width).toBe(4);
+    expect(style.letterSpacing).toBe("-4px");
+    expect(assignments.every((value) => value !== "")).toBe(true);
+    expect(assignments).toEqual(["-4px"]);
   });
 
   it("reapplies patched metrics synchronously when xterm resize resets dimensions", () => {

--- a/src/lib/terminal-cjk-cell-width-addon.ts
+++ b/src/lib/terminal-cjk-cell-width-addon.ts
@@ -67,7 +67,6 @@ export function patchTerminalCellMeasurements(
     return;
   }
 
-  restoreLegacyCellWidthPatch(renderer);
   const patchOptions = normalizePatchOptions(options);
   if (renderer.__acornCjkCellPatch) {
     renderer.__acornCjkCellPatch.cjkCellWidthHeuristic =
@@ -80,26 +79,19 @@ export function patchTerminalCellMeasurements(
     patchOptions,
   );
   if (targetCellWidth === null) {
-    restoreTerminalCellMeasurements(renderer, widthCache);
-    restoreDefaultSpacing(renderer);
+    if (renderer.__acornCjkCellPatch) {
+      restoreTerminalCellMeasurements(renderer, widthCache);
+      restoreDefaultSpacing(renderer);
+    }
     return;
   }
 
-  const originalCellWidth =
+  const baselineWidth =
     renderer.__acornCjkCellPatch?.originalCellWidth ?? getCellWidth(renderer);
-  if (
-    renderer.__acornCjkCellPatch &&
-    !patchWidthsDiffer(targetCellWidth, originalCellWidth)
-  ) {
-    restoreTerminalCellMeasurements(renderer, widthCache);
-    return;
-  }
-
-  if (
-    !renderer.__acornCjkCellPatch &&
-    !patchWidthsDiffer(targetCellWidth, getCellWidth(renderer))
-  ) {
-    restoreDefaultSpacing(renderer);
+  if (!patchWidthsDiffer(targetCellWidth, baselineWidth)) {
+    if (renderer.__acornCjkCellPatch) {
+      restoreTerminalCellMeasurements(renderer, widthCache);
+    }
     return;
   }
 
@@ -112,7 +104,8 @@ export function patchTerminalCellMeasurements(
       originalCanvasWidth: renderer.dimensions?.css?.canvas?.width,
     };
     renderer._setDefaultSpacing = () => {
-      restoreLegacyCellWidthPatch(renderer);
+      // xterm writes the unpatched cell width before this hook.
+      rememberCurrentRendererMetrics(renderer);
       const patchOptions = currentPatchOptions(renderer);
       const targetCellWidth = measureTargetCellWidth(
         term,
@@ -123,6 +116,13 @@ export function patchTerminalCellMeasurements(
       if (targetCellWidth === null) {
         restoreTerminalCellMeasurements(renderer, widthCache);
         restoreDefaultSpacing(renderer);
+        return;
+      }
+      const baselineWidth =
+        renderer.__acornCjkCellPatch?.originalCellWidth ??
+        getCellWidth(renderer);
+      if (!patchWidthsDiffer(targetCellWidth, baselineWidth)) {
+        restoreTerminalCellMeasurements(renderer, widthCache);
         return;
       }
       recalibrateDefaultSpacing(term, renderer, widthCache, targetCellWidth);
@@ -136,7 +136,10 @@ export function patchTerminalCellMeasurements(
     }
   }
 
-  widthCache.clear?.();
+  if (metricsAlreadyApplied(renderer, widthCache, targetCellWidth)) {
+    return;
+  }
+
   recalibrateDefaultSpacing(term, renderer, widthCache, targetCellWidth);
 
   if (typeof term.rows === "number" && term.rows > 0) {
@@ -270,11 +273,10 @@ function measureTargetCellWidth(
   widthCache: WidthCache,
   options: CellMeasurementPatchOptions,
 ): number | null {
-  if (renderer._rowContainer) {
-    renderer._rowContainer.style.letterSpacing = "";
-  }
-  widthCache.clear?.();
-
+  // xterm's width cache lives under `.xterm-helpers`, a sibling of
+  // `.xterm-rows`, so glyph widths do not inherit the row container's
+  // letter-spacing. Clearing the live container to measure would reflow
+  // every visible cell.
   const asciiWidth = widthCache.get("W", false, false);
   if (asciiWidth <= 0) return null;
 
@@ -286,7 +288,21 @@ function measureTargetCellWidth(
       return asciiWidth / 2 + letterSpacing;
     }
   }
-  return getCellWidth(renderer) + fractionalLetterSpacingDelta(letterSpacing);
+  const baselineWidth =
+    renderer.__acornCjkCellPatch?.originalCellWidth ?? getCellWidth(renderer);
+  return baselineWidth + fractionalLetterSpacingDelta(letterSpacing);
+}
+
+function metricsAlreadyApplied(
+  renderer: DomRenderer,
+  widthCache: WidthCache,
+  cellWidth: number,
+): boolean {
+  if (patchWidthsDiffer(getCellWidth(renderer), cellWidth)) return false;
+  const glyphWidth = widthCache.get("W", false, false);
+  const spacing = cellWidth - glyphWidth;
+  if (!Number.isFinite(spacing)) return false;
+  return renderer._rowContainer?.style.letterSpacing === `${spacing}px`;
 }
 
 function restoreDefaultSpacing(renderer: DomRenderer): void {
@@ -303,17 +319,17 @@ function recalibrateDefaultSpacing(
   widthCache: WidthCache,
   cellWidth: number,
 ): void {
-  if (renderer._rowContainer) {
-    renderer._rowContainer.style.letterSpacing = "";
-  }
-
   applyCellWidth(term, renderer, cellWidth);
 
   const spacing = cellWidth - widthCache.get("W", false, false);
   if (!Number.isFinite(spacing)) return;
 
-  if (renderer._rowContainer) {
-    renderer._rowContainer.style.letterSpacing = `${spacing}px`;
+  const next = `${spacing}px`;
+  if (
+    renderer._rowContainer &&
+    renderer._rowContainer.style.letterSpacing !== next
+  ) {
+    renderer._rowContainer.style.letterSpacing = next;
   }
   if (renderer._rowFactory) {
     renderer._rowFactory.defaultSpacing = spacing;

--- a/src/lib/terminalWheelScroll.test.ts
+++ b/src/lib/terminalWheelScroll.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import {
+  altScreenOwnsWheel,
+  applicationOwnsWheel,
   patchTerminalWheelScroll,
   wheelScrollLineCount,
 } from "./terminalWheelScroll";
@@ -121,6 +123,35 @@ describe("wheelScrollLineCount", () => {
         carry: 0,
       }).lines,
     ).toBe(6);
+  });
+});
+
+describe("altScreenOwnsWheel", () => {
+  it("is true on the alternate buffer", () => {
+    const { term } = makeTerm({
+      mouseTrackingMode: "none",
+      bufferType: "alternate",
+    });
+    expect(applicationOwnsWheel(term)).toBe(true);
+    expect(altScreenOwnsWheel(term)).toBe(true);
+  });
+
+  it("is false for a mouse-tracking overlay on the normal buffer", () => {
+    const { term } = makeTerm({
+      mouseTrackingMode: "any",
+      bufferType: "normal",
+    });
+    expect(applicationOwnsWheel(term)).toBe(true);
+    expect(altScreenOwnsWheel(term)).toBe(false);
+  });
+
+  it("is false for a normal-buffer shell", () => {
+    const { term } = makeTerm({
+      mouseTrackingMode: "none",
+      bufferType: "normal",
+    });
+    expect(applicationOwnsWheel(term)).toBe(false);
+    expect(altScreenOwnsWheel(term)).toBe(false);
   });
 });
 

--- a/src/lib/terminalWheelScroll.ts
+++ b/src/lib/terminalWheelScroll.ts
@@ -81,6 +81,11 @@ export function applicationOwnsWheel(term: XTerm): boolean {
   );
 }
 
+/** Alternate buffer is active and the foreground app owns the wheel. */
+export function altScreenOwnsWheel(term: XTerm): boolean {
+  return term.buffer.active.type === "alternate" && applicationOwnsWheel(term);
+}
+
 /**
  * @param getSpeed Terminal scroll-speed multiplier, read per event so the
  *   setting applies live. Mirrors xterm's own `scrollSensitivity`, which

--- a/tests/e2e/terminal.spec.ts
+++ b/tests/e2e/terminal.spec.ts
@@ -1252,6 +1252,160 @@ test.describe("terminal: spawn", () => {
       });
   });
 
+  test("keeps fractional letter spacing while an alt-screen TUI is scrolled", async ({
+    page,
+    tauri,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "acorn:settings:v1",
+        JSON.stringify({ terminal: { letterSpacing: -0.25 } }),
+      );
+    });
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as { __scrollLetterChannelId?: number };
+      w.__scrollLetterChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __scrollLetterChannelId?: number })
+              .__scrollLetterChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const readSpacing = () =>
+      page.evaluate(() => {
+        const rows = document.querySelector<HTMLElement>(".xterm-rows");
+        return rows?.style.letterSpacing ?? null;
+      });
+
+    await expect.poll(readSpacing).not.toBe("");
+    const before = await readSpacing();
+    expect(before).not.toBeNull();
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__scrollLetterChannelId",
+      "\x1b[?1049h\x1b[?1002h\x1b[?1006h\x1b[2J\x1b[H",
+      0,
+    );
+    for (let n = 1; n <= 8; n++) {
+      await page.evaluate(() => {
+        document.querySelector<HTMLElement>(".xterm-screen")?.dispatchEvent(
+          new WheelEvent("wheel", {
+            deltaY: 100,
+            deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await emitSubscribedPtyOutput(
+        page,
+        "__scrollLetterChannelId",
+        `\x1b[H\x1b[2Kclaude frame ${n}`,
+        n,
+      );
+    }
+
+    await expect.poll(readSpacing).toBe(before);
+  });
+
+  test("keeps a normal-buffer overlay TUI to a single copy while scrolling", async ({
+    page,
+    tauri,
+  }) => {
+    await seedWritableTerminal(tauri);
+    await tauri.handle("pty_subscribe_output", (args) => {
+      const { channel } = args as { channel: { id: number } };
+      const w = window as unknown as { __grokScrollChannelId?: number };
+      w.__grokScrollChannelId = channel.id;
+      return 1;
+    });
+
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /^shell main · Ready$/ })
+      .click();
+    await page.locator(".xterm-helper-textarea").waitFor({ state: "attached" });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (window as unknown as { __grokScrollChannelId?: number })
+              .__grokScrollChannelId ?? null,
+        ),
+      )
+      .not.toBeNull();
+
+    const frame = (n: number) => {
+      let out = "\x1b[H";
+      for (let r = 1; r <= 12; r++) {
+        out += `\x1b[${r};1Hgrok row ${r} tick ${n}\x1b[K`;
+      }
+      return out;
+    };
+
+    await emitSubscribedPtyOutput(
+      page,
+      "__grokScrollChannelId",
+      `\x1b[?1002h\x1b[?1006h\x1b[2J${frame(0)}`,
+      0,
+    );
+    await expect(page.locator(".xterm")).toContainText("grok row 1 tick 0");
+
+    const readState = () =>
+      page.evaluate(() => {
+        const viewport = document.querySelector<HTMLElement>(".xterm-viewport");
+        const rowTexts = Array.from(
+          document.querySelectorAll(".xterm-rows > div"),
+        )
+          .map((el) => (el.textContent ?? "").trim())
+          .filter((t) => t.length > 0);
+        return {
+          scrollHeight: viewport?.scrollHeight ?? 0,
+          dupTicks: rowTexts.filter((t) => t.includes("grok row 1 tick"))
+            .length,
+        };
+      });
+
+    const before = await readState();
+    expect(before.dupTicks).toBe(1);
+
+    for (let n = 1; n <= 8; n++) {
+      await page.evaluate(() => {
+        document.querySelector<HTMLElement>(".xterm-screen")?.dispatchEvent(
+          new WheelEvent("wheel", {
+            deltaY: 100,
+            deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+      await emitSubscribedPtyOutput(page, "__grokScrollChannelId", frame(n), n);
+    }
+
+    await expect
+      .poll(async () => page.locator(".xterm").innerText())
+      .toContain("grok row 1 tick 8");
+    const after = await readState();
+    expect(after.scrollHeight).toBe(before.scrollHeight);
+    expect(after.dupTicks).toBe(1);
+  });
+
   test("applies terminal line height setting to xterm rows", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
- Keep wheel-burst skipped viewport refresh (and the WebGL swap) armed only while an alt-screen catch-up timer is running, so a recent Grok/shell flick cannot suppress the first Claude frame with no replacement refresh.
- Stop the CJK cell-width patch from blanking live `.xterm-rows` letter-spacing during measurement; skip rewriting when metrics are already applied.

## Test plan
- [x] Unit: CJK spacing never writes `""` on re-patch; `altScreenOwnsWheel` false for normal-buffer mouse tracking
- [x] E2E: fractional letter-spacing survives alt-screen TUI scroll; Grok-like overlay stays a single copy
- [ ] Live: Claude REPL scroll (letter-spacing) and Grok overlay scroll (no doubled frame) in the production preview