### PR TITLE
fix(sessions): keep Grok working while monitors and subagents run

### DIFF
--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -30,7 +30,7 @@
 //!   WaitingForInput as an interrupted turn.
 //! - last `sessionUpdate=turn_completed` -> WaitingForInput while the Grok
 //!   process remains live (the TUI has returned to its prompt), unless a live
-//!   monitor or unfinished subagent is still running.
+//!   monitor or a running child agent is still in flight.
 //! - user/agent/thought chunks, tool call updates, `task_backgrounded`, and
 //!   `subagent_spawned` -> Working.
 //! - `task_completed` / `subagent_finished` with `will_wake=true` -> Working.
@@ -53,8 +53,8 @@ use std::path::{Path, PathBuf};
 use acorn_agent::AgentKind;
 use acorn_pty::ShellHint;
 use acorn_transcript::{
-    grok_has_live_background_tasks, grok_tail_has_pending_followup, latest_turn_observation,
-    read_tail, TailRead, TurnObservation, TurnState,
+    grok_has_live_background_tasks, grok_has_running_subagents, grok_tail_has_pending_followup,
+    latest_turn_observation, read_tail, TailRead, TurnObservation, TurnState,
 };
 use serde::Serialize;
 
@@ -190,7 +190,7 @@ pub fn detect_with_reason(
             timestamp,
             agent_activity_timestamp,
         }) => {
-            if kind == AgentKind::Grok && grok_has_unfinished_followup(&path, tail.as_ref()) {
+            if grok_followup_overrides_resting_status(kind, &path, tail.as_ref()) {
                 StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
                     .with_turn_timestamp(timestamp)
                     .with_agent_activity_timestamp(agent_activity_timestamp)
@@ -218,13 +218,20 @@ pub fn detect_with_reason(
             provider_turn_id,
             timestamp,
             ..
-        }) => StatusDetection::new(
-            SessionStatus::WaitingForInput,
-            Some(StatusReason::TurnInterrupted),
-            StatusEvidence::Transcript,
-        )
-        .with_completed_provider_turn_id(provider_turn_id)
-        .with_turn_timestamp(timestamp),
+        }) => {
+            if grok_followup_overrides_resting_status(kind, &path, tail.as_ref()) {
+                StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
+                    .with_turn_timestamp(timestamp)
+            } else {
+                StatusDetection::new(
+                    SessionStatus::WaitingForInput,
+                    Some(StatusReason::TurnInterrupted),
+                    StatusEvidence::Transcript,
+                )
+                .with_completed_provider_turn_id(provider_turn_id)
+                .with_turn_timestamp(timestamp)
+            }
+        }
         // Transcript exists but the tail held no turn lines; keep
         // whatever the caller previously observed instead of regressing
         // to Ready. The next poll that lands on a real turn line corrects
@@ -244,9 +251,15 @@ fn completed_turn_status(kind: AgentKind) -> SessionStatus {
     }
 }
 
