### PR TITLE
fix(files): keep open viewer after deleting from the file list

### DIFF
--- a/src-tauri/src/fs_explorer.rs
+++ b/src-tauri/src/fs_explorer.rs
@@ -966,7 +966,13 @@ fn fs_git_diff_stats_scoped(
         let rel = rel_path.to_string_lossy().into_owned();
         let abs = scoped.requested.to_string_lossy().into_owned();
         match entry.kind.as_str() {
-            "added" => added.push((abs, scoped.resolved)),
+            "added" => match std::fs::symlink_metadata(&scoped.resolved) {
+                Ok(_) => added.push((abs, scoped.resolved)),
+                // The explorer can still ask for stats after trashing an
+                // untracked file; skip it instead of failing the whole batch.
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err.into()),
+            },
             "deleted" => deleted.push((abs, rel)),
             _ => diffable.push((abs, rel)),
         }
@@ -1582,9 +1588,13 @@ pub fn fs_git_diff_lines(
 
 fn fs_git_diff_lines_scoped(scope: &FsScope, path: String) -> AppResult<Vec<LineDiffEntry>> {
     let target = PathBuf::from(&path);
-    let scoped = scope.authorize_existing(&target)?;
+    let scoped = scope.authorize_existing_or_missing(&target)?;
     let target = scoped.resolved;
-    let target_metadata = std::fs::metadata(&target)?;
+    let target_metadata = match std::fs::metadata(&target) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
     if !target_metadata.is_file() {
         return Ok(Vec::new());
     }
@@ -3538,6 +3548,40 @@ mod tests {
     }
 
     #[test]
+    fn diff_stats_skips_missing_added_files() {
+        use git2::Repository;
+
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        Repository::init(&repo_path).unwrap();
+        let missing = repo_path.join("gone.txt");
+        let present = repo_path.join("kept.txt");
+        fs::write(&present, "a\nb\n").unwrap();
+
+        let scope = scope_for(&repo_path);
+        let stats = fs_git_diff_stats_scoped(
+            &scope,
+            repo_path.to_string_lossy().into_owned(),
+            vec![
+                GitDiffStatsRequest {
+                    path: missing.to_string_lossy().into_owned(),
+                    kind: "added".to_string(),
+                },
+                GitDiffStatsRequest {
+                    path: present.to_string_lossy().into_owned(),
+                    kind: "added".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert!(!stats.contains_key(&missing.to_string_lossy().into_owned()));
+        let kept = &stats[&present.to_string_lossy().into_owned()];
+        assert_eq!(kept.additions, 2);
+        assert_eq!(kept.deletions, 0);
+    }
+
+    #[test]
     fn diff_lines_returns_markers_for_requested_file() {
         let d = tmpdir();
         let repo_path = d.path().canonicalize().unwrap();
@@ -3619,5 +3663,23 @@ mod tests {
             .expect_err("oversized file should stop before diff generation");
 
         assert!(error.to_string().contains("diff line byte limit exceeded"));
+    }
+
+    #[test]
+    fn diff_lines_returns_empty_when_worktree_file_is_missing() {
+        use git2::Repository;
+
+        let d = tmpdir();
+        let repo_path = d.path().canonicalize().unwrap();
+        let repo = Repository::init(&repo_path).unwrap();
+        let tracked = repo_path.join("tracked.txt");
+        fs::write(&tracked, "one\ntwo\n").unwrap();
+        commit_paths(&repo, &["tracked.txt"]);
+        fs::remove_file(&tracked).unwrap();
+
+        let scope = scope_for(&repo_path);
+        let lines =
+            fs_git_diff_lines_scoped(&scope, tracked.to_string_lossy().into_owned()).unwrap();
+        assert!(lines.is_empty());
     }
 }

--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -9,6 +9,7 @@ import {
   type FsLineDiffEntry,
   type FsReadFileResult,
 } from "../lib/api";
+import { isMissingPathError } from "../lib/fsErrors";
 import { highlightCode, langFromPath } from "../lib/highlight";
 import { matchesHotkeyEvent } from "../lib/hotkeys";
 import { cn } from "../lib/cn";
@@ -48,6 +49,7 @@ interface ViewerState {
   highlightedLines: (string | null)[] | null;
   error: string | null;
   loading: boolean;
+  missing: boolean;
 }
 
 const EMPTY_STATE: ViewerState = {
@@ -55,6 +57,7 @@ const EMPTY_STATE: ViewerState = {
   highlightedLines: null,
   error: null,
   loading: true,
+  missing: false,
 };
 
 const DIFF_KIND_CLASS: Record<FsLineDiffEntry["kind"], string> = {
@@ -196,14 +199,21 @@ export function CodeViewer({
           highlightedLines: null,
           error: null,
           loading: false,
+          missing: false,
         });
       } catch (err: unknown) {
         if (seq !== loadSeqRef.current) return;
-        setState({
-          data: null,
-          highlightedLines: null,
-          error: err instanceof Error ? err.message : String(err),
-          loading: false,
+        setState((current) => {
+          if (current.data && isMissingPathError(err)) {
+            return { ...current, error: null, loading: false, missing: true };
+          }
+          return {
+            data: null,
+            highlightedLines: null,
+            error: err instanceof Error ? err.message : String(err),
+            loading: false,
+            missing: false,
+          };
         });
       }
     },
@@ -220,7 +230,13 @@ export function CodeViewer({
     } catch (err: unknown) {
       if (seq !== diffLoadSeqRef.current) return;
       setDiffLines([]);
-      setDiffError(err instanceof Error ? err.message : String(err));
+      setDiffError(
+        isMissingPathError(err)
+          ? null
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
     }
   }, [path]);
 
@@ -453,13 +469,20 @@ export function CodeViewer({
   }
   if (state.data?.binary) {
     return (
-      <Notice
-        title={t("codeViewer.binaryFile")}
-        body={t("codeViewer.binaryFileBody").replace(
-          "{bytes}",
-          state.data.size.toLocaleString(),
-        )}
-      />
+      <div className="flex h-full w-full flex-col bg-bg">
+        {state.missing ? (
+          <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
+            {t("codeViewer.fileDeleted")}
+          </div>
+        ) : null}
+        <Notice
+          title={t("codeViewer.binaryFile")}
+          body={t("codeViewer.binaryFileBody").replace(
+            "{bytes}",
+            state.data.size.toLocaleString(),
+          )}
+        />
+      </div>
     );
   }
   if (!state.data) return null;
@@ -472,6 +495,11 @@ export function CodeViewer({
         isActive ? "" : "pointer-events-none",
       )}
     >
+      {state.missing ? (
+        <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
+          {t("codeViewer.fileDeleted")}
+        </div>
+      ) : null}
       {state.data.truncated ? (
         <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
           {t("codeViewer.truncated")}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -985,13 +985,17 @@ export function FileExplorer({
       try {
         await api.fsTrash(entry.path);
         await fetchDir(parentPath(entry.path));
+        retainRecentGitStatPaths(changedPathsRef.current, [entry.path]);
+        pendingWorkingTreeRef.current = true;
+        scheduleGitStatusRefresh("user");
+        scheduleGitDiffStats();
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
         setError(message);
         showToast(`${t("toasts.files.trashFailed")} ${message}`);
       }
     },
-    [fetchDir, showToast, t],
+    [fetchDir, scheduleGitDiffStats, scheduleGitStatusRefresh, showToast, t],
   );
 
   const dirtyAncestors = useMemo(

--- a/src/components/FileViewer.test.tsx
+++ b/src/components/FileViewer.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
 }));
 
+import { listen } from "@tauri-apps/api/event";
 import { api } from "../lib/api";
 import { FileViewer } from "./FileViewer";
 
@@ -49,6 +50,23 @@ async function flushScrollReport() {
   });
 }
 
+function emitFsChanged(payload: {
+  paths: string[];
+  root?: string;
+  overflow?: boolean;
+  refresh?: { kind: "root" | "subtree"; path: string } | null;
+  dotgit_changed: boolean;
+}) {
+  const calls = vi.mocked(listen).mock.calls;
+  const listener = calls[calls.length - 1]?.[1];
+  if (!listener) throw new Error("fs listener not registered");
+  listener({
+    event: "acorn:fs-changed",
+    id: 1,
+    payload,
+  });
+}
+
 describe("FileViewer", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -62,6 +80,8 @@ describe("FileViewer", () => {
     vi.mocked(api.fsReleaseAsset).mockResolvedValue();
     vi.mocked(api.fsReadFile).mockReset();
     vi.mocked(api.fsGitDiffLines).mockReset();
+    vi.mocked(listen).mockClear();
+    vi.mocked(listen).mockResolvedValue(() => {});
     useSettings.setState({ settings: structuredClone(DEFAULT_SETTINGS) });
   });
 
@@ -273,5 +293,77 @@ describe("FileViewer", () => {
     expect(onViewStateChange).toHaveBeenLastCalledWith({
       code: { scrollTop: 96, scrollLeft: 14 },
     });
+  });
+
+  it("keeps an open image after the file is deleted", async () => {
+    vi.mocked(api.fsPrepareAsset).mockResolvedValueOnce({
+      size: 1024,
+      asset_path: "/private/snapshots/logo.png",
+      capability: "asset-logo",
+    });
+    vi.mocked(api.fsPrepareAsset).mockRejectedValueOnce(
+      new Error("io error: No such file or directory (os error 2)"),
+    );
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/assets/logo.png" isActive />);
+    });
+    await flushPromises();
+
+    await act(async () => {
+      emitFsChanged({
+        root: "/repo",
+        paths: ["/repo/assets/logo.png"],
+        dotgit_changed: false,
+      });
+    });
+    await flushPromises();
+
+    const image = container.querySelector<HTMLImageElement>('img[alt="logo.png"]');
+    expect(image).not.toBeNull();
+    expect(image?.src).toContain(
+      encodeURIComponent("/private/snapshots/logo.png"),
+    );
+    expect(container.textContent).toContain("This file was deleted.");
+    expect(container.textContent).not.toContain("No such file or directory");
+    expect(api.fsReleaseAsset).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-acorn-media-missing="true"]'),
+    ).not.toBeNull();
+  });
+
+  it("keeps an open text file after the file is deleted", async () => {
+    vi.mocked(api.fsReadFile).mockResolvedValueOnce({
+      content: "still on screen",
+      size: 15,
+      truncated: false,
+      binary: false,
+    });
+    vi.mocked(api.fsReadFile).mockRejectedValueOnce(
+      new Error("io error: No such file or directory (os error 2)"),
+    );
+    vi.mocked(api.fsGitDiffLines).mockResolvedValueOnce([]);
+    vi.mocked(api.fsGitDiffLines).mockRejectedValueOnce(
+      new Error("io error: No such file or directory (os error 2)"),
+    );
+
+    await act(async () => {
+      root.render(<FileViewer path="/repo/notes.md" isActive />);
+    });
+    await flushPromises();
+
+    await act(async () => {
+      emitFsChanged({
+        root: "/repo",
+        paths: ["/repo/notes.md"],
+        dotgit_changed: false,
+      });
+    });
+    await flushPromises();
+
+    expect(container.textContent).toContain("still on screen");
+    expect(container.textContent).toContain("This file was deleted.");
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).not.toContain("No such file or directory");
   });
 });

