### PR TITLE
fix(resume): queue resume when the session PTY is not attached

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9321,14 +9321,17 @@ pub async fn pty_write(
     // Daemon-managed sessions route stdin through the control socket.
     // A stream attachment is the fast-path signal, but detached/re-attaching
     // sessions can be alive in the daemon without an app-side output pump
-    // for a short window. The write itself is blocking I/O (socket or PTY
-    // master); run it off the UI thread so a TUI wheel burst cannot stall
-    // WKWebView eval of the matching output.
+    // for a short window. A persisted `daemon_session_id` is sticky even
+    // when `is_alive` is false (boot reconnect, list_sessions blip) so a
+    // bound UUID cannot fall through to the empty in-process map.
+    // The write itself is blocking I/O (socket or PTY master); run it off
+    // the UI thread so a TUI wheel burst cannot stall WKWebView eval of
+    // the matching output.
     let state = state.inner().clone();
     let lock = state.pty_write_lock(id);
     let _write_order = lock.lock().await;
     run_blocking("pty_write", move || {
-        if daemon_session_alive_or_attached(&state, id) {
+        if pty_io_uses_daemon(&state, id) {
             state
                 .daemon_bridge
                 .send_input(id, &bytes)
@@ -9356,7 +9359,7 @@ pub fn pty_resize(
     let id = parse_id(&session_id)?;
     let pixel_width = pixel_width.unwrap_or(0);
     let pixel_height = pixel_height.unwrap_or(0);
-    if daemon_session_alive_or_attached(&state, id) {
+    if pty_io_uses_daemon(&state, id) {
         return state
             .daemon_bridge
             .resize(id, cols, rows, pixel_width, pixel_height)
@@ -9442,6 +9445,18 @@ pub fn pty_detach(
 
 fn daemon_session_alive_or_attached(state: &AppState, id: Uuid) -> bool {
     state.stream_registry.contains(&id) || state.daemon_bridge.is_alive(id)
+}
+
+fn pty_io_uses_daemon(state: &AppState, id: Uuid) -> bool {
+    if daemon_session_alive_or_attached(state, id) {
+        return true;
+    }
+    state
+        .sessions
+        .get(&id)
+        .ok()
+        .and_then(|session| session.daemon_session_id)
+        .is_some()
 }
 
 fn detach_requested_by_stale_renderer(
@@ -12225,7 +12240,7 @@ mod tests {
         infer_acornd_root_from_session_pids, inject_agent_hook_env,
         linked_worktree_root_for_registered_path, memory_root_pids, normalize_session_goal,
         normalize_session_graph, poll_defers_to_hook, project_creation_git_error,
-        remove_linked_worktree_at_path, restore_pending_session_removal,
+        pty_io_uses_daemon, remove_linked_worktree_at_path, restore_pending_session_removal,
         retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror,
         should_route_session_to_daemon, terminate_session_runtime, validate_display_name,
         validate_editor_command, validate_new_project_name, validate_pty_caller_env,
@@ -16457,6 +16472,30 @@ mod tests {
         assert!(should_route_session_to_daemon(true, None));
         assert!(should_route_session_to_daemon(false, Some(daemon_id)));
         assert!(!should_route_session_to_daemon(false, None));
+    }
+
+    #[test]
+    fn sticky_daemon_binding_routes_pty_io_without_live_attachment() {
+        let state = AppState::new();
+        let session = state
+            .sessions
+            .insert(scoped_session("sticky-daemon", "/tmp", false));
+        state
+            .sessions
+            .set_daemon_session_id(&session.id, Some(session.id))
+            .expect("bind session to daemon");
+
+        assert!(pty_io_uses_daemon(&state, session.id));
+    }
+
+    #[test]
+    fn unbound_session_does_not_route_pty_io_through_daemon() {
+        let state = AppState::new();
+        let session = state
+            .sessions
+            .insert(scoped_session("in-process", "/tmp", false));
+
+        assert!(!pty_io_uses_daemon(&state, session.id));
     }
 
     #[test]

--- a/src/components/AgentResumeModal.test.tsx
+++ b/src/components/AgentResumeModal.test.tsx
@@ -25,6 +25,7 @@ vi.mock("../lib/toasts", () => ({
 
 import { AgentResumeModal } from "./AgentResumeModal";
 import type { AgentKind, ResumeCandidate } from "../lib/api";
+import { useAppStore } from "../store";
 
 const CANDIDATE: ResumeCandidate = {
   uuid: "deadbeef-1234-5678-9abc-def012345678",
@@ -55,6 +56,7 @@ describe("AgentResumeModal", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    useAppStore.setState({ pendingTerminalInput: {} });
     vi.clearAllMocks();
   });
 
@@ -203,9 +205,30 @@ describe("AgentResumeModal", () => {
 
     expect(onDismiss).not.toHaveBeenCalled();
     expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
+    expect(useAppStore.getState().pendingTerminalInput[SESSION_ID]).toBeUndefined();
     expect(document.querySelector('[role="alert"]')?.textContent).toContain(
       "Failed to send the resume command: PTY access denied",
     );
+  });
+
+  it("queues Resume for the next PTY spawn when the session has no live handle", async () => {
+    mocks.ptyWrite.mockRejectedValueOnce(
+      new Error(
+        "pty error: pty error: no pty for session 11111111-2222-3333-4444-555555555555",
+      ),
+    );
+    const onDismiss = render("grok", CANDIDATE);
+
+    await clickButton("Resume");
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(mocks.acknowledgeAgentResume).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="alert"]')).toBeNull();
+    expect(useAppStore.getState().pendingTerminalInput[SESSION_ID]).toEqual({
+      command: `grok --resume ${CANDIDATE.uuid}`,
+      adoptWorktreeOnExit: false,
+      agentProvider: "grok",
+    });
   });
 
   it("keeps the candidate open and unacknowledged when clipboard access fails", async () => {

--- a/src/components/AgentResumeModal.tsx
+++ b/src/components/AgentResumeModal.tsx
@@ -3,9 +3,11 @@ import { useEffect, useMemo, useState, type ReactElement } from "react";
 import { api, type AgentKind, type ResumeCandidate } from "../lib/api";
 import { buildAgentResumeCommand } from "../lib/agentProvider";
 import type { TranslationKey, Translator } from "../lib/i18n";
+import { isMissingPtyError } from "../lib/ptyErrors";
 import { useToasts } from "../lib/toasts";
 import { writeClipboardText } from "../lib/clipboardText";
 import { useTranslation } from "../lib/useTranslation";
+import { useAppStore } from "../store";
 import {
   Button,
   CodeValue,
@@ -131,10 +133,20 @@ export function AgentResumeModal({
     // PTYs expect a carriage return (`\r`, what xterm sends when the
     // user presses Enter) to commit a line. Using `\n` lands as a
     // literal LF in zsh's line buffer instead of running the command.
-    const cmd = `${buildAgentResumeCommand(agent, candidate.uuid)}\r`;
+    const command = buildAgentResumeCommand(agent, candidate.uuid);
     try {
-      await api.ptyWrite(sessionId, cmd);
+      await api.ptyWrite(sessionId, `${command}\r`);
     } catch (writeError: unknown) {
+      // Cold boot paints the restored snapshot before `pty_spawn`
+      // returns, so Resume can land with no live handle. Queue for
+      // the in-flight or next spawn instead of failing the click.
+      if (isMissingPtyError(writeError)) {
+        useAppStore.getState().setPendingTerminalInput(sessionId, command, {
+          agentProvider: agent,
+        });
+        onDismiss();
+        return;
+      }
       setError(
         `${dt(t, "dialogs.agentResume.resumeFailed")} ${errorMessage(writeError)}`,
       );

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2728,19 +2728,26 @@ export function Terminal({
     // created it while this shell was idle.
     let worktreeSnapshot: Set<string> | null = null;
     let worktreeAdoptionIntent: WorktreeAdoptionIntent = { kind: "none" };
+    // Restore after a failed drain re-enters `pendingTerminalInput`. The
+    // subscribe below would otherwise retry the same live PTY in a loop.
+    let restoringFailedQueue = false;
 
     async function writeQueuedCommand(queued: PendingTerminalInput) {
       if (disposed) {
+        restoringFailedQueue = true;
         useAppStore.getState().restorePendingTerminalInput(sessionId, queued);
+        restoringFailedQueue = false;
         return;
       }
       const payload = encodeStringToBase64(queued.command + "\r");
       try {
         await invoke("pty_write", { sessionId, data: payload });
       } catch (err) {
+        restoringFailedQueue = true;
         const restored = useAppStore
           .getState()
           .restorePendingTerminalInput(sessionId, queued);
+        restoringFailedQueue = false;
         console.error("[Terminal] pending pty_write failed", err);
         if (!disposed) {
           const retryDetail = restored
@@ -2852,7 +2859,7 @@ export function Terminal({
     // immediately when the PTY is live; respawn if this shell already
     // exited. An in-flight spawn still consumes the queue at the end.
     const unsubPendingInput = useAppStore.subscribe((state, prev) => {
-      if (disposed) return;
+      if (disposed || restoringFailedQueue) return;
       if (!state.pendingTerminalInput[sessionId]) return;
       if (prev.pendingTerminalInput[sessionId]) return;
       if (ptyReady) {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -130,7 +130,7 @@ import {
   type WorktreeAdoptionIntent,
 } from "../lib/worktreeAdoption";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
-import { useAppStore } from "../store";
+import { useAppStore, type PendingTerminalInput } from "../store";
 import { StickyUserPrompt } from "./StickyUserPrompt";
 import { FloatingTooltip, Tooltip, type TooltipAnchorRect } from "./Tooltip";
 
@@ -2719,6 +2719,7 @@ export function Terminal({
     resizeObserver.observe(container);
 
     let exited = false;
+    let spawnInFlight = false;
     // Snapshot of linked worktrees taken right before each PTY spawn. On exit
     // we re-fetch and compare when this spawn cycle carried an explicit
     // adoption intent, or when this session's own live cwd was observed inside
@@ -2728,8 +2729,49 @@ export function Terminal({
     let worktreeSnapshot: Set<string> | null = null;
     let worktreeAdoptionIntent: WorktreeAdoptionIntent = { kind: "none" };
 
+    async function writeQueuedCommand(queued: PendingTerminalInput) {
+      if (disposed) {
+        useAppStore.getState().restorePendingTerminalInput(sessionId, queued);
+        return;
+      }
+      const payload = encodeStringToBase64(queued.command + "\r");
+      try {
+        await invoke("pty_write", { sessionId, data: payload });
+      } catch (err) {
+        const restored = useAppStore
+          .getState()
+          .restorePendingTerminalInput(sessionId, queued);
+        console.error("[Terminal] pending pty_write failed", err);
+        if (!disposed) {
+          const retryDetail = restored
+            ? " The command remains queued for the next terminal attach."
+            : " A newer command is already queued for this session.";
+          term.write(
+            `\r\n${ANSI_RED}[acorn] Failed to run queued command: ${formatError(err)}${retryDetail}${ANSI_RESET}\r\n`,
+          );
+          showTranslatedErrorToast(
+            "toasts.session.pendingCommandFailed",
+            err,
+          );
+        }
+        return;
+      }
+      if (queued.adoptWorktreeOnExit) {
+        worktreeAdoptionIntent = { kind: "after-exit" };
+      }
+    }
+
+    async function drainQueuedTerminalInput() {
+      const queued = useAppStore
+        .getState()
+        .consumePendingTerminalInput(sessionId);
+      if (!queued) return;
+      await writeQueuedCommand(queued);
+    }
+
     async function spawnPty() {
-      if (disposed) return;
+      if (disposed || spawnInFlight) return;
+      spawnInFlight = true;
       try {
         ptyReady = false;
         lastPtyResize = null;
@@ -2793,53 +2835,32 @@ export function Terminal({
         // Drain the queue once the PTY is alive — the shell buffers the
         // bytes until its prompt is ready, so a small startup delay is
         // tolerable without coordinating with the prompt-ready signal.
-        const queued = useAppStore
-          .getState()
-          .consumePendingTerminalInput(sessionId);
-        // Cleanup can run between consume and write under StrictMode's
-        // mount/cleanup/mount sequence. Re-check `disposed` so we do not
-        // pty_write into a session whose PTY has already been killed.
-        if (queued) {
-          if (disposed) {
-            useAppStore
-              .getState()
-              .restorePendingTerminalInput(sessionId, queued);
-            return;
-          }
-          const payload = encodeStringToBase64(queued.command + "\r");
-          try {
-            await invoke("pty_write", { sessionId, data: payload });
-          } catch (err) {
-            const restored = useAppStore
-              .getState()
-              .restorePendingTerminalInput(sessionId, queued);
-            console.error("[Terminal] pending pty_write failed", err);
-            if (!disposed) {
-              const retryDetail = restored
-                ? " The command remains queued for the next terminal attach."
-                : " A newer command is already queued for this session.";
-              term.write(
-                `\r\n${ANSI_RED}[acorn] Failed to run queued command: ${formatError(err)}${retryDetail}${ANSI_RESET}\r\n`,
-              );
-              showTranslatedErrorToast(
-                "toasts.session.pendingCommandFailed",
-                err,
-              );
-            }
-            return;
-          }
-          if (queued.adoptWorktreeOnExit) {
-            worktreeAdoptionIntent = { kind: "after-exit" };
-          }
-        }
+        await drainQueuedTerminalInput();
       } catch (err) {
         if (!disposed) {
           term.write(
             `\r\n${ANSI_RED}[acorn] Failed to spawn pty: ${formatError(err)}${ANSI_RESET}\r\n`,
           );
         }
+      } finally {
+        spawnInFlight = false;
       }
     }
+
+    // Resume can queue after this mount already drained an empty queue
+    // (snapshot restore finishes, then the user clicks Resume). Drain
+    // immediately when the PTY is live; respawn if this shell already
+    // exited. An in-flight spawn still consumes the queue at the end.
+    const unsubPendingInput = useAppStore.subscribe((state, prev) => {
+      if (disposed) return;
+      if (!state.pendingTerminalInput[sessionId]) return;
+      if (prev.pendingTerminalInput[sessionId]) return;
+      if (ptyReady) {
+        void drainQueuedTerminalInput();
+        return;
+      }
+      if (exited) void spawnPty();
+    });
 
     const outputWriter = createTerminalOutputWriter({
       write: (bytes, onParsed) => {
@@ -3250,6 +3271,7 @@ export function Terminal({
       disposed = true;
       void api.flushPtyWrite(sessionId);
       const detachingForReuse = consumeTerminalDetaching(sessionId);
+      unsubPendingInput();
       unsubSettings();
       hideLinkTooltip(true);
       if (themeFrame !== null) {

--- a/src/lib/ptyErrors.test.ts
+++ b/src/lib/ptyErrors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isMissingPtyError } from "./ptyErrors";
+
+describe("isMissingPtyError", () => {
+  it("matches the in-process manager miss wrapped by AppError::Pty", () => {
+    expect(
+      isMissingPtyError(
+        new Error(
+          "pty error: pty error: no pty for session cc3fe5a0-bc1c-4172-ad7a-11f8a0e5cdce",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a daemon registry miss", () => {
+    expect(
+      isMissingPtyError(
+        new Error("pty error: no pty for 01a03753-00fb-70e3-8309-478ee878d227"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects other PTY failures so they stay visible to the caller", () => {
+    expect(isMissingPtyError(new Error("PTY access denied"))).toBe(false);
+    expect(isMissingPtyError(new Error("pty error: write failed"))).toBe(false);
+    expect(isMissingPtyError("clipboard permission denied")).toBe(false);
+  });
+});

--- a/src/lib/ptyErrors.ts
+++ b/src/lib/ptyErrors.ts
@@ -1,0 +1,10 @@
+/**
+ * True when a PTY write/resize/kill failed because this session has no live
+ * PTY handle yet — in-process manager miss (`no pty for session <id>`) or
+ * daemon registry miss (`no pty for <id>`). Resume can queue for the next
+ * spawn in that window; other failures should stay visible.
+ */
+export function isMissingPtyError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /no pty for(?: session)? /i.test(message);
+}

--- a/tests/e2e/agent-resume-modal.spec.ts
+++ b/tests/e2e/agent-resume-modal.spec.ts
@@ -289,6 +289,80 @@ test.describe("agent resume modal", () => {
     expect(acked).not.toContain(SESSION.id);
   });
 
+  test("Resume queues grok --resume when the PTY is missing and writes it after spawn", async ({
+    page,
+    tauri,
+    errorTracker,
+  }) => {
+    errorTracker.allow(/no pty for session/);
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION]);
+    await tauri.handle("get_agent_resume_candidate", (args) => {
+      const input = (args ?? {}) as { kind?: string };
+      if (input.kind !== "grok") return null;
+      return {
+        uuid: "deadbeef-1234-5678-9abc-def012345678",
+        lastActivityUnix: Math.floor(Date.now() / 1000) - 60,
+        preview: "Previous Grok turn",
+        lastUserMessage: "continue from cold boot",
+        lastAgentMessage: "Previous Grok turn",
+      };
+    });
+    await tauri.handle("pty_write", (args) => {
+      const w = window as unknown as {
+        __ACORN_PTY_WRITES__?: { sessionId: string; data: string }[];
+        __ACORN_PTY_WRITE_ATTEMPTS__?: number;
+      };
+      w.__ACORN_PTY_WRITES__ = w.__ACORN_PTY_WRITES__ ?? [];
+      w.__ACORN_PTY_WRITE_ATTEMPTS__ = (w.__ACORN_PTY_WRITE_ATTEMPTS__ ?? 0) + 1;
+      const input = (args ?? {}) as { sessionId?: string; data?: string };
+      const decoded = input.data
+        ? new TextDecoder().decode(
+            Uint8Array.from(atob(input.data), (c) => c.charCodeAt(0)),
+          )
+        : "";
+      if (w.__ACORN_PTY_WRITE_ATTEMPTS__ === 1) {
+        throw new Error(
+          "pty error: pty error: no pty for session s-resume",
+        );
+      }
+      w.__ACORN_PTY_WRITES__.push({
+        sessionId: input.sessionId ?? "",
+        data: decoded,
+      });
+      return undefined;
+    });
+
+    await page.goto("/");
+
+    const modal = page.getByRole("dialog", {
+      name: /Resume previous conversation/,
+    });
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText("Grok");
+    await modal.getByRole("button", { name: /Resume/ }).click();
+    await expect(modal).toBeHidden();
+    await expect(modal.getByRole("alert")).toHaveCount(0);
+
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __ACORN_PTY_WRITES__?: { sessionId: string; data: string }[];
+              }
+            ).__ACORN_PTY_WRITES__ ?? [],
+        ),
+      )
+      .toEqual([
+        {
+          sessionId: SESSION.id,
+          data: `grok --resume ${CANDIDATE_UUID}\r`,
+        },
+      ]);
+  });
+
   test("Cancel writes a shell-comment hint with the resume command", async ({
     page,
     tauri,


### PR DESCRIPTION
## Summary
Cold boot restores the terminal snapshot before `pty_spawn` returns. Clicking Resume in that window wrote stdin into the empty in-process PTY map and showed `no pty for session`.

Resume now queues the provider command for the next spawn (or drains it immediately if the PTY is already live). Daemon-bound sessions stay on the daemon write/resize path even before stream attach, so a sticky `daemon_session_id` cannot fall through to a missing in-process handle.

Verified: unit tests, agent-resume-modal E2E, and a local cold-boot Grok resume in the debug app.

## Self-review
- Queue path matches existing `pendingTerminalInput` used by CommandRunDialog.
- Missing-PTY matching is scoped to `no pty for` so permission/write failures still stay on the modal.
- Sticky daemon routing is the same invariant as spawn: one UUID never splits across two PTY backends.
- Non-blocking: store subscribe ignores an overwrite of an already-queued command (resume is the first queue in this flow).

## Test plan
- [x] Vitest: `ptyErrors`, `AgentResumeModal` queue-on-no-pty
- [x] Playwright: Resume with first `pty_write` failing, then spawn writes `grok --resume`
- [x] Manual: quit debug Acorn, relaunch, Resume previous Grok conversation