-fn grok_has_unfinished_followup(path: &Path, tail: Option<&TailRead>) -> bool {
-    grok_has_live_background_tasks(path)
-        || tail.is_some_and(|tail| grok_tail_has_pending_followup(&tail.text, tail.read_full))
+fn grok_followup_overrides_resting_status(
+    kind: AgentKind,
+    path: &Path,
+    tail: Option<&TailRead>,
+) -> bool {
+    kind == AgentKind::Grok
+        && (grok_has_live_background_tasks(path)
+            || grok_has_running_subagents(path)
+            || tail.is_some_and(|tail| grok_tail_has_pending_followup(&tail.text, tail.read_full)))
 }
 
 #[cfg(test)]
@@ -858,10 +871,10 @@ mod tests {
     }
 
     #[test]
-    fn grok_cancelled_turn_stays_waiting_even_with_a_live_background_task() {
+    fn grok_cancelled_turn_stays_waiting_with_a_detached_shell() {
         let path = write_grok_session_transcript(
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#,
-            Some(r#"[{"task_id":"task-1"}]"#),
+            Some(r#"[{"task_id":"task-1","kind":"bash"}]"#),
         );
 
         let detection = detect_with_reason(
@@ -872,6 +885,60 @@ mod tests {
 
         assert_eq!(detection.status, SessionStatus::WaitingForInput);
         assert_eq!(detection.reason, Some(StatusReason::TurnInterrupted));
+    }
+
+    #[test]
+    fn grok_cancelled_turn_stays_working_with_a_live_monitor() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#,
+            Some(r#"[{"task_id":"task-1","kind":"monitor"}]"#),
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+    }
+
+    #[test]
+    fn grok_stays_working_while_a_subagent_meta_is_running() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            None,
+        );
+        write_grok_subagent_meta(&path, r#"{"status":"running"}"#);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_cancelled_turn_stays_working_with_a_running_subagent() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#,
+            None,
+        );
+        write_grok_subagent_meta(&path, r#"{"status":"running"}"#);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
     }
 
     #[test]
@@ -921,5 +988,15 @@ mod tests {
                 .expect("write grok background manifest");
         }
         path
+    }
+
+    fn write_grok_subagent_meta(transcript: &Path, meta: &str) {
+        let dir = transcript
+            .parent()
+            .expect("grok transcript has a session dir")
+            .join("subagents")
+            .join("child-1");
+        std::fs::create_dir_all(&dir).expect("create grok subagent dir");
+        std::fs::write(dir.join("meta.json"), meta).expect("write grok subagent meta");
     }
 }

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -29,8 +29,11 @@
 //! - last `sessionUpdate=turn_completed` with `stop_reason=cancelled` ->
 //!   WaitingForInput as an interrupted turn.
 //! - last `sessionUpdate=turn_completed` -> WaitingForInput while the Grok
-//!   process remains live (the TUI has returned to its prompt).
-//! - user/agent/thought chunks and tool call updates -> Working.
+//!   process remains live (the TUI has returned to its prompt), unless a live
+//!   monitor or unfinished subagent is still running.
+//! - user/agent/thought chunks, tool call updates, `task_backgrounded`, and
+//!   `subagent_spawned` -> Working.
+//! - `task_completed` / `subagent_finished` with `will_wake=true` -> Working.
 //! - hook and other metadata updates are ignored when selecting the last turn
 //!   event.
 //!
@@ -45,11 +48,14 @@
 //! `agent_resume`'s persister markers + the legacy `~/.claude/projects/`
 //! UUID-named fallback) and is passed in here as `(PathBuf, AgentKind)`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use acorn_agent::AgentKind;
 use acorn_pty::ShellHint;
-use acorn_transcript::{latest_turn_observation, read_tail, TurnObservation, TurnState};
+use acorn_transcript::{
+    grok_has_live_background_tasks, grok_tail_has_pending_followup, latest_turn_observation,
+    read_tail, TailRead, TurnObservation, TurnState,
+};
 use serde::Serialize;
 
 use crate::session::SessionStatus;
@@ -172,8 +178,9 @@ pub fn detect_with_reason(
         None => return detect_shell_hint(shell_hint),
     };
 
-    let classified = read_tail(&path, TAIL_BYTES)
-        .ok()
+    let tail = read_tail(&path, TAIL_BYTES).ok();
+    let classified = tail
+        .as_ref()
         .and_then(|tail| latest_turn_observation(kind, &tail.text, tail.read_full));
 
     match classified {
@@ -182,14 +189,22 @@ pub fn detect_with_reason(
             provider_turn_id,
             timestamp,
             agent_activity_timestamp,
-        }) => StatusDetection::new(
-            completed_turn_status(kind),
-            Some(StatusReason::TurnComplete),
-            StatusEvidence::Transcript,
-        )
-        .with_completed_provider_turn_id(provider_turn_id)
-        .with_turn_timestamp(timestamp)
-        .with_agent_activity_timestamp(agent_activity_timestamp),
+        }) => {
+            if kind == AgentKind::Grok && grok_has_unfinished_followup(&path, tail.as_ref()) {
+                StatusDetection::new(SessionStatus::Working, None, StatusEvidence::Transcript)
+                    .with_turn_timestamp(timestamp)
+                    .with_agent_activity_timestamp(agent_activity_timestamp)
+            } else {
+                StatusDetection::new(
+                    completed_turn_status(kind),
+                    Some(StatusReason::TurnComplete),
+                    StatusEvidence::Transcript,
+                )
+                .with_completed_provider_turn_id(provider_turn_id)
+                .with_turn_timestamp(timestamp)
+                .with_agent_activity_timestamp(agent_activity_timestamp)
+            }
+        }
         Some(TurnObservation {
             state: TurnState::Working,
             timestamp,
@@ -227,6 +242,11 @@ fn completed_turn_status(kind: AgentKind) -> SessionStatus {
         AgentKind::Grok => SessionStatus::WaitingForInput,
         AgentKind::Claude | AgentKind::Codex | AgentKind::Antigravity => SessionStatus::Ready,
     }
+}
+
+fn grok_has_unfinished_followup(path: &Path, tail: Option<&TailRead>) -> bool {
+    grok_has_live_background_tasks(path)
+        || tail.is_some_and(|tail| grok_tail_has_pending_followup(&tail.text, tail.read_full))
 }
 
 #[cfg(test)]
@@ -749,6 +769,112 @@ mod tests {
     }
 
     #[test]
+    fn grok_stays_working_while_a_background_task_is_still_live() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            Some(r#"[{"task_id":"task-1","kind":"monitor"}]"#),
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_stays_working_while_a_subagent_is_still_running() {
+        let path = write_status_transcript(concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"subagent_spawned","subagent_id":"child-1"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        ));
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_will_wake_keeps_working_after_turn_completed() {
+        let path = write_status_transcript(concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","will_wake":true,"task_snapshot":{"task_id":"task-1"}}}}"#,
+        ));
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::WaitingForInput,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_empty_background_manifest_still_waits_after_turn_completed() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            Some("[]"),
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
+    }
+
+    #[test]
+    fn grok_detached_shell_manifest_still_waits_after_turn_completed() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            Some(r#"[{"task_id":"task-1","kind":"bash","command":"npm run dev"}]"#),
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
+    }
+
+    #[test]
+    fn grok_cancelled_turn_stays_waiting_even_with_a_live_background_task() {
+        let path = write_grok_session_transcript(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7","stop_reason":"cancelled"}}}"#,
+            Some(r#"[{"task_id":"task-1"}]"#),
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnInterrupted));
+    }
+
+    #[test]
     fn detect_preserves_previous_evidence_when_transcript_has_no_turn() {
         let path = write_status_transcript(&meta_lines().join("\n"));
 
@@ -779,6 +905,21 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("acorn-status-test-{}.jsonl", uuid::Uuid::new_v4()));
         std::fs::write(&path, body).expect("write status transcript");
+        path
+    }
+
+    fn write_grok_session_transcript(body: &str, manifest: Option<&str>) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-status-grok-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).expect("create grok session dir");
+        let path = dir.join("updates.jsonl");
+        std::fs::write(&path, body).expect("write grok transcript");
+        if let Some(manifest) = manifest {
+            std::fs::write(dir.join("background_tasks_manifest.json"), manifest)
+                .expect("write grok background manifest");
+        }
         path
     }
 }

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -2725,6 +2725,69 @@ pub fn grok_has_live_background_tasks(transcript: &Path) -> bool {
     grok_live_background_task_count(transcript) > 0
 }
 