--- a/src/components/MediaViewer.tsx
+++ b/src/components/MediaViewer.tsx
@@ -14,6 +14,7 @@ import {
   type FsChangePayload,
   type FsPrepareAssetResult,
 } from "../lib/api";
+import { isMissingPathError } from "../lib/fsErrors";
 import { basenameFromPath, type MediaFileKind } from "../lib/mediaFiles";
 import { cn } from "../lib/cn";
 import type { ScrollPosition } from "../lib/scrollPosition";
@@ -40,6 +41,7 @@ interface MediaState {
   asset: FsPrepareAssetResult | null;
   error: string | null;
   loading: boolean;
+  missing: boolean;
 }
 
 const EMPTY_STATE: MediaState = {
@@ -47,6 +49,7 @@ const EMPTY_STATE: MediaState = {
   asset: null,
   error: null,
   loading: true,
+  missing: false,
 };
 
 const IMAGE_ZOOM_MIN = 0.25;
@@ -98,9 +101,18 @@ export function MediaViewer({
           asset,
           error: null,
           loading: false,
+          missing: false,
         });
       } catch (err: unknown) {
         if (seq !== loadSeqRef.current) return;
+        if (isMissingPathError(err) && assetCapabilityRef.current) {
+          setState((current) =>
+            current.src
+              ? { ...current, error: null, loading: false, missing: true }
+              : current,
+          );
+          return;
+        }
         const previousCapability = assetCapabilityRef.current;
         assetCapabilityRef.current = null;
         if (previousCapability) void api.fsReleaseAsset(previousCapability);
@@ -109,6 +121,7 @@ export function MediaViewer({
           asset: null,
           error: err instanceof Error ? err.message : String(err),
           loading: false,
+          missing: false,
         });
       }
     },
