### PR TITLE
feat(github): start work on a PR or issue from the right panel

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5285,9 +5285,7 @@ fn create_session_inner(
         if name.trim().is_empty() {
             name = project_basename(&repo);
         }
-        let base = sanitize_worktree_name(&name);
-        let (_safe_name, path) = create_unique_project_worktree(&repo, &base)?;
-        path
+        isolated_session_worktree_path(&repo, &name, cwd_path.as_deref())?
     } else {
         cwd_path.unwrap_or(selected_path)
     };
@@ -5313,6 +5311,29 @@ fn create_session_inner(
     }
     persist(state);
     Ok(enrich_session(inserted))
+}
+
+fn isolated_session_worktree_path(
+    repo: &Path,
+    name: &str,
+    cwd_path: Option<&Path>,
+) -> AppResult<PathBuf> {
+    if let Some(cwd) = cwd_path {
+        if worktree::is_linked_worktree_root(cwd) {
+            return worktree::list_worktree_paths(repo)?
+                .into_iter()
+                .find(|candidate| worktree::same_path(candidate, cwd))
+                .ok_or_else(|| {
+                    AppError::InvalidPath(format!(
+                        "worktree is not registered for the project: {}",
+                        cwd.display()
+                    ))
+                });
+        }
+    }
+    let base = sanitize_worktree_name(name);
+    let (_safe_name, path) = create_unique_project_worktree(repo, &base)?;
+    Ok(path)
 }
 
 fn validate_special_session_creation(
@@ -8592,6 +8613,29 @@ pub fn list_project_worktrees(
 ) -> AppResult<Vec<worktree::ProjectWorktreeInfo>> {
     let path = authorize_registered_project_root(state.inner(), Path::new(&repo_path))?;
     crate::worktree::list_worktree_infos(&path)
+}
+
+#[tauri::command]
+pub fn ensure_project_worktree_for_branch(
+    state: State<'_, AppState>,
+    repo_path: String,
+    branch: String,
+    name_hint: String,
+    create_if_missing: Option<bool>,
+    fetch_ref: Option<String>,
+) -> AppResult<worktree::EnsuredWorktree> {
+    let repo_path = authorize_registered_project_root(state.inner(), Path::new(&repo_path))?;
+    let settings = project_settings::get(&repo_path)?;
+    worktree::ensure_worktree_for_branch(
+        &repo_path,
+        &branch,
+        &name_hint,
+        worktree::EnsureWorktreeOptions {
+            create_if_missing: create_if_missing.unwrap_or(false),
+            fetch_ref: fetch_ref.as_deref(),
+            base_branch: settings.settings.worktrees.base_branch.as_deref(),
+        },
+    )
 }
 
 #[tauri::command]
@@ -12233,8 +12277,8 @@ mod tests {
         authorize_existing_session_id, authorize_registered_repository,
         authorize_registered_worktree, auto_title_enabled_for_new_session,
         can_store_generated_session_title, cleanup_removed_scrollbacks_from_dir,
-        collect_memory_usage_from_roots, configured_git_identity, create_unique_worktree,
-        daemon_attach_replay_scrollback, daemon_spawn_name_for_session,
+        collect_memory_usage_from_roots, configured_git_identity, create_session_inner,
+        create_unique_worktree, daemon_attach_replay_scrollback, daemon_spawn_name_for_session,
         detach_requested_by_stale_renderer, discard_pending_session_removal_from_dir,
         ensure_new_project_destination_available, font_name_from_path,
         infer_acornd_root_from_session_pids, inject_agent_hook_env,
@@ -12363,6 +12407,52 @@ mod tests {
         );
         assert!(linked_worktree_root_for_registered_path(&state, external.path()).is_none());
         assert!(authorize_registered_worktree(&state, root.path(), external.path()).is_err());
+    }
+
+    #[test]
+    fn isolated_session_adopts_an_existing_linked_worktree_cwd() {
+        let repo_dir = unique_repo_dir("adopt-isolated-cwd");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path =
+            crate::worktree::create_worktree(&repo_dir, "feature").expect("create linked worktree");
+        assert_eq!(
+            crate::worktree::list_worktree_paths(&repo_dir)
+                .expect("list before")
+                .len(),
+            1
+        );
+
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let created = create_session_inner(
+            &state,
+            "PR work".to_string(),
+            repo_dir.clone(),
+            Some(worktree_path.clone()),
+            true,
+            SessionKind::Regular,
+            None,
+            true,
+            SessionMode::Terminal,
+            None,
+            None,
+            false,
+        )
+        .expect("create session");
+
+        assert!(created.isolated);
+        assert_eq!(
+            created.worktree_path.canonicalize().unwrap(),
+            worktree_path.canonicalize().unwrap()
+        );
+        assert_eq!(
+            crate::worktree::list_worktree_paths(&repo_dir)
+                .expect("list after")
+                .len(),
+            1
+        );
+        std::fs::remove_dir_all(&repo_dir).ok();
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -868,6 +868,7 @@ pub fn run() {
             commands::prepare_chat_session_worktree,
             commands::git_worktrees,
             commands::list_project_worktrees,
+            commands::ensure_project_worktree_for_branch,
             commands::list_project_branches,
             commands::remove_worktree,
             commands::retry_removal_cleanup,

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -459,17 +459,18 @@ fn materialize_local_branch(
         return Ok(());
     }
 
+    if let Some(fetch_ref) = options.fetch_ref {
+        drop(repo);
+        fetch_ref_into_branch(repo_path, fetch_ref, branch)?;
+        return Ok(());
+    }
+
     let remote_ref = format!("refs/remotes/origin/{branch}");
     if repo.find_reference(&remote_ref).is_ok() {
         create_local_branch_from_ref(&repo, branch, &remote_ref)?;
         return Ok(());
     }
     drop(repo);
-
-    if let Some(fetch_ref) = options.fetch_ref {
-        fetch_ref_into_branch(repo_path, fetch_ref, branch)?;
-        return Ok(());
-    }
 
     if options.create_if_missing {
         let repo = ensure_repo(repo_path)?;
@@ -495,6 +496,8 @@ fn fetch_ref_into_branch(repo_path: &Path, fetch_ref: &str, branch: &str) -> App
     let spec = format!("{fetch_ref}:refs/heads/{branch}");
     let output = crate::cli_resolver::run("git", |cmd| {
         cmd.current_dir(repo_path);
+        cmd.env("GIT_TERMINAL_PROMPT", "0");
+        cmd.env("GCM_INTERACTIVE", "never");
         cmd.args(["fetch", "origin", &spec]);
     })?;
     if output.status.success() {
@@ -2489,6 +2492,79 @@ mod tests {
                 .shorthand()
                 .expect("shorthand"),
             "feature/from-pr"
+        );
+
+        std::fs::remove_dir_all(&work_root).ok();
+        std::fs::remove_dir_all(&origin_root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_prefers_pull_head_over_origin_branch() {
+        let origin_root = unique_temp_dir("ensure-fetch-fork-origin");
+        let origin = init_repo_with_tracked_file(&origin_root);
+        let sig = git2::Signature::now("acorn-test", "test@acorn").expect("sig");
+        let first = origin
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        let first_oid = first.id();
+        origin
+            .branch("patch-1", &first, false)
+            .expect("create colliding origin branch");
+        drop(first);
+
+        std::fs::write(origin_root.join("tracked.txt"), "pr-head").expect("write pr head");
+        let tree_id = {
+            let mut idx = origin.index().expect("index");
+            idx.add_path(Path::new("tracked.txt"))
+                .expect("add pr-head file");
+            idx.write_tree().expect("write pr-head tree")
+        };
+        let tree = origin.find_tree(tree_id).expect("pr-head tree");
+        let parent = origin
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("parent");
+        let pr_oid = origin
+            .commit(Some("HEAD"), &sig, &sig, "pr head", &tree, &[&parent])
+            .expect("commit pr head");
+        drop(tree);
+        drop(parent);
+        origin
+            .reference("refs/pull/91/head", pr_oid, true, "pr head")
+            .expect("create pull head ref");
+        drop(origin);
+
+        let work_root = unique_temp_dir("ensure-fetch-fork-work");
+        let work = git2::build::RepoBuilder::new()
+            .clone(origin_root.to_str().expect("origin path utf8"), &work_root)
+            .expect("clone origin");
+        work.reference(
+            "refs/remotes/origin/patch-1",
+            first_oid,
+            true,
+            "stale origin branch",
+        )
+        .expect("pin origin/patch-1 at the first commit");
+        drop(work);
+
+        let ensured = ensure_worktree_for_branch(
+            &work_root,
+            "patch-1",
+            "pr-91-patch-1",
+            ensure_options(false, Some("refs/pull/91/head"), None),
+        )
+        .expect("fetch pull head instead of origin/patch-1");
+
+        let worktree_repo = Repository::open(&ensured.path).expect("open worktree");
+        assert_eq!(
+            worktree_repo.head().expect("head").target(),
+            Some(pr_oid),
+            "worktree must check out the pull head, not origin/patch-1",
+        );
+        assert_eq!(
+            std::fs::read_to_string(Path::new(&ensured.path).join("tracked.txt")).unwrap(),
+            "pr-head",
         );
 
         std::fs::remove_dir_all(&work_root).ok();

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -1,4 +1,4 @@
-use git2::{BranchType, Repository, WorktreeAddOptions, WorktreePruneOptions};
+use git2::{BranchType, ErrorCode, Repository, WorktreeAddOptions, WorktreePruneOptions};
 use serde::Serialize;
 use std::fs::{File, Metadata, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
@@ -302,6 +302,260 @@ pub fn create_worktree_from_base_branch(
         return Err(err.into());
     }
     Ok(target)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EnsureWorktreeOptions<'a> {
+    pub create_if_missing: bool,
+    pub fetch_ref: Option<&'a str>,
+    pub base_branch: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EnsuredWorktree {
+    pub path: String,
+    pub branch: String,
+    pub created: bool,
+}
+
+/// Guarantee a checkout of `branch` — reuse an existing one, or add a linked
+/// worktree under `.acorn/worktrees/`. The git branch name and the worktree
+/// directory name are independent so a PR head like `feature/foo` can live in
+/// `pr-91-foo` without minting a second branch.
+pub fn ensure_worktree_for_branch(
+    repo_path: &Path,
+    branch: &str,
+    worktree_name_hint: &str,
+    options: EnsureWorktreeOptions<'_>,
+) -> AppResult<EnsuredWorktree> {
+    let branch = normalize_local_branch_name(branch)?;
+    if let Some(fetch_ref) = options.fetch_ref {
+        validate_pull_head_fetch_ref(fetch_ref)?;
+    }
+    let hint = sanitize_worktree_dir_name(worktree_name_hint);
+
+    if let Some(path) = find_checkout_for_branch(repo_path, &branch)? {
+        return Ok(ensured_worktree(path, branch, false));
+    }
+
+    materialize_local_branch(repo_path, &branch, &options)?;
+
+    if let Some(path) = find_checkout_for_branch(repo_path, &branch)? {
+        return Ok(ensured_worktree(path, branch, false));
+    }
+
+    match add_worktree_for_local_branch(repo_path, &branch, &hint) {
+        Ok(path) => Ok(ensured_worktree(path, branch, true)),
+        Err(error) => {
+            if let Some(path) = find_checkout_for_branch(repo_path, &branch)? {
+                return Ok(ensured_worktree(path, branch, false));
+            }
+            Err(error)
+        }
+    }
+}
+
+fn ensured_worktree(path: PathBuf, branch: String, created: bool) -> EnsuredWorktree {
+    EnsuredWorktree {
+        path: path.to_string_lossy().into_owned(),
+        branch,
+        created,
+    }
+}
+
+fn normalize_local_branch_name(branch: &str) -> AppResult<String> {
+    let branch = branch.trim();
+    let branch = branch.strip_prefix("refs/heads/").unwrap_or(branch).trim();
+    validate_git_branch_name(branch)?;
+    Ok(branch.to_string())
+}
+
+fn validate_git_branch_name(name: &str) -> AppResult<()> {
+    if name.is_empty() {
+        return Err(AppError::Other("branch name must not be empty".into()));
+    }
+    if name.starts_with('-')
+        || name.starts_with('/')
+        || name.ends_with('/')
+        || name.ends_with('.')
+        || name.ends_with(".lock")
+        || name.contains("..")
+        || name.contains("//")
+        || name.contains("@{")
+        || name.contains('\0')
+    {
+        return Err(AppError::Other(format!("invalid branch name: {name}")));
+    }
+    if name.bytes().any(|byte| {
+        byte.is_ascii_control()
+            || matches!(
+                byte,
+                b' ' | b'~' | b'^' | b':' | b'?' | b'*' | b'[' | b'\\' | b'\x7f'
+            )
+    }) {
+        return Err(AppError::Other(format!("invalid branch name: {name}")));
+    }
+    Ok(())
+}
+
+fn validate_pull_head_fetch_ref(fetch_ref: &str) -> AppResult<()> {
+    let valid = fetch_ref
+        .strip_prefix("refs/pull/")
+        .and_then(|rest| rest.strip_suffix("/head"))
+        .is_some_and(|number| {
+            !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit())
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(AppError::Other(format!(
+            "unsupported fetch ref: {fetch_ref}"
+        )))
+    }
+}
+
+fn sanitize_worktree_dir_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "worktree".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn find_checkout_for_branch(repo_path: &Path, branch: &str) -> AppResult<Option<PathBuf>> {
+    let repo = ensure_repo(repo_path)?;
+    if let Some(workdir) = repo.workdir() {
+        if current_branch(workdir).ok().as_deref() == Some(branch) {
+            return Ok(Some(workdir.to_path_buf()));
+        }
+    }
+    for path in list_worktree_paths(repo_path)? {
+        if current_branch(&path).ok().as_deref() == Some(branch) {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+fn materialize_local_branch(
+    repo_path: &Path,
+    branch: &str,
+    options: &EnsureWorktreeOptions<'_>,
+) -> AppResult<()> {
+    let repo = ensure_repo(repo_path)?;
+    if repo.find_reference(&format!("refs/heads/{branch}")).is_ok() {
+        return Ok(());
+    }
+
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    if repo.find_reference(&remote_ref).is_ok() {
+        create_local_branch_from_ref(&repo, branch, &remote_ref)?;
+        return Ok(());
+    }
+    drop(repo);
+
+    if let Some(fetch_ref) = options.fetch_ref {
+        fetch_ref_into_branch(repo_path, fetch_ref, branch)?;
+        return Ok(());
+    }
+
+    if options.create_if_missing {
+        let repo = ensure_repo(repo_path)?;
+        let base = worktree_base_commit(&repo, options.base_branch)?;
+        repo.branch(branch, &base, false)?;
+        return Ok(());
+    }
+
+    Err(AppError::Other(format!("branch was not found: {branch}")))
+}
+
+fn create_local_branch_from_ref(
+    repo: &Repository,
+    branch: &str,
+    source_ref: &str,
+) -> AppResult<()> {
+    let commit = repo.find_reference(source_ref)?.peel_to_commit()?;
+    repo.branch(branch, &commit, false)?;
+    Ok(())
+}
+
+fn fetch_ref_into_branch(repo_path: &Path, fetch_ref: &str, branch: &str) -> AppResult<()> {
+    let spec = format!("{fetch_ref}:refs/heads/{branch}");
+    let output = crate::cli_resolver::run("git", |cmd| {
+        cmd.current_dir(repo_path);
+        cmd.args(["fetch", "origin", &spec]);
+    })?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = stderr.trim();
+    let detail = if detail.is_empty() {
+        stdout.trim()
+    } else {
+        detail
+    };
+    Err(AppError::Other(if detail.is_empty() {
+        format!("failed to fetch {fetch_ref}")
+    } else {
+        format!("failed to fetch {fetch_ref}: {detail}")
+    }))
+}
+
+fn add_worktree_for_local_branch(repo_path: &Path, branch: &str, hint: &str) -> AppResult<PathBuf> {
+    let repo = ensure_repo(repo_path)?;
+    ensure_git_excluded(&repo).ok();
+    let (name, target) = unique_managed_worktree_target(&repo, repo_path, hint)?;
+    let branch_ref_name = format!("refs/heads/{branch}");
+    let branch_ref = repo.find_reference(&branch_ref_name)?;
+    let mut opts = WorktreeAddOptions::new();
+    opts.checkout_existing(true).reference(Some(&branch_ref));
+    repo.worktree(&name, &target, Some(&opts))?;
+    Ok(target)
+}
+
+fn unique_managed_worktree_target(
+    repo: &Repository,
+    repo_path: &Path,
+    hint: &str,
+) -> AppResult<(String, PathBuf)> {
+    let root = checked_worktree_root(repo_path, true)?;
+    let mut n = 1u32;
+    loop {
+        let name = if n == 1 {
+            hint.to_string()
+        } else {
+            format!("{hint}-{n}")
+        };
+        let target = root.join(&name);
+        let registration_taken = match repo.find_worktree(&name) {
+            Ok(_) => true,
+            Err(err) if err.code() == ErrorCode::NotFound => false,
+            Err(err) => return Err(err.into()),
+        };
+        if !target.exists() && !registration_taken {
+            return Ok((name, target));
+        }
+        if n >= 100 {
+            return Err(AppError::Other(format!(
+                "could not find a free worktree name for {hint}"
+            )));
+        }
+        n += 1;
+    }
 }
 
 pub fn validate_worktree_base_branch(repo_path: &Path, branch: &str) -> AppResult<()> {
@@ -1978,5 +2232,284 @@ mod tests {
         std::fs::remove_file(root.join(ACORN_DIR)).ok();
         std::fs::remove_dir_all(&root).ok();
         std::fs::remove_dir_all(&external).ok();
+    }
+
+    fn ensure_options<'a>(
+        create_if_missing: bool,
+        fetch_ref: Option<&'a str>,
+        base_branch: Option<&'a str>,
+    ) -> EnsureWorktreeOptions<'a> {
+        EnsureWorktreeOptions {
+            create_if_missing,
+            fetch_ref,
+            base_branch,
+        }
+    }
+
+    #[test]
+    fn ensure_worktree_reuses_root_when_branch_is_already_checked_out() {
+        let root = unique_temp_dir("ensure-reuse-root");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+        let current = current_branch(&root).expect("current branch");
+
+        let ensured = ensure_worktree_for_branch(
+            &root,
+            &current,
+            "pr-1-main",
+            ensure_options(false, None, None),
+        )
+        .expect("reuse root checkout");
+
+        assert!(!ensured.created);
+        assert_eq!(ensured.branch, current);
+        assert_eq!(
+            Path::new(&ensured.path).canonicalize().unwrap(),
+            root.canonicalize().unwrap()
+        );
+        assert!(list_worktree_paths(&root).expect("list").is_empty());
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_checks_out_existing_branch_in_new_directory() {
+        let root = unique_temp_dir("ensure-existing-branch");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("main", &initial, false).expect("create main");
+        repo.branch("feature/pr-head", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+        checkout_branch(&repo, "main");
+        drop(repo);
+
+        let ensured = ensure_worktree_for_branch(
+            &root,
+            "feature/pr-head",
+            "pr-91-open-the-matching",
+            ensure_options(false, None, None),
+        )
+        .expect("add worktree for existing branch");
+
+        assert!(ensured.created);
+        assert_eq!(ensured.branch, "feature/pr-head");
+        let worktree_path = Path::new(&ensured.path);
+        assert_eq!(
+            worktree_path.file_name().and_then(|name| name.to_str()),
+            Some("pr-91-open-the-matching")
+        );
+        let worktree_repo = Repository::open(worktree_path).expect("open worktree");
+        assert_eq!(
+            worktree_repo
+                .head()
+                .expect("head")
+                .shorthand()
+                .expect("shorthand"),
+            "feature/pr-head"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_reuses_linked_checkout_for_the_same_branch() {
+        let root = unique_temp_dir("ensure-reuse-linked");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("main", &initial, false).expect("create main");
+        repo.branch("feature/shared", &initial, false)
+            .expect("create feature");
+        drop(initial);
+        checkout_branch(&repo, "main");
+        drop(repo);
+
+        let first = ensure_worktree_for_branch(
+            &root,
+            "feature/shared",
+            "pr-3-first",
+            ensure_options(false, None, None),
+        )
+        .expect("create first worktree");
+        let second = ensure_worktree_for_branch(
+            &root,
+            "feature/shared",
+            "pr-3-second",
+            ensure_options(false, None, None),
+        )
+        .expect("reuse first worktree");
+
+        assert!(first.created);
+        assert!(!second.created);
+        assert_eq!(
+            Path::new(&first.path).canonicalize().unwrap(),
+            Path::new(&second.path).canonicalize().unwrap()
+        );
+        assert_eq!(list_worktree_paths(&root).expect("list").len(), 1);
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_creates_named_branch_from_base_when_missing() {
+        let root = unique_temp_dir("ensure-create-issue");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        let main_oid = initial.id();
+        repo.branch("main", &initial, false).expect("create main");
+        drop(initial);
+        checkout_branch(&repo, "main");
+        drop(repo);
+
+        let ensured = ensure_worktree_for_branch(
+            &root,
+            "issue-12-login-form",
+            "issue-12-login-form",
+            ensure_options(true, None, Some("main")),
+        )
+        .expect("create issue branch worktree");
+
+        assert!(ensured.created);
+        assert_eq!(ensured.branch, "issue-12-login-form");
+        let worktree_repo = Repository::open(&ensured.path).expect("open worktree");
+        let head = worktree_repo.head().expect("head");
+        assert_eq!(head.shorthand().expect("shorthand"), "issue-12-login-form");
+        assert_eq!(head.target(), Some(main_oid));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_errors_when_branch_is_missing_and_not_created() {
+        let root = unique_temp_dir("ensure-missing");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+
+        let error = ensure_worktree_for_branch(
+            &root,
+            "feature/missing",
+            "pr-4-missing",
+            ensure_options(false, None, None),
+        )
+        .expect_err("missing branch must fail");
+
+        assert!(error
+            .to_string()
+            .contains("branch was not found: feature/missing"));
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_creates_local_branch_from_origin_tracking_ref() {
+        let root = unique_temp_dir("ensure-from-origin");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("main", &initial, false).expect("create main");
+        repo.reference(
+            "refs/remotes/origin/feature/from-origin",
+            initial.id(),
+            false,
+            "remote tracking",
+        )
+        .expect("create origin tracking ref");
+        drop(initial);
+        checkout_branch(&repo, "main");
+        drop(repo);
+
+        let ensured = ensure_worktree_for_branch(
+            &root,
+            "feature/from-origin",
+            "pr-5-from-origin",
+            ensure_options(false, None, None),
+        )
+        .expect("create local branch from origin");
+
+        assert!(ensured.created);
+        assert_eq!(ensured.branch, "feature/from-origin");
+        let worktree_repo = Repository::open(&ensured.path).expect("open worktree");
+        assert_eq!(
+            worktree_repo
+                .head()
+                .expect("head")
+                .shorthand()
+                .expect("shorthand"),
+            "feature/from-origin"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_fetches_pull_head_into_local_branch() {
+        let origin_root = unique_temp_dir("ensure-fetch-origin");
+        let origin = init_repo_with_tracked_file(&origin_root);
+        let oid = origin
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("origin commit")
+            .id();
+        origin
+            .reference("refs/pull/91/head", oid, true, "pr head")
+            .expect("create pull head ref");
+        drop(origin);
+
+        let work_root = unique_temp_dir("ensure-fetch-work");
+        let repo = git2::build::RepoBuilder::new()
+            .clone(origin_root.to_str().expect("origin path utf8"), &work_root)
+            .expect("clone origin");
+        drop(repo);
+
+        let ensured = ensure_worktree_for_branch(
+            &work_root,
+            "feature/from-pr",
+            "pr-91-from-pr",
+            ensure_options(false, Some("refs/pull/91/head"), None),
+        )
+        .expect("fetch pull head into worktree");
+
+        assert!(ensured.created);
+        assert_eq!(ensured.branch, "feature/from-pr");
+        let worktree_repo = Repository::open(&ensured.path).expect("open worktree");
+        assert_eq!(
+            worktree_repo
+                .head()
+                .expect("head")
+                .shorthand()
+                .expect("shorthand"),
+            "feature/from-pr"
+        );
+
+        std::fs::remove_dir_all(&work_root).ok();
+        std::fs::remove_dir_all(&origin_root).ok();
+    }
+
+    #[test]
+    fn ensure_worktree_rejects_non_pull_fetch_refs() {
+        let root = unique_temp_dir("ensure-bad-fetch-ref");
+        let repo = init_repo_with_tracked_file(&root);
+        drop(repo);
+
+        let error = ensure_worktree_for_branch(
+            &root,
+            "feature/x",
+            "pr-1",
+            ensure_options(false, Some("refs/heads/main"), None),
+        )
+        .expect_err("only pull head refs are accepted");
+
+        assert!(error.to_string().contains("unsupported fetch ref"));
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/src/components/GithubStartWorkButton.tsx
+++ b/src/components/GithubStartWorkButton.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { Loader2, Play, SquareTerminal } from "lucide-react";
+import {
+  runGithubStartWork,
+  type GithubStartWorkTarget,
+} from "../lib/githubStartWork";
+import { findSessionsForPullRequest } from "../lib/sessionContext";
+import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
+import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
+import { useAppStore } from "../store";
+
+export function GithubStartWorkButton({
+  repoPath,
+  target,
+  onStarted,
+}: {
+  repoPath: string;
+  target: GithubStartWorkTarget;
+  onStarted?: () => void;
+}) {
+  const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
+  const sessions = useAppStore((s) => s.sessions);
+  const createSession = useAppStore((s) => s.createSession);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
+  const [busy, setBusy] = useState(false);
+
+  const existing =
+    target.kind === "pr" && target.headBranch?.trim()
+      ? (findSessionsForPullRequest(
+          sessions,
+          repoPath,
+          target.headBranch,
+          readSessionPullRequestBranchLinks(),
+        )[0] ?? null)
+      : null;
+  const canStart =
+    target.kind === "issue" || Boolean(target.headBranch?.trim());
+  const label = existing
+    ? t("rightPanel.menu.openSession")
+    : t("rightPanel.menu.startWork");
+
+  async function handleClick() {
+    if (existing) {
+      openSessionSurface(existing.id);
+      onStarted?.();
+      return;
+    }
+    if (!canStart || busy) return;
+    setBusy(true);
+    try {
+      const result = await runGithubStartWork({
+        repoPath,
+        target,
+        createSession,
+        consumeError: () => useAppStore.getState().consumeError(),
+      });
+      if (!result.ok) {
+        const message =
+          result.error ?? t("rightPanel.errors.startWorkFailed");
+        showToast(`${t("toasts.session.createFailed")} ${message}`);
+        return;
+      }
+      onStarted?.();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-busy={busy}
+      disabled={!canStart || busy}
+      onClick={() => void handleClick()}
+      className="flex items-center gap-1 rounded-md bg-bg-elevated px-2.5 py-1 text-[11px] font-medium text-fg-muted transition hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {busy ? (
+        <Loader2 size={12} className="animate-spin" />
+      ) : existing ? (
+        <SquareTerminal size={12} />
+      ) : (
+        <Play size={12} />
+      )}
+      {label}
+    </button>
+  );
+}

--- a/src/components/GithubStartWorkButton.tsx
+++ b/src/components/GithubStartWorkButton.tsx
@@ -1,11 +1,10 @@
 import { useState } from "react";
 import { Loader2, Play, SquareTerminal } from "lucide-react";
 import {
+  findSessionsForGithubWork,
   runGithubStartWork,
   type GithubStartWorkTarget,
 } from "../lib/githubStartWork";
-import { findSessionsForPullRequest } from "../lib/sessionContext";
-import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
 import { useAppStore } from "../store";
@@ -27,14 +26,7 @@ export function GithubStartWorkButton({
   const [busy, setBusy] = useState(false);
 
   const existing =
-    target.kind === "pr" && target.headBranch?.trim()
-      ? (findSessionsForPullRequest(
-          sessions,
-          repoPath,
-          target.headBranch,
-          readSessionPullRequestBranchLinks(),
-        )[0] ?? null)
-      : null;
+    findSessionsForGithubWork(sessions, repoPath, target)[0] ?? null;
   const canStart =
     target.kind === "issue" || Boolean(target.headBranch?.trim());
   const label = existing

--- a/src/components/IssueDetailModal.tsx
+++ b/src/components/IssueDetailModal.tsx
@@ -22,6 +22,7 @@ import type {
 import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag } from "./AuthorTag";
+import { GithubStartWorkButton } from "./GithubStartWorkButton";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
 import { DiscardCommentDraftDialog } from "./DiscardCommentDraftDialog";
 import { GitHubCommentEditForm } from "./GitHubCommentEditForm";
@@ -232,12 +233,17 @@ export function IssueDetailModal({
               detail={listing.detail}
               commentDraft={commentDraft}
               onCommentDraftChange={setCommentDraft}
+              repoPath={open.repoPath}
               onClose={requestClose}
               onRefresh={handleRefresh}
               refreshing={refreshing}
               onSubmitComment={handleSubmitComment}
               onUpdateComment={handleUpdateComment}
               onRequestDeleteComment={setDeleteCommentId}
+              onStartedWork={() => {
+                setCommentDraft("");
+                onClose();
+              }}
             />
           )
         ) : null}
@@ -290,23 +296,27 @@ function IssueDetailBody({
   detail,
   commentDraft,
   onCommentDraftChange,
+  repoPath,
   onClose,
   onRefresh,
   refreshing,
   onSubmitComment,
   onUpdateComment,
   onRequestDeleteComment,
+  onStartedWork,
 }: {
   account: string;
   detail: IssueDetail;
   commentDraft: string;
   onCommentDraftChange: (body: string) => void;
+  repoPath: string;
   onClose: () => void;
   onRefresh: () => void;
   refreshing: boolean;
   onSubmitComment: (body: string) => Promise<void>;
   onUpdateComment: (commentId: number, body: string) => Promise<void>;
   onRequestDeleteComment: (commentId: number) => void;
+  onStartedWork: () => void;
 }) {
   const t = useTranslation();
   const created = toUnixSeconds(detail.created_at);
@@ -386,6 +396,15 @@ function IssueDetailBody({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          <GithubStartWorkButton
+            repoPath={repoPath}
+            target={{
+              kind: "issue",
+              number: detail.number,
+              title: detail.title,
+            }}
+            onStarted={onStartedWork}
+          />
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <Tooltip
             label={dt(t, "dialogs.issueDetail.openOnGithub")}

--- a/src/components/PullRequestDetailModal.tsx
+++ b/src/components/PullRequestDetailModal.tsx
@@ -47,6 +47,7 @@ import type {
 import { useTranslation } from "../lib/useTranslation";
 import { AuthorTag, buildProfileMenuItems } from "./AuthorTag";
 import { ClosePullRequestDialog } from "./ClosePullRequestDialog";
+import { GithubStartWorkButton } from "./GithubStartWorkButton";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { DeleteCommentDialog } from "./DeleteCommentDialog";
 import { DiscardCommentDraftDialog } from "./DiscardCommentDraftDialog";
@@ -518,6 +519,10 @@ export function PullRequestDetailModal({
             onSubmitComment={handleSubmitComment}
             onUpdateComment={handleUpdateComment}
             onRequestDeleteComment={setDeleteCommentId}
+            onStartedWork={() => {
+              setCommentDraft("");
+              onClose();
+            }}
           />
         )
       ) : null}
@@ -604,6 +609,7 @@ function DetailBody({
   onSubmitComment,
   onUpdateComment,
   onRequestDeleteComment,
+  onStartedWork,
 }: {
   account: string;
   detail: PullRequestDetail;
@@ -628,6 +634,7 @@ function DetailBody({
   onSubmitComment: (body: string) => Promise<void>;
   onUpdateComment: (commentId: number, body: string) => Promise<void>;
   onRequestDeleteComment: (commentId: number) => void;
+  onStartedWork: () => void;
 }) {
   const t = useTranslation();
   const conversationCount = detail.comments.length + detail.reviews.length;
@@ -826,6 +833,16 @@ function DetailBody({
               <span className="mx-1 h-4 w-px bg-border" aria-hidden />
             </>
           ) : null}
+          <GithubStartWorkButton
+            repoPath={repoPath}
+            target={{
+              kind: "pr",
+              number: detail.number,
+              title: detail.title,
+              headBranch: detail.head_branch,
+            }}
+            onStarted={onStartedWork}
+          />
           <RefreshButton onClick={onRefresh} loading={refreshing} size={14} />
           <Tooltip label={dt(t, "dialogs.pullRequestDetail.openOnGithub")} side="bottom">
             <button

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -62,9 +62,10 @@ import { trimTrailingPathSeparators } from "../lib/pathUtils";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import { openSafeUrl } from "../lib/safeOpenUrl";
 import { openExternalUrlWithFeedback } from "../lib/externalOpener";
-import { findSessionsForPullRequest } from "../lib/sessionContext";
-import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
-import { runGithubStartWork } from "../lib/githubStartWork";
+import {
+  findSessionsForGithubWork,
+  runGithubStartWork,
+} from "../lib/githubStartWork";
 import {
   onPullRequestMutation,
   pullRequestMutationAffectsOpenContext,
@@ -3020,12 +3021,12 @@ function usePrRowActions(
   }
 
   const matchingSessions = menu
-    ? findSessionsForPullRequest(
-        sessions,
-        repoPath,
-        menu.pr.head_branch,
-        readSessionPullRequestBranchLinks(),
-      )
+    ? findSessionsForGithubWork(sessions, repoPath, {
+        kind: "pr",
+        number: menu.pr.number,
+        title: menu.pr.title,
+        headBranch: menu.pr.head_branch,
+      })
     : [];
 
   async function startWork(pr: PullRequestInfo) {
@@ -3042,7 +3043,6 @@ function usePrRowActions(
     });
     if (result.ok) return;
     const message = result.error ?? rt(t, "rightPanel.errors.startWorkFailed");
-    setError(message);
     showToast(`${t("toasts.session.createFailed")} ${message}`);
   }
 
@@ -3531,7 +3531,9 @@ function useIssueRowActions(
 ) {
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
+  const sessions = useAppStore((s) => s.sessions);
   const createSession = useAppStore((s) => s.createSession);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -3568,7 +3570,6 @@ function useIssueRowActions(
     });
     if (result.ok) return;
     const message = result.error ?? rt(t, "rightPanel.errors.startWorkFailed");
-    setError(message);
     showToast(`${t("toasts.session.createFailed")} ${message}`);
   }
 
@@ -3579,6 +3580,46 @@ function useIssueRowActions(
     e.preventDefault();
     setMenu({ x: e.clientX, y: e.clientY, issue });
   }
+
+  const matchingSessions = menu
+    ? findSessionsForGithubWork(sessions, repoPath, {
+        kind: "issue",
+        number: menu.issue.number,
+        title: menu.issue.title,
+      })
+    : [];
+
+  const openSessionMenuItem: ContextMenuItem | null =
+    matchingSessions.length === 1
+      ? {
+          label: rtf(t, "rightPanel.menu.openSessionWithName", {
+            name: matchingSessions[0].name,
+          }),
+          icon: <SquareTerminal size={12} />,
+          onClick: () => openSessionSurface(matchingSessions[0].id),
+        }
+      : matchingSessions.length > 1
+        ? {
+            type: "submenu",
+            label: rt(t, "rightPanel.menu.openSession"),
+            icon: <SquareTerminal size={12} />,
+            children: matchingSessions.map((session) => ({
+              label: session.name,
+              icon: <SquareTerminal size={12} />,
+              onClick: () => openSessionSurface(session.id),
+            })),
+          }
+        : null;
+
+  const startWorkMenuItem: ContextMenuItem = {
+    label: rt(t, "rightPanel.menu.startWork"),
+    icon: <Play size={12} />,
+    onClick: () => {
+      if (menu) void startWork(menu.issue);
+    },
+  };
+
+  const sessionOrStartWorkItem = openSessionMenuItem ?? startWorkMenuItem;
 
   const overlays = (
     <ContextMenu
@@ -3598,11 +3639,7 @@ function useIssueRowActions(
                 icon: <ExternalLink size={12} />,
                 onClick: () => void openIssueInBrowser(menu.issue),
               },
-              {
-                label: rt(t, "rightPanel.menu.startWork"),
-                icon: <Play size={12} />,
-                onClick: () => void startWork(menu.issue),
-              },
+              sessionOrStartWorkItem,
               { type: "separator" },
               {
                 label: rt(t, "rightPanel.menu.copyIssueNumber"),

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -64,6 +64,7 @@ import { openSafeUrl } from "../lib/safeOpenUrl";
 import { openExternalUrlWithFeedback } from "../lib/externalOpener";
 import { findSessionsForPullRequest } from "../lib/sessionContext";
 import { readSessionPullRequestBranchLinks } from "../lib/sessionPullRequestLinks";
+import { runGithubStartWork } from "../lib/githubStartWork";
 import {
   onPullRequestMutation,
   pullRequestMutationAffectsOpenContext,
@@ -2849,7 +2850,9 @@ function usePrRowActions(
   onMutated?: () => void,
 ) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
   const sessions = useAppStore((s) => s.sessions);
+  const createSession = useAppStore((s) => s.createSession);
   const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const [menu, setMenu] = useState<{
     x: number;
@@ -3025,7 +3028,25 @@ function usePrRowActions(
       )
     : [];
 
-  const openSessionMenuItem: ContextMenuItem =
+  async function startWork(pr: PullRequestInfo) {
+    const result = await runGithubStartWork({
+      repoPath,
+      target: {
+        kind: "pr",
+        number: pr.number,
+        title: pr.title,
+        headBranch: pr.head_branch,
+      },
+      createSession,
+      consumeError: () => useAppStore.getState().consumeError(),
+    });
+    if (result.ok) return;
+    const message = result.error ?? rt(t, "rightPanel.errors.startWorkFailed");
+    setError(message);
+    showToast(`${t("toasts.session.createFailed")} ${message}`);
+  }
+
+  const openSessionMenuItem: ContextMenuItem | null =
     matchingSessions.length === 1
       ? {
           label: rtf(t, "rightPanel.menu.openSessionWithName", {
@@ -3045,12 +3066,18 @@ function usePrRowActions(
               onClick: () => openSessionSurface(session.id),
             })),
           }
-        : {
-            label: rt(t, "rightPanel.menu.openSession"),
-            icon: <SquareTerminal size={12} />,
-            disabled: true,
-            onClick: () => undefined,
-          };
+        : null;
+
+  const startWorkMenuItem: ContextMenuItem = {
+    label: rt(t, "rightPanel.menu.startWork"),
+    icon: <Play size={12} />,
+    disabled: !menu?.pr.head_branch.trim(),
+    onClick: () => {
+      if (menu) void startWork(menu.pr);
+    },
+  };
+
+  const sessionOrStartWorkItem = openSessionMenuItem ?? startWorkMenuItem;
 
   const overlays = (
     <>
@@ -3071,7 +3098,7 @@ function usePrRowActions(
                   icon: <ExternalLink size={12} />,
                   onClick: () => void openPrInBrowser(menu.pr),
                 },
-                openSessionMenuItem,
+                sessionOrStartWorkItem,
                 { type: "separator" },
                 {
                   label: rt(t, "rightPanel.menu.copyPrNumber"),
@@ -3498,8 +3525,13 @@ function issueListStateFromCache(
   };
 }
 
-function useIssueRowActions(onOpenDetail: (number: number) => void) {
+function useIssueRowActions(
+  repoPath: string,
+  onOpenDetail: (number: number) => void,
+) {
   const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
+  const createSession = useAppStore((s) => s.createSession);
   const [menu, setMenu] = useState<{
     x: number;
     y: number;
@@ -3521,6 +3553,23 @@ function useIssueRowActions(onOpenDetail: (number: number) => void) {
     } catch (e) {
       setError(String(e));
     }
+  }
+
+  async function startWork(issue: IssueInfo) {
+    const result = await runGithubStartWork({
+      repoPath,
+      target: {
+        kind: "issue",
+        number: issue.number,
+        title: issue.title,
+      },
+      createSession,
+      consumeError: () => useAppStore.getState().consumeError(),
+    });
+    if (result.ok) return;
+    const message = result.error ?? rt(t, "rightPanel.errors.startWorkFailed");
+    setError(message);
+    showToast(`${t("toasts.session.createFailed")} ${message}`);
   }
 
   function openContextMenu(
@@ -3548,6 +3597,11 @@ function useIssueRowActions(onOpenDetail: (number: number) => void) {
                 label: rt(t, "rightPanel.menu.openInBrowser"),
                 icon: <ExternalLink size={12} />,
                 onClick: () => void openIssueInBrowser(menu.issue),
+              },
+              {
+                label: rt(t, "rightPanel.menu.startWork"),
+                icon: <Play size={12} />,
+                onClick: () => void startWork(menu.issue),
               },
               { type: "separator" },
               {
@@ -3697,7 +3751,7 @@ function IssuesTab({ repoPath }: { repoPath: string }) {
     (number: number) => setIssueDetail({ repoPath, number }),
     [repoPath],
   );
-  const rowActions = useIssueRowActions(openIssueDetail);
+  const rowActions = useIssueRowActions(repoPath, openIssueDetail);
 
   function handleScroll(e: React.UIEvent<HTMLDivElement>) {
     if (loading) return;
@@ -5220,7 +5274,7 @@ function IssueSearchModal({
   const [loading, setLoading] = useState(false);
   const [limit, setLimit] = useState(ISSUE_PAGE_SIZE);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const rowActions = useIssueRowActions(onOpenDetail);
+  const rowActions = useIssueRowActions(repoPath ?? "", onOpenDetail);
 
   useDialogShortcuts(open !== null && !detailOpen, { onCancel: onClose });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
   ProjectSettings,
   ProjectSettingsRecord,
   ProjectWorktree,
+  EnsuredProjectWorktree,
   PrStateFilter,
   PullRequestDetailListing,
   PullRequestDiffListing,
@@ -498,6 +499,31 @@ export const api = {
   },
   listProjectWorktrees(repoPath: string): Promise<ProjectWorktree[]> {
     return invoke<ProjectWorktree[]>("list_project_worktrees", { repoPath });
+  },
+  ensureProjectWorktreeForBranch(
+    repoPath: string,
+    branch: string,
+    nameHint: string,
+    createIfMissing = false,
+    fetchRef?: string | null,
+  ): Promise<EnsuredProjectWorktree> {
+    const args: {
+      repoPath: string;
+      branch: string;
+      nameHint: string;
+      createIfMissing: boolean;
+      fetchRef?: string;
+    } = {
+      repoPath,
+      branch,
+      nameHint,
+      createIfMissing,
+    };
+    if (fetchRef) args.fetchRef = fetchRef;
+    return invoke<EnsuredProjectWorktree>(
+      "ensure_project_worktree_for_branch",
+      args,
+    );
   },
   listProjectBranches(repoPath: string): Promise<ProjectBranch[]> {
     return invoke<ProjectBranch[]>("list_project_branches", { repoPath });

--- a/src/lib/githubStartWork.test.ts
+++ b/src/lib/githubStartWork.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readSessionPullRequestBranchLinks } from "./sessionPullRequestLinks";
+import type { Session } from "./types";
 import {
   createGithubWorkSession,
+  findSessionsForGithubWork,
   githubWorkSessionName,
   githubWorkSlug,
   planGithubStartWork,
@@ -50,6 +52,43 @@ describe("githubWorkSessionName", () => {
 
   it("falls back to the number when the title is empty", () => {
     expect(githubWorkSessionName(12, "   ")).toBe("#12");
+  });
+});
+
+function session(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    name: id,
+    repo_path: "/repo",
+    worktree_path: `/repo/.acorn/worktrees/${id}`,
+    branch: "main",
+    isolated: true,
+    status: "ready",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: true,
+    ...overrides,
+  };
+}
+
+describe("findSessionsForGithubWork", () => {
+  it("matches issue sessions on the planned branch name", () => {
+    const sessions = [
+      session("other", { branch: "issue-12-other" }),
+      session("hit", { branch: "issue-12-login-form" }),
+    ];
+    expect(
+      findSessionsForGithubWork(sessions, "/repo", {
+        kind: "issue",
+        number: 12,
+        title: "Login form",
+      }).map((item) => item.id),
+    ).toEqual(["hit"]);
   });
 });
 

--- a/src/lib/githubStartWork.test.ts
+++ b/src/lib/githubStartWork.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readSessionPullRequestBranchLinks } from "./sessionPullRequestLinks";
+import {
+  createGithubWorkSession,
+  githubWorkSessionName,
+  githubWorkSlug,
+  planGithubStartWork,
+  runGithubStartWork,
+} from "./githubStartWork";
+
+vi.mock("./api", () => ({
+  api: {
+    ensureProjectWorktreeForBranch: vi.fn(),
+  },
+}));
+
+import { api } from "./api";
+
+const ensureProjectWorktreeForBranch = vi.mocked(
+  api.ensureProjectWorktreeForBranch,
+);
+
+describe("githubWorkSlug", () => {
+  it("lowercases and hyphenates ascii titles", () => {
+    expect(githubWorkSlug("Open the matching session")).toBe(
+      "open-the-matching-session",
+    );
+  });
+
+  it("strips combining marks and drops empty results", () => {
+    expect(githubWorkSlug("Café login")).toBe("cafe-login");
+    expect(githubWorkSlug("로그인 폼")).toBe("");
+  });
+
+  it("caps length without leaving a trailing hyphen", () => {
+    const slug = githubWorkSlug(
+      "this is a very long pull request title that should be truncated",
+    );
+    expect(slug.length).toBeLessThanOrEqual(40);
+    expect(slug.endsWith("-")).toBe(false);
+  });
+});
+
+describe("githubWorkSessionName", () => {
+  it("prefixes the number and collapses whitespace", () => {
+    expect(githubWorkSessionName(91, "  Open   the session ")).toBe(
+      "#91 Open the session",
+    );
+  });
+
+  it("falls back to the number when the title is empty", () => {
+    expect(githubWorkSessionName(12, "   ")).toBe("#12");
+  });
+});
+
+describe("planGithubStartWork", () => {
+  it("plans a PR checkout of the existing head branch", () => {
+    expect(
+      planGithubStartWork({
+        kind: "pr",
+        number: 91,
+        title: "Open the matching session",
+        headBranch: "feature/pr-session",
+      }),
+    ).toEqual({
+      branch: "feature/pr-session",
+      nameHint: "pr-91-open-the-matching-session",
+      sessionName: "#91 Open the matching session",
+      createIfMissing: false,
+      fetchRef: "refs/pull/91/head",
+    });
+  });
+
+  it("returns null when a PR has no head branch", () => {
+    expect(
+      planGithubStartWork({
+        kind: "pr",
+        number: 8,
+        title: "No branch",
+        headBranch: "  ",
+      }),
+    ).toBeNull();
+  });
+
+  it("plans a new issue branch from the title slug", () => {
+    expect(
+      planGithubStartWork({
+        kind: "issue",
+        number: 12,
+        title: "Login form",
+      }),
+    ).toEqual({
+      branch: "issue-12-login-form",
+      nameHint: "issue-12-login-form",
+      sessionName: "#12 Login form",
+      createIfMissing: true,
+      fetchRef: null,
+    });
+  });
+
+  it("omits the slug from issue branches when none remains", () => {
+    expect(
+      planGithubStartWork({
+        kind: "issue",
+        number: 12,
+        title: "로그인",
+      }),
+    ).toEqual({
+      branch: "issue-12",
+      nameHint: "issue-12",
+      sessionName: "#12 로그인",
+      createIfMissing: true,
+      fetchRef: null,
+    });
+  });
+});
+
+describe("createGithubWorkSession", () => {
+  beforeEach(() => {
+    ensureProjectWorktreeForBranch.mockReset();
+  });
+
+  it("creates an isolated session when the worktree is new", async () => {
+    ensureProjectWorktreeForBranch.mockResolvedValue({
+      path: "/repo/.acorn/worktrees/pr-91-open",
+      branch: "feature/pr-session",
+      created: true,
+    });
+    const createSession = vi.fn().mockResolvedValue({ id: "s-new" });
+
+    await createGithubWorkSession(
+      createSession,
+      "/repo",
+      planGithubStartWork({
+        kind: "pr",
+        number: 91,
+        title: "Open",
+        headBranch: "feature/pr-session",
+      })!,
+    );
+
+    expect(ensureProjectWorktreeForBranch).toHaveBeenCalledWith(
+      "/repo",
+      "feature/pr-session",
+      "pr-91-open",
+      false,
+      "refs/pull/91/head",
+    );
+    expect(createSession).toHaveBeenCalledWith(
+      "#91 Open",
+      "/repo",
+      true,
+      "regular",
+      null,
+      true,
+      "terminal",
+      undefined,
+      "/repo/.acorn/worktrees/pr-91-open",
+    );
+  });
+
+  it("creates a non-isolated session when an existing checkout is reused", async () => {
+    ensureProjectWorktreeForBranch.mockResolvedValue({
+      path: "/repo",
+      branch: "main",
+      created: false,
+    });
+    const createSession = vi.fn().mockResolvedValue({ id: "s-root" });
+
+    await createGithubWorkSession(createSession, "/repo", {
+      branch: "main",
+      nameHint: "pr-1-main",
+      sessionName: "#1 Main",
+      createIfMissing: false,
+      fetchRef: "refs/pull/1/head",
+    });
+
+    expect(createSession).toHaveBeenCalledWith(
+      "#1 Main",
+      "/repo",
+      false,
+      "regular",
+      null,
+      true,
+      "terminal",
+      undefined,
+      "/repo",
+    );
+  });
+});
+
+describe("runGithubStartWork", () => {
+  beforeEach(() => {
+    ensureProjectWorktreeForBranch.mockReset();
+    window.localStorage.clear();
+  });
+
+  it("links a created PR session to its head branch", async () => {
+    ensureProjectWorktreeForBranch.mockResolvedValue({
+      path: "/repo/.acorn/worktrees/pr-91-open",
+      branch: "feature/pr-session",
+      created: true,
+    });
+    const createSession = vi.fn().mockResolvedValue({ id: "s-new" });
+
+    const result = await runGithubStartWork({
+      repoPath: "/repo",
+      target: {
+        kind: "pr",
+        number: 91,
+        title: "Open",
+        headBranch: "feature/pr-session",
+      },
+      createSession,
+      consumeError: () => null,
+    });
+
+    expect(result).toEqual({ ok: true, session: { id: "s-new" } });
+    expect(readSessionPullRequestBranchLinks()).toEqual({
+      "s-new": { repoPath: "/repo", headBranch: "feature/pr-session" },
+    });
+  });
+
+  it("returns a planned failure when a PR has no head branch", async () => {
+    const result = await runGithubStartWork({
+      repoPath: "/repo",
+      target: { kind: "pr", number: 8, title: "No branch", headBranch: "  " },
+      createSession: vi.fn(),
+      consumeError: () => null,
+    });
+
+    expect(result).toEqual({ ok: false, error: null });
+    expect(ensureProjectWorktreeForBranch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces store errors without writing a PR link", async () => {
+    ensureProjectWorktreeForBranch.mockResolvedValue({
+      path: "/repo/.acorn/worktrees/issue-12",
+      branch: "issue-12-login-form",
+      created: true,
+    });
+    const result = await runGithubStartWork({
+      repoPath: "/repo",
+      target: { kind: "issue", number: 12, title: "Login form" },
+      createSession: vi.fn().mockResolvedValue({ id: "s-issue" }),
+      consumeError: () => "disk full",
+    });
+
+    expect(result).toEqual({ ok: false, error: "disk full" });
+    expect(readSessionPullRequestBranchLinks()).toEqual({});
+  });
+});

--- a/src/lib/githubStartWork.ts
+++ b/src/lib/githubStartWork.ts
@@ -1,4 +1,5 @@
 import { api } from "./api";
+import { findSessionsForPullRequest } from "./sessionContext";
 import {
   readSessionPullRequestBranchLinks,
   writeSessionPullRequestBranchLinks,
@@ -56,6 +57,24 @@ export function githubWorkSlug(title: string): string {
 export function githubWorkSessionName(number: number, title: string): string {
   const trimmed = title.trim().replace(/\s+/g, " ");
   return trimmed ? `#${number} ${trimmed}` : `#${number}`;
+}
+
+export function findSessionsForGithubWork(
+  sessions: readonly Session[],
+  repoPath: string,
+  target: GithubStartWorkTarget,
+): Session[] {
+  if (target.kind === "pr") {
+    return findSessionsForPullRequest(
+      sessions,
+      repoPath,
+      target.headBranch ?? "",
+      readSessionPullRequestBranchLinks(),
+    );
+  }
+  const plan = planGithubStartWork(target);
+  if (!plan) return [];
+  return findSessionsForPullRequest(sessions, repoPath, plan.branch);
 }
 
 export function planGithubStartWork(

--- a/src/lib/githubStartWork.ts
+++ b/src/lib/githubStartWork.ts
@@ -1,0 +1,152 @@
+import { api } from "./api";
+import {
+  readSessionPullRequestBranchLinks,
+  writeSessionPullRequestBranchLinks,
+} from "./sessionPullRequestLinks";
+import type {
+  Session,
+  SessionAgentProvider,
+  SessionKind,
+  SessionMode,
+} from "./types";
+
+const SLUG_MAX = 40;
+
+export type GithubStartWorkKind = "pr" | "issue";
+
+export interface GithubStartWorkTarget {
+  kind: GithubStartWorkKind;
+  number: number;
+  title: string;
+  headBranch?: string;
+}
+
+export interface GithubStartWorkPlan {
+  branch: string;
+  nameHint: string;
+  sessionName: string;
+  createIfMissing: boolean;
+  fetchRef: string | null;
+}
+
+export type GithubWorkSessionFactory = (
+  name: string,
+  repoPath: string,
+  isolated?: boolean,
+  kind?: SessionKind,
+  agentProvider?: SessionAgentProvider | null,
+  projectScoped?: boolean,
+  mode?: SessionMode,
+  projectFolderId?: string,
+  cwdPath?: string,
+) => Promise<Session | null>;
+
+export function githubWorkSlug(title: string): string {
+  const slug = title
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!slug) return "";
+  if (slug.length <= SLUG_MAX) return slug;
+  return slug.slice(0, SLUG_MAX).replace(/-+$/g, "");
+}
+
+export function githubWorkSessionName(number: number, title: string): string {
+  const trimmed = title.trim().replace(/\s+/g, " ");
+  return trimmed ? `#${number} ${trimmed}` : `#${number}`;
+}
+
+export function planGithubStartWork(
+  target: GithubStartWorkTarget,
+): GithubStartWorkPlan | null {
+  const sessionName = githubWorkSessionName(target.number, target.title);
+  const slug = githubWorkSlug(target.title);
+  if (target.kind === "pr") {
+    const branch = target.headBranch?.trim() ?? "";
+    if (!branch) return null;
+    return {
+      branch,
+      nameHint: slug ? `pr-${target.number}-${slug}` : `pr-${target.number}`,
+      sessionName,
+      createIfMissing: false,
+      fetchRef: `refs/pull/${target.number}/head`,
+    };
+  }
+  const branch = slug
+    ? `issue-${target.number}-${slug}`
+    : `issue-${target.number}`;
+  return {
+    branch,
+    nameHint: branch,
+    sessionName,
+    createIfMissing: true,
+    fetchRef: null,
+  };
+}
+
+export async function createGithubWorkSession(
+  createSession: GithubWorkSessionFactory,
+  repoPath: string,
+  plan: GithubStartWorkPlan,
+): Promise<Session | null> {
+  const ensured = await api.ensureProjectWorktreeForBranch(
+    repoPath,
+    plan.branch,
+    plan.nameHint,
+    plan.createIfMissing,
+    plan.fetchRef,
+  );
+  return createSession(
+    plan.sessionName,
+    repoPath,
+    ensured.created,
+    "regular",
+    null,
+    true,
+    "terminal",
+    undefined,
+    ensured.path,
+  );
+}
+
+export type GithubStartWorkOutcome =
+  | { ok: true; session: Session }
+  | { ok: false; error: string | null };
+
+export async function runGithubStartWork(options: {
+  repoPath: string;
+  target: GithubStartWorkTarget;
+  createSession: GithubWorkSessionFactory;
+  consumeError: () => string | null;
+}): Promise<GithubStartWorkOutcome> {
+  const plan = planGithubStartWork(options.target);
+  if (!plan) return { ok: false, error: null };
+  try {
+    const created = await createGithubWorkSession(
+      options.createSession,
+      options.repoPath,
+      plan,
+    );
+    const storeError = options.consumeError();
+    if (!created || storeError) {
+      return { ok: false, error: storeError };
+    }
+    if (options.target.kind === "pr") {
+      const headBranch = options.target.headBranch?.trim() ?? "";
+      if (headBranch) {
+        writeSessionPullRequestBranchLinks({
+          ...readSessionPullRequestBranchLinks(),
+          [created.id]: {
+            repoPath: options.repoPath,
+            headBranch,
+          },
+        });
+      }
+    }
+    return { ok: true, session: created };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -571,6 +571,12 @@ export interface ProjectWorktree {
   modified_ms: number | null;
 }
 
+export interface EnsuredProjectWorktree {
+  path: string;
+  branch: string;
+  created: boolean;
+}
+
 export interface ProjectBranch {
   name: string;
   is_remote: boolean;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1860,7 +1860,8 @@
       "deletedFile": "File was deleted; nothing to open.",
       "notGitHubRemote": "This repo's origin is not a GitHub remote.",
       "originNotGitHub": "Origin remote is not a GitHub repository.",
-      "noAccessToSlug": "No access to {slug}."
+      "noAccessToSlug": "No access to {slug}.",
+      "startWorkFailed": "Could not start work on this item."
     },
     "menu": {
       "expandDiff": "Expand diff",
@@ -1873,6 +1874,7 @@
       "openInBrowser": "Open in browser",
       "openSession": "Open session",
       "openSessionWithName": "Open session ({name})",
+      "startWork": "Start work",
       "copyPrNumber": "Copy PR number",
       "copyIssueNumber": "Copy issue number",
       "copyUrl": "Copy URL",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1860,7 +1860,8 @@
       "deletedFile": "ファイルが削除されました。何も開けない。",
       "notGitHubRemote": "このリポジトリのオリジンは GitHub リモートではありません。",
       "originNotGitHub": "オリジンリモートは GitHub リポジトリではありません。",
-      "noAccessToSlug": "{slug} にアクセスできません。"
+      "noAccessToSlug": "{slug} にアクセスできません。",
+      "startWorkFailed": "この項目の作業を開始できませんでした。"
     },
     "menu": {
       "expandDiff": "差分を展開する",
@@ -1873,6 +1874,7 @@
       "openInBrowser": "ブラウザで開く",
       "openSession": "オープンセッション",
       "openSessionWithName": "セッションを開く ({name})",
+      "startWork": "作業を開始",
       "copyPrNumber": "PR番号をコピーする",
       "copyIssueNumber": "発行番号をコピーする",
       "copyUrl": "URLをコピー",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1860,7 +1860,8 @@
       "deletedFile": "파일이 삭제되어 열 수 없습니다.",
       "notGitHubRemote": "이 저장소의 origin은 GitHub 원격이 아닙니다.",
       "originNotGitHub": "origin 원격은 GitHub 저장소가 아닙니다.",
-      "noAccessToSlug": "{slug}에 접근할 수 없습니다."
+      "noAccessToSlug": "{slug}에 접근할 수 없습니다.",
+      "startWorkFailed": "이 항목에서 작업을 시작하지 못했습니다."
     },
     "menu": {
       "expandDiff": "diff 확장",
@@ -1873,6 +1874,7 @@
       "openInBrowser": "브라우저에서 열기",
       "openSession": "세션 열기",
       "openSessionWithName": "세션 열기({name})",
+      "startWork": "작업 시작",
       "copyPrNumber": "PR 번호 복사",
       "copyIssueNumber": "이슈 번호 복사",
       "copyUrl": "URL 복사",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1860,7 +1860,8 @@
       "deletedFile": "文件已删除；没有什么可打开的。",
       "notGitHubRemote": "此仓库的源远程仓库不在 GitHub 上。",
       "originNotGitHub": "源远程仓库不是 GitHub 仓库。",
-      "noAccessToSlug": "无法访问 {slug}。"
+      "noAccessToSlug": "无法访问 {slug}。",
+      "startWorkFailed": "无法开始处理此项目。"
     },
     "menu": {
       "expandDiff": "展开差异",
@@ -1873,6 +1874,7 @@
       "openInBrowser": "在浏览器中打开",
       "openSession": "打开会话",
       "openSessionWithName": "打开会话 ({name})",
+      "startWork": "开始工作",
       "copyPrNumber": "复制 PR 编号",
       "copyIssueNumber": "复制议题编号",
       "copyUrl": "复制 URL",

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -571,6 +571,15 @@ export const tauriMockSource = `
     if (cmd === 'pty_in_worktree_all') return Promise.resolve({});
     if (cmd === 'is_path_linked_worktree') return Promise.resolve(false);
     if (cmd === 'list_project_worktrees') return Promise.resolve([]);
+    if (cmd === 'ensure_project_worktree_for_branch') {
+      const repoPath = args?.repoPath || '/tmp/demo';
+      const nameHint = args?.nameHint || 'worktree';
+      return Promise.resolve({
+        path: repoPath + '/.acorn/worktrees/' + nameHint,
+        branch: args?.branch || 'main',
+        created: true,
+      });
+    }
     if (cmd === 'list_project_branches') return Promise.resolve([]);
     if (cmd === 'remove_session' || cmd === 'remove_worktree') {
       return Promise.resolve({

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1161,6 +1161,623 @@ test.describe("right panel: tab switching", () => {
     await expect(
       page.locator('[data-tab-drag-handle="pr-session"]').locator(".."),
     ).toHaveClass(/acorn-tab-active-bg/);
+    await prRow.click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Start work" }),
+    ).toHaveCount(0);
+  });
+
+  test("right-clicking a pull request can start work in a new worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 91,
+          title: "Start work from the PR row",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/start-work",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/91",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", (args) => {
+      const w = window as unknown as { __ensureWorktreeArgs?: unknown[] };
+      w.__ensureWorktreeArgs = w.__ensureWorktreeArgs ?? [];
+      w.__ensureWorktreeArgs.push(args);
+      return {
+        path: "/tmp/demo/.acorn/worktrees/pr-91-start-work-from-the-pr-row",
+        branch: "feature/start-work",
+        created: true,
+      };
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      const session = {
+        id: "started-pr",
+        name: (args as { name?: string }).name ?? "#91",
+        repo_path: "/tmp/demo",
+        worktree_path:
+          (args as { cwdPath?: string }).cwdPath ??
+          "/tmp/demo/.acorn/worktrees/pr-91-start-work-from-the-pr-row",
+        branch: "feature/start-work",
+        isolated: Boolean((args as { isolated?: boolean }).isolated),
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+
+    const prRow = page
+      .getByText("Start work from the PR row")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await prRow.click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Open session" }),
+    ).toHaveCount(0);
+    await page.getByRole("menuitem", { name: "Start work" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __createSessionCalls?: unknown[] })
+                .__createSessionCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const ensureArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __ensureWorktreeArgs?: unknown[] })
+          .__ensureWorktreeArgs?.[0],
+    )) as {
+      repoPath: string;
+      branch: string;
+      nameHint: string;
+      createIfMissing: boolean;
+      fetchRef: string;
+    };
+    expect(ensureArgs).toEqual({
+      repoPath: "/tmp/demo",
+      branch: "feature/start-work",
+      nameHint: "pr-91-start-work-from-the-pr-row",
+      createIfMissing: false,
+      fetchRef: "refs/pull/91/head",
+    });
+
+    const createArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls?.[0],
+    )) as {
+      name: string;
+      repoPath: string;
+      isolated: boolean;
+      cwdPath: string;
+    };
+    expect(createArgs.name).toBe("#91 Start work from the PR row");
+    expect(createArgs.repoPath).toBe("/tmp/demo");
+    expect(createArgs.isolated).toBe(true);
+    expect(createArgs.cwdPath).toBe(
+      "/tmp/demo/.acorn/worktrees/pr-91-start-work-from-the-pr-row",
+    );
+
+    await expect(
+      page.locator('[data-tab-drag-handle="started-pr"]').locator(".."),
+    ).toHaveClass(/acorn-tab-active-bg/);
+  });
+
+  test("right-clicking an issue can start work in a new worktree", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.respond("list_issues", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 12,
+          title: "Login form",
+          state: "OPEN",
+          author: "im-ian",
+          url: "https://github.com/im-ian/acorn/issues/12",
+          created_at: "2026-05-18T00:00:00Z",
+          updated_at: "2026-05-19T00:00:00Z",
+          state_reason: null,
+          comments: 0,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", (args) => {
+      const w = window as unknown as { __ensureWorktreeArgs?: unknown[] };
+      w.__ensureWorktreeArgs = w.__ensureWorktreeArgs ?? [];
+      w.__ensureWorktreeArgs.push(args);
+      return {
+        path: "/tmp/demo/.acorn/worktrees/issue-12-login-form",
+        branch: "issue-12-login-form",
+        created: true,
+      };
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      const session = {
+        id: "started-issue",
+        name: (args as { name?: string }).name ?? "#12",
+        repo_path: "/tmp/demo",
+        worktree_path:
+          (args as { cwdPath?: string }).cwdPath ??
+          "/tmp/demo/.acorn/worktrees/issue-12-login-form",
+        branch: "issue-12-login-form",
+        isolated: Boolean((args as { isolated?: boolean }).isolated),
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "Issues" }).click();
+
+    const issueRow = page
+      .getByText("Login form")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await issueRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Start work" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __createSessionCalls?: unknown[] })
+                .__createSessionCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const ensureArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __ensureWorktreeArgs?: unknown[] })
+          .__ensureWorktreeArgs?.[0],
+    )) as {
+      repoPath: string;
+      branch: string;
+      nameHint: string;
+      createIfMissing: boolean;
+      fetchRef?: string;
+    };
+    expect(ensureArgs).toEqual({
+      repoPath: "/tmp/demo",
+      branch: "issue-12-login-form",
+      nameHint: "issue-12-login-form",
+      createIfMissing: true,
+    });
+
+    const createArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __createSessionCalls?: unknown[] })
+          .__createSessionCalls?.[0],
+    )) as {
+      name: string;
+      isolated: boolean;
+      cwdPath: string;
+    };
+    expect(createArgs.name).toBe("#12 Login form");
+    expect(createArgs.isolated).toBe(true);
+    expect(createArgs.cwdPath).toBe(
+      "/tmp/demo/.acorn/worktrees/issue-12-login-form",
+    );
+  });
+
+  test("the pull request detail modal can start work", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 87,
+          title: "Start work from the PR modal",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/modal-start",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/87",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.respond("get_pull_request_detail", {
+      kind: "ok",
+      account: "test-account",
+      detail: {
+        number: 87,
+        title: "Start work from the PR modal",
+        body: "Loaded pull request body from gh.",
+        state: "OPEN",
+        is_draft: false,
+        author: "im-ian",
+        head_branch: "feature/modal-start",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/87",
+        created_at: "2026-05-18T00:00:00Z",
+        updated_at: "2026-05-19T00:00:00Z",
+        merged_at: null,
+        additions: 12,
+        deletions: 3,
+        changed_files: 2,
+        mergeable: "MERGEABLE",
+        labels: [],
+        comments: [],
+        reviews: [],
+        checks: [],
+        commits: [],
+      },
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", (args) => {
+      const w = window as unknown as { __ensureWorktreeArgs?: unknown[] };
+      w.__ensureWorktreeArgs = w.__ensureWorktreeArgs ?? [];
+      w.__ensureWorktreeArgs.push(args);
+      return {
+        path: "/tmp/demo/.acorn/worktrees/pr-87-start-work-from-the-pr-modal",
+        branch: "feature/modal-start",
+        created: true,
+      };
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      const session = {
+        id: "started-pr-modal",
+        name: (args as { name?: string }).name ?? "#87",
+        repo_path: "/tmp/demo",
+        worktree_path:
+          (args as { cwdPath?: string }).cwdPath ??
+          "/tmp/demo/.acorn/worktrees/pr-87-start-work-from-the-pr-modal",
+        branch: "feature/modal-start",
+        isolated: Boolean((args as { isolated?: boolean }).isolated),
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+    const prRow = page
+      .getByText("Start work from the PR modal")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await dblclickRowRightSide(page, prRow);
+
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", {
+        name: "Start work from the PR modal",
+      }),
+    });
+    await expect(dialog.getByText("Loaded pull request body from gh.")).toBeVisible();
+    await dialog.getByRole("button", { name: "Start work" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __createSessionCalls?: unknown[] })
+                .__createSessionCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const ensureArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __ensureWorktreeArgs?: unknown[] })
+          .__ensureWorktreeArgs?.[0],
+    )) as {
+      repoPath: string;
+      branch: string;
+      nameHint: string;
+      createIfMissing: boolean;
+      fetchRef: string;
+    };
+    expect(ensureArgs).toEqual({
+      repoPath: "/tmp/demo",
+      branch: "feature/modal-start",
+      nameHint: "pr-87-start-work-from-the-pr-modal",
+      createIfMissing: false,
+      fetchRef: "refs/pull/87/head",
+    });
+
+    await expect(dialog).toHaveCount(0);
+    await expect(
+      page.locator('[data-tab-drag-handle="started-pr-modal"]').locator(".."),
+    ).toHaveClass(/acorn-tab-active-bg/);
+  });
+
+  test("the issue detail modal can start work", async ({ page, tauri }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__sessions = w.__sessions ?? [
+        {
+          id: "s-1",
+          name: "sess",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo",
+          branch: "main",
+          isolated: false,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+        },
+      ];
+      return w.__sessions;
+    });
+    await tauri.respond("list_issues", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 12,
+          title: "Start work from the issue modal",
+          state: "OPEN",
+          author: "im-ian",
+          url: "https://github.com/im-ian/acorn/issues/12",
+          created_at: "2026-05-18T00:00:00Z",
+          updated_at: "2026-05-19T00:00:00Z",
+          state_reason: null,
+          comments: 0,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.respond("get_issue_detail", {
+      kind: "ok",
+      account: "test-account",
+      detail: {
+        number: 12,
+        title: "Start work from the issue modal",
+        body: "Loaded issue body from gh.",
+        state: "OPEN",
+        author: "im-ian",
+        url: "https://github.com/im-ian/acorn/issues/12",
+        created_at: "2026-05-18T00:00:00Z",
+        updated_at: "2026-05-19T00:00:00Z",
+        state_reason: null,
+        labels: [],
+        comments: [],
+        assignees: [],
+        milestone: null,
+      },
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", (args) => {
+      const w = window as unknown as { __ensureWorktreeArgs?: unknown[] };
+      w.__ensureWorktreeArgs = w.__ensureWorktreeArgs ?? [];
+      w.__ensureWorktreeArgs.push(args);
+      return {
+        path: "/tmp/demo/.acorn/worktrees/issue-12-start-work-from-the-issue-modal",
+        branch: "issue-12-start-work-from-the-issue-modal",
+        created: true,
+      };
+    });
+    await tauri.handle("create_session", (args) => {
+      const w = window as unknown as {
+        __createSessionCalls?: unknown[];
+        __sessions?: Array<Record<string, unknown>>;
+      };
+      w.__createSessionCalls = w.__createSessionCalls ?? [];
+      w.__createSessionCalls.push(args);
+      const session = {
+        id: "started-issue-modal",
+        name: (args as { name?: string }).name ?? "#12",
+        repo_path: "/tmp/demo",
+        worktree_path:
+          (args as { cwdPath?: string }).cwdPath ??
+          "/tmp/demo/.acorn/worktrees/issue-12-start-work-from-the-issue-modal",
+        branch: "issue-12-start-work-from-the-issue-modal",
+        isolated: Boolean((args as { isolated?: boolean }).isolated),
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+      };
+      w.__sessions = [...(w.__sessions ?? []), session];
+      return session;
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "Issues" }).click();
+    const issueRow = page
+      .getByText("Start work from the issue modal")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await dblclickRowRightSide(page, issueRow);
+
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", {
+        name: "Start work from the issue modal",
+      }),
+    });
+    await expect(dialog.getByText("Loaded issue body from gh.")).toBeVisible();
+    await dialog.getByRole("button", { name: "Start work" }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __createSessionCalls?: unknown[] })
+                .__createSessionCalls?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
+    const ensureArgs = (await page.evaluate(
+      () =>
+        (window as unknown as { __ensureWorktreeArgs?: unknown[] })
+          .__ensureWorktreeArgs?.[0],
+    )) as {
+      repoPath: string;
+      branch: string;
+      nameHint: string;
+      createIfMissing: boolean;
+    };
+    expect(ensureArgs).toEqual({
+      repoPath: "/tmp/demo",
+      branch: "issue-12-start-work-from-the-issue-modal",
+      nameHint: "issue-12-start-work-from-the-issue-modal",
+      createIfMissing: true,
+    });
+
+    await expect(dialog).toHaveCount(0);
+    await expect(
+      page
+        .locator('[data-tab-drag-handle="started-issue-modal"]')
+        .locator(".."),
+    ).toHaveClass(/acorn-tab-active-bg/);
   });
 
   test("copies a pull request number through the native clipboard", async ({

--- a/tests/e2e/right-panel.spec.ts
+++ b/tests/e2e/right-panel.spec.ts
@@ -1319,6 +1319,47 @@ test.describe("right panel: tab switching", () => {
     ).toHaveClass(/acorn-tab-active-bg/);
   });
 
+  test("a failed Start work keeps the pull request list visible", async ({
+    page,
+    tauri,
+  }) => {
+    await seedActiveSession(tauri);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 44,
+          title: "Keep this PR row",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/keep-list",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/44",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", () => {
+      throw new Error("fetch failed");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+    const prRow = page
+      .getByText("Keep this PR row")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await prRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Start work" }).click();
+
+    await expect(page.getByText("Keep this PR row")).toBeVisible();
+    await expect(page.getByText(/Failed to create session/)).toBeVisible();
+  });
+
   test("right-clicking an issue can start work in a new worktree", async ({
     page,
     tauri,
@@ -1624,6 +1665,129 @@ test.describe("right panel: tab switching", () => {
     await expect(
       page.locator('[data-tab-drag-handle="started-pr-modal"]').locator(".."),
     ).toHaveClass(/acorn-tab-active-bg/);
+  });
+
+  test("the pull request detail modal opens an existing session instead of creating one", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.handle("list_projects", () => [
+      {
+        repo_path: "/tmp/demo",
+        name: "demo",
+        created_at: "2026-01-01T00:00:00Z",
+        position: 0,
+      },
+    ]);
+    await tauri.handle("list_sessions", () => [
+      {
+        id: "main-session",
+        name: "Main work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo",
+        branch: "main",
+        isolated: false,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        position: 0,
+      },
+      {
+        id: "pr-session",
+        name: "PR work",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/pr-work",
+        branch: "feature/pr-session",
+        isolated: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:01Z",
+        updated_at: "2026-01-01T00:00:06Z",
+        last_message: null,
+        position: 1,
+      },
+    ]);
+    await tauri.respond("list_pull_requests", {
+      kind: "ok",
+      account: "test-account",
+      items: [
+        {
+          number: 91,
+          title: "Open the matching session",
+          state: "OPEN",
+          author: "im-ian",
+          head_branch: "feature/pr-session",
+          base_branch: "main",
+          url: "https://github.com/im-ian/acorn/pull/91",
+          updated_at: "2026-05-19T00:00:00Z",
+          is_draft: false,
+          checks: null,
+          labels: [],
+        },
+      ],
+    });
+    await tauri.respond("get_pull_request_detail", {
+      kind: "ok",
+      account: "test-account",
+      detail: {
+        number: 91,
+        title: "Open the matching session",
+        body: "Loaded pull request body from gh.",
+        state: "OPEN",
+        is_draft: false,
+        author: "im-ian",
+        head_branch: "feature/pr-session",
+        base_branch: "main",
+        url: "https://github.com/im-ian/acorn/pull/91",
+        created_at: "2026-05-18T00:00:00Z",
+        updated_at: "2026-05-19T00:00:00Z",
+        merged_at: null,
+        additions: 12,
+        deletions: 3,
+        changed_files: 2,
+        mergeable: "MERGEABLE",
+        labels: [],
+        comments: [],
+        reviews: [],
+        checks: [],
+        commits: [],
+      },
+    });
+    await tauri.handle("ensure_project_worktree_for_branch", (args) => {
+      const w = window as unknown as { __ensureWorktreeArgs?: unknown[] };
+      w.__ensureWorktreeArgs = w.__ensureWorktreeArgs ?? [];
+      w.__ensureWorktreeArgs.push(args);
+      throw new Error("should not create a worktree");
+    });
+
+    await page.goto("/");
+    await page.getByRole("button", { name: "GitHub" }).click();
+    await page.getByRole("button", { name: "PRs" }).click();
+    const prRow = page
+      .getByText("Open the matching session")
+      .locator("xpath=ancestor::li[@role='button'][1]");
+    await dblclickRowRightSide(page, prRow);
+
+    const dialog = page.locator('[role="dialog"]').filter({
+      has: page.getByRole("heading", { name: "Open the matching session" }),
+    });
+    await expect(dialog.getByText("Loaded pull request body from gh.")).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Start work" })).toHaveCount(
+      0,
+    );
+    await dialog.getByRole("button", { name: "Open session" }).click();
+
+    await expect(dialog).toHaveCount(0);
+    await expect(
+      page.locator('[data-tab-drag-handle="pr-session"]').locator(".."),
+    ).toHaveClass(/acorn-tab-active-bg/);
+    expect(
+      await page.evaluate(
+        () =>
+          (window as unknown as { __ensureWorktreeArgs?: unknown[] })
+            .__ensureWorktreeArgs?.length ?? 0,
+      ),
+    ).toBe(0);
   });
 
   test("the issue detail modal can start work", async ({ page, tauri }) => {


### PR DESCRIPTION
## Summary

GitHub PRs and issues in the right panel can now jump straight into a ready-to-work session.

1. **Start work from the list** — right-click a PR or issue. If a session already matches the PR head branch, open it. Otherwise create a linked worktree and a terminal session.
2. **Start work from the detail modal** — the same action as a header button. After it succeeds, the modal closes so the new terminal is in front.
3. **PR branches stay on the PR** — new worktrees check out the existing head branch (fetching `refs/pull/<n>/head` when needed) instead of minting a city-slug branch from main. Issues still create `issue-<n>-<slug>` from the project base.

## Expected impact

| Scenario | Before | After |
| --- | --- | --- |
| Right-click an open PR with no session | Open session is disabled | **Start work** creates a worktree on the PR branch and a terminal |
| Right-click a PR that already has a session | Open session | Unchanged |
| Right-click an issue | Copy / open only | **Start work** creates `issue-<n>-<slug>` + terminal |
| PR/issue detail modal | Refresh / GitHub / merge only | **Start work** (or **Open session** if one already matches) |

## Test plan

- [x] `pnpm exec vitest run src/lib/githubStartWork.test.ts src/components/PullRequestDetailModal.modal.test.tsx`
- [x] `cd src-tauri && cargo test --lib worktree:: -- --test-threads=1`
- [x] `cd src-tauri && cargo test --lib isolated_session_adopts -- --test-threads=1`
- [x] `CI=1 PLAYWRIGHT_PORT=1421 pnpm exec playwright test tests/e2e/right-panel.spec.ts -g "start work|detail modal can start work|opens the session for its head branch"`