### PR TITLE
chore(release): v1.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.33.2",
+  "version": "1.34.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.33.2"
+version = "1.34.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.33.2"
+version = "1.34.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.34.0 from `main`, publishing the 6 commits merged since v1.33.2 — two user-facing features (auto-resume and Grok weekly token usage), three terminal/file fixes, and a README update.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.33.2 to 1.34.0.
2. **Release scope** — 2 features (#869 auto-resume previous conversations, #871 Grok weekly token usage), 3 fixes (#868 XTVERSION on the PTY reader, #874 non-blocking XTVERSION replies, #870 keep open viewer after file delete), and 1 docs update (#872).
3. **Publication path** — builds both macOS architectures and the Windows x64 NSIS updater pair, then publishes a three-platform `latest.json`.

## Expected impact

| Area | Expected impact |
| --- | --- |
| Sessions | Settings → Sessions → Auto-resume previous conversations (default off) sends the same resume command as the modal at cold boot, without showing the modal. Live agents are left alone; a missing PTY is queued for the next spawn. |
| Status bar | Grok tabs show weekly remaining % next to Codex/Claude windows, read from `~/.grok/logs/unified.jsonl`. |
| Terminal | Overlay TUIs no longer paint `>|xterm.js` from a late XTVERSION reply. The PTY reader answers `CSI > 0 q` without blocking behind a busy stdin write. |
| Files | An already-open file or image tab stays on the last snapshot after Move to Trash, with a deleted banner instead of a missing-path/git-diff error. |
| Docs | README covers Graph, Loop, Instant Sessions, auto-resume, theme library, and Grok weekly tokens. |
| Updater | Publishes a minor update for both macOS architectures and Windows x64. |

## Design notes

- 1.34.0 is a minor release because it adds two user-visible features on top of the terminal/file fixes, without changing compatibility contracts.
- This PR changes version metadata only; every change it publishes was reviewed and merged independently.
- Release notes are generated from changelog-labelled merged PRs. This version PR carries `skip-changelog` so it is excluded from them.

## Follow-up (not in this PR)

- Push annotated tag `v1.34.0` after merge.
- Verify macOS and Windows artifacts, updater signatures, `latest.json`, the Latest pointer, and release-note identity.

## Test plan

- [x] `pnpm run typecheck` — passes.
- [x] `node scripts/validate-release-version.mjs v1.34.0` — all four version sources match.
- [x] `node scripts/validate-release-version.mjs --assert-newer v1.34.0 v1.33.2` — minor ordering passes.
- [x] Locked Cargo metadata reports Acorn `1.34.0`.
- [x] Release-focused Vitest (`scripts/validate-release-version.test.mjs`, `release-notes.test.mjs`, `release-artifacts.test.mjs`) — 3 files, 19 tests pass.
- [x] `git diff --check` — passes.
- [ ] PR CI — wait for required checks.