@@ -182,38 +195,48 @@ export function MediaViewer({
   return (
     <div
       className={cn(
-        "relative flex h-full w-full items-center justify-center overflow-hidden bg-bg",
+        "relative flex h-full w-full flex-col overflow-hidden bg-bg",
         isActive ? "" : "pointer-events-none",
       )}
       data-acorn-media-viewer={kind}
       data-acorn-media-size={state.asset?.size ?? undefined}
       data-acorn-media-zoom={kind === "image" ? imageZoom : undefined}
+      data-acorn-media-missing={state.missing || undefined}
     >
-      {kind === "image" ? (
-        <>
-          <ImageZoomControls
-            zoom={imageZoom}
-            onZoomIn={() => updateImageZoom((value) => nextImageZoom(value, 1))}
-            onZoomOut={() =>
-              updateImageZoom((value) => nextImageZoom(value, -1))
-            }
-            onReset={() => updateImageZoom(() => 1)}
-          />
-          {renderMedia(
-            kind,
-            state.src,
-            title,
-            imageZoom,
-            restoreMediaScrollRef,
-            (event) =>
-              reportMediaScrollPosition(
-                scrollPositionFromEventTarget(event.currentTarget),
-              ),
-          )}
-        </>
-      ) : (
-        renderMedia(kind, state.src, title)
-      )}
+      {state.missing ? (
+        <div className="shrink-0 border-b border-border bg-bg-warning/15 px-3 py-1 text-[11px] text-fg-muted">
+          {t("mediaViewer.fileDeleted")}
+        </div>
+      ) : null}
+      <div className="relative flex min-h-0 flex-1 items-center justify-center">
+        {kind === "image" ? (
+          <>
+            <ImageZoomControls
+              zoom={imageZoom}
+              onZoomIn={() =>
+                updateImageZoom((value) => nextImageZoom(value, 1))
+              }
+              onZoomOut={() =>
+                updateImageZoom((value) => nextImageZoom(value, -1))
+              }
+              onReset={() => updateImageZoom(() => 1)}
+            />
+            {renderMedia(
+              kind,
+              state.src,
+              title,
+              imageZoom,
+              restoreMediaScrollRef,
+              (event) =>
+                reportMediaScrollPosition(
+                  scrollPositionFromEventTarget(event.currentTarget),
+                ),
+            )}
+          </>
+        ) : (
+          renderMedia(kind, state.src, title)
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/fsErrors.test.ts
+++ b/src/lib/fsErrors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isMissingPathError } from "./fsErrors";
+
+describe("isMissingPathError", () => {
+  it("matches Unix and Windows missing-path IO errors", () => {
+    expect(
+      isMissingPathError(
+        new Error("io error: No such file or directory (os error 2)"),
+      ),
+    ).toBe(true);
+    expect(
+      isMissingPathError(
+        new Error(
+          "io error: The system cannot find the file specified. (os error 2)",
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      isMissingPathError("The system cannot find the path specified"),
+    ).toBe(true);
+  });
+
+  it("rejects other filesystem failures so they stay visible", () => {
+    expect(isMissingPathError(new Error("permission denied"))).toBe(false);
+    expect(
+      isMissingPathError(new Error("diff stats unavailable for oversized file")),
+    ).toBe(false);
+    expect(isMissingPathError("path outside allowed project roots")).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/fsErrors.ts
+++ b/src/lib/fsErrors.ts
@@ -1,0 +1,13 @@
+/**
+ * True when a filesystem command failed because the path is gone. Viewers
+ * keep the last loaded snapshot in that case instead of replacing it with
+ * a path-not-found error.
+ */
+export function isMissingPathError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /no such file or directory/i.test(message) ||
+    /cannot find the (?:file|path) specified/i.test(message) ||
+    /\bos error 2\b/i.test(message)
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1202,10 +1202,12 @@
     "zoomControls": "Image zoom controls",
     "zoomIn": "Zoom in",
     "zoomOut": "Zoom out",
-    "resetZoom": "Reset zoom"
+    "resetZoom": "Reset zoom",
+    "fileDeleted": "This file was deleted."
   },
   "codeViewer": {
     "loading": "Loading...",
+    "fileDeleted": "This file was deleted.",
     "binaryFile": "Binary file",
     "binaryFileBody": "{bytes} bytes - not shown in the readonly viewer.",
     "truncated": "File truncated to 2 MB. Open externally to view the rest.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1202,10 +1202,12 @@
     "zoomControls": "画像ズームコントロール",
     "zoomIn": "ズームイン",
     "zoomOut": "ズームアウト",
-    "resetZoom": "ズームをリセットする"
+    "resetZoom": "ズームをリセットする",
+    "fileDeleted": "このファイルは削除されました。"
   },
   "codeViewer": {
     "loading": "読み込み中...",
+    "fileDeleted": "このファイルは削除されました。",
     "binaryFile": "バイナリファイル",
     "binaryFileBody": "{bytes} バイト - 読み取り専用ビューアには表示されません。",
     "truncated": "ファイルは 2 MB に切り詰められました。外部から開いて残りを表示します。",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1202,10 +1202,12 @@
     "zoomControls": "이미지 확대/축소 컨트롤",
     "zoomIn": "확대",
     "zoomOut": "축소",
-    "resetZoom": "확대/축소 초기화"
+    "resetZoom": "확대/축소 초기화",
+    "fileDeleted": "이 파일이 삭제되었습니다."
   },
   "codeViewer": {
     "loading": "불러오는 중...",
+    "fileDeleted": "이 파일이 삭제되었습니다.",
     "binaryFile": "바이너리 파일",
     "binaryFileBody": "{bytes}바이트 - 읽기 전용 뷰어에 표시되지 않습니다.",
     "truncated": "파일이 2 MB로 잘렸습니다. 나머지는 외부에서 열어 확인하세요.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1202,10 +1202,12 @@
     "zoomControls": "图像缩放控件",
     "zoomIn": "放大",
     "zoomOut": "缩小",
-    "resetZoom": "重置缩放"
+    "resetZoom": "重置缩放",
+    "fileDeleted": "该文件已删除。"
   },
   "codeViewer": {
     "loading": "正在加载...",
+    "fileDeleted": "该文件已删除。",
     "binaryFile": "二进制文件",
     "binaryFileBody": "{bytes} 字节 - 未显示在只读查看器中。",
     "truncated": "文件被截断为 2 MB。外部打开即可查看其余内容。",


### PR DESCRIPTION
## Summary
- Keep an already-open file or image tab when the path is moved to trash from the right-hand file list.
- Show a muted deleted banner instead of replacing the pane with a missing-path or git-diff error.
- Skip vanished untracked files in git stats so the explorer banner does not fail the whole batch.

## Test plan
- [x] Vitest: FileViewer keeps image and text content after a delete FS event; fsErrors path matching
- [x] Rust: `fs_git_diff_lines` returns empty for a missing worktree file; `fs_git_diff_stats` skips missing added files
- [ ] Manual: open an image from Files, right-click → Move to Trash, confirm the tab stays with the last snapshot and no git-diff/path error