### PR TITLE
fix(terminal): answer XTVERSION on the PTY reader so Grok cannot paint >|xterm.js

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/pty.rs
+++ b/src-tauri/crates/acorn-daemon/src/pty.rs
@@ -20,7 +20,7 @@
 //!    context. Unknown agents pass through unmodified.
 
 use std::collections::HashMap;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -265,13 +265,11 @@ impl PtyManager {
         let created_at = session.created_at;
         registry.insert(session);
 
-        let stop_reader = stop.clone();
-        let scrollback_reader = scrollback.clone();
-        let output_tx_reader = output_tx.clone();
+        let handle_reader = Arc::clone(&handle);
         std::thread::Builder::new()
             .name(format!("acornd-pty-read-{session_id}"))
             .spawn(move || {
-                read_loop(reader, stop_reader, scrollback_reader, output_tx_reader);
+                read_loop(reader, handle_reader);
             })?;
 
         let handles_for_wait = Arc::clone(&self.handles);
@@ -459,28 +457,31 @@ fn apply_resume_strategy(
     }
 }
 
-fn read_loop(
-    mut reader: Box<dyn Read + Send>,
-    stop: Arc<AtomicBool>,
-    scrollback: Arc<RingBuffer>,
-    output_tx: broadcast::Sender<OutputChunk>,
-) {
+fn read_loop(mut reader: Box<dyn Read + Send>, handle: Arc<PtyHandle>) {
     let mut buf = [0u8; READ_BUFFER_SIZE];
+    let mut xtversion = acorn_platform::xtversion::XtversionProbe::default();
     loop {
-        if stop.load(Ordering::SeqCst) {
+        if handle.stop.load(Ordering::SeqCst) {
             break;
         }
         match reader.read(&mut buf) {
             Ok(0) => break, // EOF
             Ok(n) => {
                 let chunk = &buf[..n];
-                let span = scrollback.push_tracked(chunk);
+                let hits = xtversion.push(chunk);
+                if hits > 0 {
+                    let mut writer = handle.writer.lock();
+                    acorn_platform::xtversion::write_replies(hits, writer.as_mut());
+                }
+                let span = handle.scrollback.push_tracked(chunk);
                 // Broadcast is a best-effort delivery; if no clients are
                 // attached, the send fails and we drop the chunk for
                 // them. The scrollback ring is the safety net on
                 // reattach.
                 if let Some(span) = span {
-                    let _ = output_tx.send(OutputChunk::new(chunk.to_vec(), span));
+                    let _ = handle
+                        .output_tx
+                        .send(OutputChunk::new(chunk.to_vec(), span));
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,

--- a/src-tauri/crates/acorn-platform/src/lib.rs
+++ b/src-tauri/crates/acorn-platform/src/lib.rs
@@ -3,3 +3,4 @@
 pub mod executable;
 pub mod fs;
 pub mod process;
+pub mod xtversion;

--- a/src-tauri/crates/acorn-platform/src/xtversion.rs
+++ b/src-tauri/crates/acorn-platform/src/xtversion.rs
@@ -1,0 +1,180 @@
+//! XTVERSION (CSI > 0 q) matching for PTY reader threads.
+//!
+//! Overlay TUIs such as Grok probe `CSI > 0 q` and treat a late DCS reply as
+//! leftover input, which paints `>|xterm.js` into the viewport.
+
+use std::io::Write;
+
+/// DCS `>|xterm.js` ST. Grok keys off the `xterm.js` name to stay on the
+/// non-kitty overlay path.
+pub const XTVERSION_REPLY: &[u8] = b"\x1bP>|xterm.js\x1b\\";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum State {
+    #[default]
+    Ground,
+    Esc,
+    Csi,
+    Gt,
+    GtZero,
+}
+
+/// Incremental scanner for `CSI > 0 q` / `CSI > q`, including 8-bit CSI and
+/// probes split across reads.
+#[derive(Debug, Default)]
+pub struct XtversionProbe {
+    state: State,
+}
+
+impl XtversionProbe {
+    pub fn push(&mut self, bytes: &[u8]) -> usize {
+        let mut hits = 0;
+        for &byte in bytes {
+            if self.feed(byte) {
+                hits += 1;
+            }
+        }
+        hits
+    }
+
+    fn feed(&mut self, byte: u8) -> bool {
+        match self.state {
+            State::Ground => {
+                self.state = match byte {
+                    0x1b => State::Esc,
+                    0x9b => State::Csi,
+                    _ => State::Ground,
+                };
+                false
+            }
+            State::Esc => {
+                self.state = match byte {
+                    b'[' => State::Csi,
+                    0x1b => State::Esc,
+                    0x9b => State::Csi,
+                    _ => State::Ground,
+                };
+                false
+            }
+            State::Csi => {
+                self.state = match byte {
+                    b'>' => State::Gt,
+                    0x1b => State::Esc,
+                    0x9b => State::Csi,
+                    _ => State::Ground,
+                };
+                false
+            }
+            State::Gt => match byte {
+                b'q' => {
+                    self.state = State::Ground;
+                    true
+                }
+                b'0' => {
+                    self.state = State::GtZero;
+                    false
+                }
+                0x1b => {
+                    self.state = State::Esc;
+                    false
+                }
+                0x9b => {
+                    self.state = State::Csi;
+                    false
+                }
+                _ => {
+                    self.state = State::Ground;
+                    false
+                }
+            },
+            State::GtZero => match byte {
+                b'q' => {
+                    self.state = State::Ground;
+                    true
+                }
+                b'0' => false,
+                0x1b => {
+                    self.state = State::Esc;
+                    false
+                }
+                0x9b => {
+                    self.state = State::Csi;
+                    false
+                }
+                _ => {
+                    self.state = State::Ground;
+                    false
+                }
+            },
+        }
+    }
+}
+
+pub fn write_replies(hits: usize, writer: &mut dyn Write) {
+    for _ in 0..hits {
+        if writer.write_all(XTVERSION_REPLY).is_err() {
+            return;
+        }
+    }
+    if hits > 0 {
+        let _ = writer.flush();
+    }
+}
+
+pub fn answer_probes(probe: &mut XtversionProbe, bytes: &[u8], writer: &mut dyn Write) {
+    write_replies(probe.push(bytes), writer);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hits(chunks: &[&[u8]]) -> usize {
+        let mut probe = XtversionProbe::default();
+        chunks.iter().map(|chunk| probe.push(chunk)).sum()
+    }
+
+    #[test]
+    fn matches_explicit_and_default_zero() {
+        assert_eq!(hits(&[b"\x1b[>0q"]), 1);
+        assert_eq!(hits(&[b"\x1b[>q"]), 1);
+        assert_eq!(hits(&[b"\x1b[>00q"]), 1);
+        assert_eq!(hits(&[b"\x9b>0q"]), 1);
+    }
+
+    #[test]
+    fn ignores_other_version_queries() {
+        assert_eq!(hits(&[b"\x1b[>1q"]), 0);
+        assert_eq!(hits(&[b"\x1b[>0;1q"]), 0);
+        assert_eq!(hits(&[b"\x1b[6n"]), 0);
+    }
+
+    #[test]
+    fn matches_across_reads_and_surrounding_output() {
+        assert_eq!(hits(&[b"\x1b[", b">0q"]), 1);
+        assert_eq!(hits(&[b"\x1b", b"[>0", b"q"]), 1);
+        assert_eq!(hits(&[b"hello\x1b[>0qworld"]), 1);
+        assert_eq!(hits(&[b"\x1b[2J\x1b[>0q"]), 1);
+        assert_eq!(hits(&[b"\x1b[>0q\x1b[>q"]), 2);
+    }
+
+    #[test]
+    fn own_reply_does_not_retrigger() {
+        assert_eq!(hits(&[XTVERSION_REPLY]), 0);
+    }
+
+    #[test]
+    fn writes_one_reply_per_hit() {
+        let mut probe = XtversionProbe::default();
+        let mut out = Vec::new();
+        answer_probes(&mut probe, b"pre\x1b[>0qmid\x1b[>qpost", &mut out);
+        assert_eq!(out, [XTVERSION_REPLY, XTVERSION_REPLY].concat());
+    }
+
+    #[test]
+    fn write_replies_is_a_noop_without_hits() {
+        let mut out = Vec::new();
+        write_replies(0, &mut out);
+        assert!(out.is_empty());
+    }
+}

--- a/src-tauri/crates/acorn-pty/src/lib.rs
+++ b/src-tauri/crates/acorn-pty/src/lib.rs
@@ -12,7 +12,7 @@
 //!   * `pty:exit:{session_id}` — payload `{ "code": Option<i32> }`
 
 use std::collections::VecDeque;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -413,6 +413,7 @@ fn read_loop(
 ) {
     let event = format!("pty:output:{session_id}");
     let mut buf = [0u8; READ_BUFFER_SIZE];
+    let mut xtversion = acorn_platform::xtversion::XtversionProbe::default();
     loop {
         if stop.load(Ordering::SeqCst) {
             break;
@@ -420,8 +421,14 @@ fn read_loop(
         match reader.read(&mut buf) {
             Ok(0) => break, // EOF — child closed the slave
             Ok(n) => {
-                push_tail(&handle.tail_buf, &buf[..n]);
-                output_sink(&event, &session_id, &buf[..n]);
+                let chunk = &buf[..n];
+                let hits = xtversion.push(chunk);
+                if hits > 0 {
+                    let mut writer = handle.writer.lock();
+                    acorn_platform::xtversion::write_replies(hits, writer.as_mut());
+                }
+                push_tail(&handle.tail_buf, chunk);
+                output_sink(&event, &session_id, chunk);
             }
             Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
             Err(e) => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -43,7 +43,6 @@ import {
 import {
   ptyPixelSize,
   shouldForceCommandPtyResize,
-  xtversionReplyForParams,
 } from "../lib/terminalPtySize";
 import {
   createTerminalOutputWriter,
@@ -1416,18 +1415,6 @@ export function Terminal({
     const sendToPty = (data: string) => {
       writeToPty(sessionId, data);
     };
-    // xterm.js does not answer CSI > 0 q (XTVERSION). Grok uses that
-    // probe to treat the emulator as xterm.js and keep overlay TUIs on
-    // the non-kitty path.
-    const xtversionParserDisposable = term.parser.registerCsiHandler(
-      { prefix: ">", final: "q" },
-      (params) => {
-        const reply = xtversionReplyForParams(params);
-        if (!reply) return false;
-        sendToPty(reply);
-        return true;
-      },
-    );
     const sendUserInputToPty = (data: string) => {
       if (data.length === 0) return;
       const state = useAppStore.getState();
@@ -3255,7 +3242,6 @@ export function Terminal({
       try { cursorStyleParserDisposable.dispose(); } catch { /* ignore */ }
       try { cursorSoftResetParserDisposable.dispose(); } catch { /* ignore */ }
       try { cursorFullResetParserDisposable.dispose(); } catch { /* ignore */ }
-      try { xtversionParserDisposable.dispose(); } catch { /* ignore */ }
       container.removeAttribute("data-acorn-cursor-application-override");
       container.classList.remove(COMPOSING_CLASS);
       try { fitAddon.dispose(); } catch { /* ignore */ }

--- a/src/lib/terminalPtySize.test.ts
+++ b/src/lib/terminalPtySize.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
-  XTVERSION_REPLY,
   ptyPixelSize,
   shouldForceCommandPtyResize,
-  xtversionReplyForParams,
 } from "./terminalPtySize";
 
 function term(type: string, mouseTrackingMode: string) {
@@ -60,14 +58,4 @@ describe("ptyPixelSize", () => {
   });
 });
 
-describe("xtversionReplyForParams", () => {
-  it("answers XTVERSION (CSI > 0 q) as xterm.js", () => {
-    expect(xtversionReplyForParams([0])).toBe(XTVERSION_REPLY);
-    expect(xtversionReplyForParams([])).toBe(XTVERSION_REPLY);
-  });
 
-  it("ignores other DA3-style version queries", () => {
-    expect(xtversionReplyForParams([1])).toBeNull();
-    expect(xtversionReplyForParams([[1]])).toBeNull();
-  });
-});

--- a/src/lib/terminalPtySize.ts
+++ b/src/lib/terminalPtySize.ts
@@ -1,5 +1,3 @@
-export const XTVERSION_REPLY = "\x1bP>|xterm.js\x1b\\";
-
 const U16_MAX = 65535;
 
 export function shouldForceCommandPtyResize(term: {
@@ -36,15 +34,6 @@ export function ptyPixelSize(
     pixelWidth: toU16(cols * cell.width),
     pixelHeight: toU16(rows * cell.height),
   };
-}
-
-export function xtversionReplyForParams(
-  params: (number | number[])[],
-): string | null {
-  const raw = params[0];
-  const code = Array.isArray(raw) ? raw[0] : (raw ?? 0);
-  if (code !== 0) return null;
-  return XTVERSION_REPLY;
 }
 
 function toU16(value: number): number {


### PR DESCRIPTION
## Summary
Grok overlay TUIs probe `CSI > 0 q` (XTVERSION) and paint stalled DCS fragments as `>|xterm.js` when the reply arrives after the wait window. Acorn used to answer from the xterm.js CSI handler via async `pty_write`, which is that late hop.

This answers XTVERSION on the PTY reader thread (in-process and daemon) through a shared `acorn-platform::xtversion` scanner, and removes the frontend sender so the reply is not doubled.

## Test plan
- [x] `cargo test -p acorn-platform xtversion`
- [x] `cargo test -p acorn-pty --lib`
- [x] `cargo test -p acorn-daemon --lib`
- [x] `pnpm exec vitest run src/lib/terminalPtySize.test.ts`
- [x] `pnpm run typecheck`
- [ ] Live Grok `/usage show` overlay in a running Acorn window — confirm no `>|xterm.js` leak and overlay still draws