### PR TITLE
fix(terminal): do not block PTY readers on XTVERSION replies

### DIFF
--- a/src-tauri/crates/acorn-daemon/src/pty.rs
+++ b/src-tauri/crates/acorn-daemon/src/pty.rs
@@ -470,8 +470,17 @@ fn read_loop(mut reader: Box<dyn Read + Send>, handle: Arc<PtyHandle>) {
                 let chunk = &buf[..n];
                 let hits = xtversion.push(chunk);
                 if hits > 0 {
-                    let mut writer = handle.writer.lock();
-                    acorn_platform::xtversion::write_replies(hits, writer.as_mut());
+                    // Skip when stdin already holds the writer. Waiting
+                    // stalls this stdout reader, and a late DCS reply
+                    // paints into the viewport.
+                    acorn_platform::xtversion::write_replies_if(
+                        hits,
+                        handle
+                            .writer
+                            .try_lock()
+                            .as_mut()
+                            .map(|writer| writer.as_mut() as &mut dyn Write),
+                    );
                 }
                 let span = handle.scrollback.push_tracked(chunk);
                 // Broadcast is a best-effort delivery; if no clients are

--- a/src-tauri/crates/acorn-platform/src/xtversion.rs
+++ b/src-tauri/crates/acorn-platform/src/xtversion.rs
@@ -121,6 +121,15 @@ pub fn write_replies(hits: usize, writer: &mut dyn Write) {
     }
 }
 
+/// Write replies only when the caller already holds the PTY writer.
+/// Pass `mutex.try_lock()` so a busy stdin burst cannot stall the stdout
+/// reader; a late DCS reply paints into the viewport.
+pub fn write_replies_if(hits: usize, writer: Option<&mut dyn Write>) {
+    if let Some(writer) = writer {
+        write_replies(hits, writer);
+    }
+}
+
 pub fn answer_probes(probe: &mut XtversionProbe, bytes: &[u8], writer: &mut dyn Write) {
     write_replies(probe.push(bytes), writer);
 }
@@ -176,5 +185,13 @@ mod tests {
         let mut out = Vec::new();
         write_replies(0, &mut out);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn write_replies_if_skips_a_missing_writer() {
+        write_replies_if(2, None);
+        let mut out = Vec::new();
+        write_replies_if(1, Some(&mut out));
+        assert_eq!(out, XTVERSION_REPLY);
     }
 }

--- a/src-tauri/crates/acorn-pty/src/lib.rs
+++ b/src-tauri/crates/acorn-pty/src/lib.rs
@@ -424,8 +424,17 @@ fn read_loop(
                 let chunk = &buf[..n];
                 let hits = xtversion.push(chunk);
                 if hits > 0 {
-                    let mut writer = handle.writer.lock();
-                    acorn_platform::xtversion::write_replies(hits, writer.as_mut());
+                    // Skip when stdin already holds the writer. Waiting
+                    // stalls this stdout reader, and a late DCS reply
+                    // paints into the viewport.
+                    acorn_platform::xtversion::write_replies_if(
+                        hits,
+                        handle
+                            .writer
+                            .try_lock()
+                            .as_mut()
+                            .map(|writer| writer.as_mut() as &mut dyn Write),
+                    );
                 }
                 push_tail(&handle.tail_buf, chunk);
                 output_sink(&event, &session_id, chunk);


### PR DESCRIPTION
## Summary

XTVERSION replies were written under a blocking `handle.writer.lock()` on both PTY reader threads. That mutex is also held by stdin `pty_write`. Waiting for it stalls the only stdout consumer, and a late DCS `>|xterm.js` is leftover input — the leak #868 is meant to stop.

Skip the reply when the writer is already held (`try_lock`) instead of waiting.

## Changes

- Add `write_replies_if` so a missing/busy writer is a no-op.
- In-process (`acorn-pty`) and daemon (`acorn-daemon`) readers use `try_lock` before answering `CSI > 0 q`.

## Test plan

- [x] `cargo test -p acorn-platform xtversion`
- [x] `cargo test -p acorn-pty --lib`
- [x] `cargo test -p acorn-daemon --lib xtversion` (compiles; no daemon-specific xtversion tests)
- [ ] PR CI

## Changelog category

`fix`