### PR TITLE
chore(release): v1.33.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.33.0",
+  "version": "1.33.1",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.33.0"
+version = "1.33.1"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.33.0"
+version = "1.33.1"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.33.1 from `main`, publishing the 14 commits merged since v1.33.0 — a patch of terminal TUI correctness/performance work, the Grok/Claude resume cold-boot fix, and two dependency group bumps.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.33.0 to 1.33.1.
2. **Release scope** — 9 terminal TUI fixes (#855, #856, #858, #860, #862–#864, plus #865 resume), 3 terminal performance patches (#857, #859, #861), and 2 dependency group bumps (#853, #854). No new user-facing features.
3. **Publication path** — builds both macOS architectures and the Windows x64 NSIS updater pair, then publishes a three-platform `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Resume | Cold-boot "Resume previous conversation" no longer fails with `no pty for session` when the PTY is not attached yet; the command is queued and written after spawn. Sticky daemon sessions keep write/resize on the daemon route. |
| Terminal TUI | Overlay TUIs stay painted, clicks forward while right-click paste is on, letter-spacing/DOM renderer stay stable during scroll, link clicks work inside mouse-tracking TUIs, and PTY byte order is preserved. |
| Terminal performance | TUI scroll IPC is coalesced; wheel-driven bursts skip full-viewport repaint and use the GPU renderer. |
| Updater | Publishes a patch update for both macOS architectures and Windows x64. |

## Design notes

- 1.33.1 is a patch release because everything since v1.33.0 is fixes, performance, and dependency bumps — no new user-visible features.
- This PR changes version metadata only; every change it publishes was reviewed and merged independently.
- Release notes are generated from changelog-labelled merged PRs. This version PR carries `skip-changelog` so it is excluded from them.

## Follow-up (not in this PR)

- Push annotated tag `v1.33.1` after merge.
- Verify macOS and Windows artifacts, updater signatures, `latest.json`, the Latest pointer, and release-note identity.

## Test plan

- [x] `pnpm run typecheck` — passes.
- [x] `node scripts/validate-release-version.mjs v1.33.1` — all four version sources match.
- [x] `node scripts/validate-release-version.mjs --assert-newer v1.33.1 v1.33.0` — patch ordering passes.
- [x] Locked Cargo metadata reports Acorn `1.33.1`.
- [x] Release-focused Vitest (`scripts/validate-release-version.test.mjs`, `release-notes.test.mjs`, `release-artifacts.test.mjs`) — 3 files, 19 tests pass.
- [x] `git diff --check` — passes.
- [ ] PR CI — wait for required checks.