+const GROK_SUBAGENTS_DIR: &str = "subagents";
+const GROK_SUBAGENT_META: &str = "meta.json";
+const GROK_SUBAGENT_META_MAX_BYTES: u64 = 256 * 1024;
+const GROK_SUBAGENT_ENTRY_LIMIT: usize = 128;
+
+/// Child agents write `subagents/<id>/meta.json` with `status: "running"`
+/// while they are still in flight. The parent `updates.jsonl` tail is only
+/// 256 KiB, so a spawn line can age out before `turn_completed`.
+pub fn grok_has_running_subagents(transcript: &Path) -> bool {
+    if transcript.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
+        return false;
+    }
+    let Some(dir) = transcript.parent() else {
+        return false;
+    };
+    let root = dir.join(GROK_SUBAGENTS_DIR);
+    match std::fs::symlink_metadata(&root) {
+        Ok(meta) if meta.file_type().is_dir() => {}
+        _ => return false,
+    }
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return false;
+    };
+    for (index, entry) in entries.enumerate() {
+        if index >= GROK_SUBAGENT_ENTRY_LIMIT {
+            break;
+        }
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        if grok_subagent_meta_is_running(&entry.path().join(GROK_SUBAGENT_META)) {
+            return true;
+        }
+    }
+    false
+}
+
+fn grok_subagent_meta_is_running(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta)
+            if meta.file_type().is_file()
+                && meta.len() > 0
+                && meta.len() <= GROK_SUBAGENT_META_MAX_BYTES => {}
+        _ => return false,
+    }
+    let Ok(bytes) = std::fs::read(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return false;
+    };
+    value
+        .get("status")
+        .and_then(|status| status.as_str())
+        .is_some_and(|status| status.eq_ignore_ascii_case("running"))
+}
+
 fn grok_live_background_task_count(transcript: &Path) -> usize {
     if transcript.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
         return 0;
@@ -2828,6 +2891,27 @@ mod grok_background_task_tests {
         assert!(!grok_has_live_background_tasks(
             &std::env::temp_dir().join("acorn-status-test.jsonl")
         ));
+    }
+
+    #[test]
+    fn running_subagent_meta_is_detected_next_to_the_transcript() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-grok-sa-{}", uuid::Uuid::new_v4().simple()));
+        let child = dir.join(GROK_SUBAGENTS_DIR).join("child-1");
+        std::fs::create_dir_all(&child).expect("create subagent dir");
+        let transcript = dir.join("updates.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("write transcript");
+        std::fs::write(child.join(GROK_SUBAGENT_META), r#"{"status":"running"}"#)
+            .expect("write running meta");
+
+        assert!(grok_has_running_subagents(&transcript));
+
+        std::fs::write(
+            child.join(GROK_SUBAGENT_META),
+            r#"{"status":"completed","completed_at":"t"}"#,
+        )
+        .expect("write completed meta");
+        assert!(!grok_has_running_subagents(&transcript));
     }
 }
 

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -49,9 +49,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, U
 mod line;
 
 pub use line::{
-    assistant_message_text, collapse_preview, latest_turn_observation, latest_turn_state,
-    parse_transcript_line, parse_transcript_value, read_tail, ParsedTranscriptLine, TailRead,
-    TranscriptRole, TurnObservation, TurnState,
+    assistant_message_text, collapse_preview, grok_tail_has_pending_followup,
+    latest_turn_observation, latest_turn_state, parse_transcript_line, parse_transcript_value,
+    read_tail, ParsedTranscriptLine, TailRead, TranscriptRole, TurnObservation, TurnState,
 };
 
 // Maximum age (mtime → now) of a transcript that will be paired with
@@ -2712,6 +2712,123 @@ fn locate_grok_transcript_in_checked(
 
 pub fn read_grok_session_summary(transcript: &Path) -> Option<GrokSessionSummary> {
     read_grok_session_summary_checked(transcript).ok().flatten()
+}
+
+const GROK_BACKGROUND_TASKS_MANIFEST: &str = "background_tasks_manifest.json";
+const GROK_BACKGROUND_TASKS_MANIFEST_MAX_BYTES: u64 = 64 * 1024;
+
+/// Live Grok *monitor* tasks live in a sibling manifest next to
+/// `updates.jsonl`. Fire-and-forget shells (dev servers) stay listed after
+/// Grok has returned to its prompt, so only monitors — which resume the
+/// agent — keep the session from flipping to WaitingForInput.
+pub fn grok_has_live_background_tasks(transcript: &Path) -> bool {
+    grok_live_background_task_count(transcript) > 0
+}
+
+fn grok_live_background_task_count(transcript: &Path) -> usize {
+    if transcript.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
+        return 0;
+    }
+    let Some(dir) = transcript.parent() else {
+        return 0;
+    };
+    let path = dir.join(GROK_BACKGROUND_TASKS_MANIFEST);
+    match std::fs::symlink_metadata(&path) {
+        Ok(meta)
+            if meta.file_type().is_file()
+                && meta.len() > 0
+                && meta.len() <= GROK_BACKGROUND_TASKS_MANIFEST_MAX_BYTES => {}
+        _ => return 0,
+    }
+    let Ok(bytes) = std::fs::read(&path) else {
+        return 0;
+    };
+    grok_background_task_count_from_json(&bytes)
+}
+
+fn grok_background_task_count_from_json(bytes: &[u8]) -> usize {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return 0;
+    };
+    let tasks = value
+        .as_array()
+        .or_else(|| value.get("tasks").and_then(|value| value.as_array()))
+        .or_else(|| {
+            value
+                .get("background_tasks")
+                .and_then(|value| value.as_array())
+        })
+        .or_else(|| {
+            value
+                .get("backgroundTasks")
+                .and_then(|value| value.as_array())
+        });
+    tasks
+        .map(|tasks| {
+            tasks
+                .iter()
+                .filter(|task| grok_background_task_resumes_agent(task))
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn grok_background_task_resumes_agent(task: &serde_json::Value) -> bool {
+    let kind = task
+        .get("kind")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    if kind.eq_ignore_ascii_case("monitor") {
+        return true;
+    }
+    task.get("display_command")
+        .or_else(|| task.get("displayCommand"))
+        .and_then(|value| value.as_str())
+        .is_some_and(|command| command.trim_start().starts_with("[monitor]"))
+}
+
+#[cfg(test)]
+mod grok_background_task_tests {
+    use super::*;
+
+    #[test]
+    fn counts_array_and_wrapped_manifest_shapes() {
+        assert_eq!(
+            grok_background_task_count_from_json(br#"[{"task_id":"a","kind":"monitor"}]"#),
+            1
+        );
+        assert_eq!(
+            grok_background_task_count_from_json(
+                br#"{"tasks":[{"task_id":"a","kind":"monitor"},{"task_id":"b","kind":"monitor"}]}"#
+            ),
+            2
+        );
+        assert_eq!(
+            grok_background_task_count_from_json(br#"[{"task_id":"a","kind":"bash"}]"#),
+            0
+        );
+        assert_eq!(grok_background_task_count_from_json(br#"[]"#), 0);
+        assert_eq!(grok_background_task_count_from_json(br#"{}"#), 0);
+    }
+
+    #[test]
+    fn live_manifest_is_read_from_the_session_directory() {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-grok-bg-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).expect("create grok session dir");
+        let transcript = dir.join("updates.jsonl");
+        std::fs::write(&transcript, "{}\n").expect("write transcript");
+        std::fs::write(
+            dir.join(GROK_BACKGROUND_TASKS_MANIFEST),
+            r#"[{"task_id":"task-1","kind":"monitor"}]"#,
+        )
+        .expect("write manifest");
+
+        assert!(grok_has_live_background_tasks(&transcript));
+        assert!(!grok_has_live_background_tasks(
+            &std::env::temp_dir().join("acorn-status-test.jsonl")
+        ));
+    }
 }
 
 /// Checked form of [`read_grok_session_summary`].

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;
@@ -401,7 +402,12 @@ fn parse_grok_value(value: &Value) -> ParsedTranscriptLine {
         | "agent_message_chunk"
         | "agent_thought_chunk"
         | "tool_call"
-        | "tool_call_update" => Some(TurnState::Working),
+        | "tool_call_update"
+        | "task_backgrounded"
+        | "subagent_spawned" => Some(TurnState::Working),
+        "task_completed" | "subagent_finished" if grok_will_wake(update) => {
+            Some(TurnState::Working)
+        }
         _ => None,
     };
 
@@ -433,6 +439,63 @@ fn grok_completed_turn_state(update: &Value) -> TurnState {
     } else {
         TurnState::Ready
     }
+}
+
+fn grok_will_wake(update: &Value) -> bool {
+    update
+        .get("will_wake")
+        .or_else(|| update.get("willWake"))
+        .and_then(Value::as_bool)
+        == Some(true)
+}
+
+/// True when the Grok tail still has a subagent that has not finished.
+/// `turn_completed` can be the newest turn event while that child is still
+/// running, so status detection has to scan past it. Detached shells are
+/// ignored here: leftover dev servers would otherwise pin Working forever.
+pub fn grok_tail_has_pending_followup(tail: &str, read_full: bool) -> bool {
+    let mut spawned = HashSet::new();
+    let mut finished = HashSet::new();
+
+    for line in tail_lines_newest_first(tail, read_full) {
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        let method = value.get("method").and_then(Value::as_str).unwrap_or("");
+        if !matches!(method, "session/update" | "_x.ai/session/update") {
+            continue;
+        }
+        let Some(update) = value.pointer("/params/update") else {
+            continue;
+        };
+        let update_type = update
+            .get("sessionUpdate")
+            .or_else(|| update.get("session_update"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        match update_type {
+            "subagent_spawned" => {
+                if let Some(id) = grok_subagent_id(update) {
+                    spawned.insert(id);
+                }
+            }
+            "subagent_finished" => {
+                if let Some(id) = grok_subagent_id(update) {
+                    finished.insert(id);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    spawned.difference(&finished).next().is_some()
+}
+
+fn grok_subagent_id(update: &Value) -> Option<String> {
+    string_at(Some(update), "subagent_id")
+        .or_else(|| string_at(Some(update), "subagentId"))
+        .or_else(|| string_at(Some(update), "child_session_id"))
+        .or_else(|| string_at(Some(update), "childSessionId"))
 }
 
 fn grok_content_text(content: &Value) -> Option<String> {
@@ -1502,6 +1565,77 @@ mod tests {
             classify(AgentKind::Grok, tail, true),
             Some(TurnState::Working)
         );
+    }
+
+    #[test]
+    fn grok_backgrounded_task_keeps_the_turn_working() {
+        let tail = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1"}}}"#;
+        assert_eq!(
+            classify(AgentKind::Grok, tail, true),
+            Some(TurnState::Working)
+        );
+    }
+
+    #[test]
+    fn grok_spawned_subagent_keeps_the_turn_working() {
+        let tail = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"subagent_spawned","subagent_id":"child-1"}}}"#;
+        assert_eq!(
+            classify(AgentKind::Grok, tail, true),
+            Some(TurnState::Working)
+        );
+    }
+
+    #[test]
+    fn grok_will_wake_completion_keeps_the_turn_working() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","will_wake":true,"task_snapshot":{"task_id":"task-1"}}}}"#,
+        );
+        assert_eq!(
+            classify(AgentKind::Grok, tail, true),
+            Some(TurnState::Working)
+        );
+    }
+
+    #[test]
+    fn grok_finished_background_task_does_not_override_turn_completed() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","will_wake":false,"task_snapshot":{"task_id":"task-1"}}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert_eq!(
+            classify(AgentKind::Grok, tail, true),
+            Some(TurnState::Ready)
+        );
+        assert!(!grok_tail_has_pending_followup(tail, true));
+    }
+
+    #[test]
+    fn grok_detached_shell_does_not_count_as_pending_followup() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert_eq!(
+            classify(AgentKind::Grok, tail, true),
+            Some(TurnState::Ready)
+        );
+        assert!(!grok_tail_has_pending_followup(tail, true));
+    }
+
+    #[test]
+    fn grok_pending_subagent_survives_turn_completed() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"subagent_spawned","subagent_id":"child-1"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert!(grok_tail_has_pending_followup(tail, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Grok writes `turn_completed` as soon as its TUI returns to the prompt. Acorn mapped that to `WaitingForInput` even when work was still running, so the sidebar and “need input” notifications fired mid-turn.

Keep the session **Working** when:

- `background_tasks_manifest.json` still lists a **monitor** (those resume the agent)
- the transcript tail has a `subagent_spawned` without `subagent_finished`
- the newest event is `task_completed` / `subagent_finished` with `will_wake: true`

Fire-and-forget shells (leftover `vite` / `npm run dev`) still map to WaitingForInput, because those stay in the manifest after Grok is actually waiting for the user.

## Test plan

- [x] `cargo test -p acorn-transcript -p acorn-session --lib`
- [ ] CI (Rust format, Frontend, E2E shards)