### PR TITLE
fix(history): toast missing-worktree resume instead of a persistent error

### DIFF
--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type DependencyList,
   type Dispatch,
   type ReactNode,
@@ -163,6 +164,14 @@ import {
   resolveProjectScopedForRepoPath,
   scopeForSession,
 } from "../lib/sessionCreation";
+import {
+  applyDismissedHistoryWorktrees,
+  getDismissedHistoryWorktreeVersion,
+  markAgentHistoryWorktreeMissing,
+  rememberDismissedHistoryWorktree,
+  subscribeDismissedHistoryWorktrees,
+  type AgentHistoryItemIdentity,
+} from "../lib/agentHistoryWorktree";
 
 interface ExpandedDiff {
   payload: DiffPayload | null;
@@ -1360,6 +1369,30 @@ function isUnavailableHistoryWorktreeError(message: string): boolean {
   );
 }
 
+function patchCachedAgentHistoryWorktreeMissing(
+  scope: "project" | "unscoped",
+  repoPath: string | null,
+  historyLimit: number,
+  item: AgentHistoryItemIdentity,
+): void {
+  if (scope === "unscoped") {
+    const cached = rightPanelCache.getUnscopedAgentHistory(historyLimit);
+    if (!cached) return;
+    const next = markAgentHistoryWorktreeMissing(cached, item);
+    if (next !== cached) {
+      rightPanelCache.setUnscopedAgentHistory(historyLimit, next);
+    }
+    return;
+  }
+  if (!repoPath) return;
+  const cached = rightPanelCache.getAgentHistory(repoPath);
+  if (!cached) return;
+  const next = markAgentHistoryWorktreeMissing(cached, item);
+  if (next !== cached) {
+    rightPanelCache.setAgentHistory(repoPath, next);
+  }
+}
+
 function AgentHistoryTab({
   scope,
   repoPath,
@@ -1379,6 +1412,11 @@ function AgentHistoryTab({
   const adoptSessionWorktree = useAppStore((s) => s.adoptSessionWorktree);
   const setPendingTerminalInput = useAppStore((s) => s.setPendingTerminalInput);
   const historyLimit = 100;
+  const dismissedWorktreeVersion = useSyncExternalStore(
+    subscribeDismissedHistoryWorktrees,
+    getDismissedHistoryWorktreeVersion,
+    getDismissedHistoryWorktreeVersion,
+  );
   // Hydrate from the module-level cache so re-opening a project or the
   // unscoped Chats history shows its list instantly.
   const [items, setItems] = useState<AgentHistoryItem[] | null>(() =>
@@ -1443,10 +1481,10 @@ function AgentHistoryTab({
 
   const historyItems = useMemo(() => {
     if (!items) return null;
-    return [...items]
+    return [...applyDismissedHistoryWorktrees(items)]
       .sort((a, b) => b.updated_at - a.updated_at)
       .slice(0, historyLimit);
-  }, [items]);
+  }, [dismissedWorktreeVersion, items]);
   const visibleItems = useMemo(() => {
     if (!historyItems) return [];
     return providerFilter === ALL_AGENT_HISTORY_PROVIDERS
@@ -1521,7 +1559,22 @@ function AgentHistoryTab({
             );
             return;
           }
-          setError(rt(t, "rightPanel.history.worktreeFallback"));
+          const fallbackItem = item;
+          const fallbackScope = scope;
+          const fallbackRepoPath = repoPath;
+          showToast(rt(t, "rightPanel.history.worktreeFallback"), {
+            // Keep the live worktree chip until this toast expires so the
+            // row still names the missing checkout.
+            onDismiss: () => {
+              rememberDismissedHistoryWorktree(fallbackItem);
+              patchCachedAgentHistoryWorktreeMissing(
+                fallbackScope,
+                fallbackRepoPath,
+                historyLimit,
+                fallbackItem,
+              );
+            },
+          });
         } else {
           adoptedWorktree = true;
         }

--- a/src/lib/agentHistoryWorktree.test.ts
+++ b/src/lib/agentHistoryWorktree.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentHistoryItem } from "./types";
+import {
+  applyDismissedHistoryWorktrees,
+  getDismissedHistoryWorktreeVersion,
+  markAgentHistoryWorktreeMissing,
+  rememberDismissedHistoryWorktree,
+  resetDismissedHistoryWorktreesForTests,
+  subscribeDismissedHistoryWorktrees,
+} from "./agentHistoryWorktree";
+
+function historyItem(
+  overrides: Partial<AgentHistoryItem> &
+    Pick<AgentHistoryItem, "id" | "transcript_path">,
+): AgentHistoryItem {
+  return {
+    provider: "codex",
+    title: overrides.id,
+    preview: null,
+    queued_message_count: 0,
+    subagent_transcript_count: 0,
+    cwd: "/tmp/demo",
+    worktree: {
+      name: "removed-goal",
+      path: "/tmp/demo/.acorn/worktrees/removed-goal",
+      exists: true,
+    },
+    updated_at: 1,
+    resume_command: "codex resume",
+    ...overrides,
+  };
+}
+
+describe("agentHistoryWorktree", () => {
+  afterEach(() => {
+    resetDismissedHistoryWorktreesForTests();
+  });
+
+  it("marks only the matching history item missing", () => {
+    const target = historyItem({
+      id: "codex-1",
+      transcript_path: "/tmp/a.jsonl",
+    });
+    const other = historyItem({
+      id: "codex-2",
+      transcript_path: "/tmp/b.jsonl",
+    });
+
+    const next = markAgentHistoryWorktreeMissing([target, other], target);
+
+    expect(next[0]?.worktree?.exists).toBe(false);
+    expect(next[1]?.worktree?.exists).toBe(true);
+    expect(markAgentHistoryWorktreeMissing(next, target)).toBe(next);
+  });
+
+  it("applies dismissed worktrees to a remounted list snapshot", () => {
+    const item = historyItem({
+      id: "codex-stale",
+      transcript_path: "/tmp/stale.jsonl",
+    });
+    const notifications: number[] = [];
+    const unsubscribe = subscribeDismissedHistoryWorktrees(() => {
+      notifications.push(getDismissedHistoryWorktreeVersion());
+    });
+
+    rememberDismissedHistoryWorktree(item);
+    rememberDismissedHistoryWorktree(item);
+
+    expect(notifications).toEqual([1]);
+    expect(applyDismissedHistoryWorktrees([item])[0]?.worktree?.exists).toBe(
+      false,
+    );
+    unsubscribe();
+  });
+});

--- a/src/lib/agentHistoryWorktree.ts
+++ b/src/lib/agentHistoryWorktree.ts
@@ -1,0 +1,100 @@
+import type { AgentHistoryItem } from "./types";
+
+export type AgentHistoryItemIdentity = Pick<
+  AgentHistoryItem,
+  "provider" | "id" | "transcript_path"
+>;
+
+function agentHistoryItemKey(item: AgentHistoryItemIdentity): string {
+  return `${item.provider}:${item.id}:${item.transcript_path}`;
+}
+
+export function isSameAgentHistoryItem(
+  a: AgentHistoryItemIdentity,
+  b: AgentHistoryItemIdentity,
+): boolean {
+  return (
+    a.provider === b.provider &&
+    a.id === b.id &&
+    a.transcript_path === b.transcript_path
+  );
+}
+
+export function markAgentHistoryWorktreeMissing(
+  items: AgentHistoryItem[],
+  item: AgentHistoryItemIdentity,
+): AgentHistoryItem[] {
+  let changed = false;
+  const next = items.map((candidate) => {
+    if (
+      !isSameAgentHistoryItem(candidate, item) ||
+      !candidate.worktree?.exists
+    ) {
+      return candidate;
+    }
+    changed = true;
+    return {
+      ...candidate,
+      worktree: { ...candidate.worktree, exists: false },
+    };
+  });
+  return changed ? next : items;
+}
+
+let dismissedVersion = 0;
+const dismissedKeys = new Set<string>();
+const listeners = new Set<() => void>();
+
+function emitDismissedHistoryWorktrees(): void {
+  dismissedVersion += 1;
+  for (const listener of listeners) listener();
+}
+
+export function rememberDismissedHistoryWorktree(
+  item: AgentHistoryItemIdentity,
+): void {
+  const key = agentHistoryItemKey(item);
+  if (dismissedKeys.has(key)) return;
+  dismissedKeys.add(key);
+  emitDismissedHistoryWorktrees();
+}
+
+export function subscribeDismissedHistoryWorktrees(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function getDismissedHistoryWorktreeVersion(): number {
+  return dismissedVersion;
+}
+
+export function applyDismissedHistoryWorktrees(
+  items: AgentHistoryItem[],
+): AgentHistoryItem[] {
+  if (dismissedKeys.size === 0) return items;
+  let changed = false;
+  const next = items.map((candidate) => {
+    if (
+      !dismissedKeys.has(agentHistoryItemKey(candidate)) ||
+      !candidate.worktree?.exists
+    ) {
+      return candidate;
+    }
+    changed = true;
+    return {
+      ...candidate,
+      worktree: { ...candidate.worktree, exists: false },
+    };
+  });
+  return changed ? next : items;
+}
+
+export function resetDismissedHistoryWorktreesForTests(): void {
+  dismissedKeys.clear();
+  dismissedVersion = 0;
+  listeners.clear();
+}

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -2627,9 +2627,16 @@ test.describe("right panel: groups", () => {
     await dblclickRowRightSide(page, historyRow);
 
     await expect(title).toBeVisible();
-    await expect(page.getByRole("alert")).toContainText(
-      "Resumed from the project root instead",
-    );
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    const fallbackToast = page.getByRole("status").filter({
+      hasText: "Resumed from the project root instead",
+    });
+    await expect(fallbackToast).toBeVisible();
+    const worktreeName = historyRow.locator("span.truncate", {
+      hasText: "removed-goal",
+    });
+    await expect(worktreeName).toBeVisible();
+    await expect(worktreeName).not.toHaveClass(/line-through/);
     await expect(
       page.getByRole("dialog", { name: "Running in worktree" }),
     ).toHaveCount(0);
@@ -2642,6 +2649,10 @@ test.describe("right panel: groups", () => {
         ),
       )
       .toContain("codex resume codex-stale-worktree\r");
+
+    await fallbackToast.click();
+    await expect(fallbackToast).toHaveCount(0);
+    await expect(worktreeName).toHaveClass(/line-through/);
   });
 
   test("History run in new terminal hosts resumed sessions in the project root", async ({


### PR DESCRIPTION
## Summary

History auto-resume already recovered when a cached worktree disappeared. This keeps that recovery and stops treating it as a History-panel error.

1. **Toast instead of a red alert** — the fallback message is a toast. History rows stay visible.
2. **Chip stays live until the toast dismisses** — the worktree name is not struck through while the toast is up, then it becomes missing.
3. **Remount-safe overlay** — dismiss records the item in a module overlay and patches `rightPanelCache` from the cache snapshot, so switching project/scope while the toast is up still updates the row.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Resume after the source worktree was deleted | Red History alert; resume still ran at the project root | Toast only; resume still runs at the project root |
| Toast dismissed | Cached row still showed a live worktree | Row shows the worktree as missing |
| Switch project while the toast is up | Capturing tab could miss the cache write | Overlay + cache patch update the remounted tab |

## Test plan

- [x] `pnpm exec vitest run src/lib/agentHistoryWorktree.test.ts`
- [x] `CI=1 PLAYWRIGHT_PORT=1427 pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "History resume falls back to the project root when its cached worktree disappeared"`