### PR TITLE
chore(release): v1.35.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,19 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Audit dependencies
-        run: pnpm audit --audit-level=low
+        # npm's audit endpoint flakes with socket timeouts on GitHub runners.
+        # Retry so a registry blip cannot skip typecheck, tests, and the
+        # production bundle. Real audit findings still fail the job.
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3 4 5; do
+            if pnpm audit --audit-level=low; then
+              exit 0
+            fi
+            echo "pnpm audit failed on attempt ${attempt}; retrying" >&2
+            sleep $((attempt * 15))
+          done
+          exit 1
 
       - name: Type check
         run: pnpm run typecheck

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.34.0"
+version = "1.35.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
## Summary

Cuts Acorn v1.35.0 from `main`, publishing the 4 commits merged since v1.34.0 — one user-facing feature (GitHub Start work) and three session/history fixes.

1. **Version synchronization** — bumps `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `src-tauri/Cargo.lock` from 1.34.0 to 1.35.0.
2. **Release scope** — 1 feature (#879 start work on a PR or issue from the right panel) and 3 fixes (#876 Grok recency pairing, #877 keep Grok working while monitors/subagents run, #878 toast missing-worktree resume).
3. **Publication path** — builds both macOS architectures and the Windows x64 NSIS updater pair, then publishes a three-platform `latest.json`.
4. **CI** — retries `pnpm audit` on npm registry socket timeouts so a GitHub-runner blip cannot skip typecheck/tests/build. Real audit findings still fail the job.

## Expected impact

| Area | Expected impact |
| --- | --- |
| GitHub panel | Right-click a PR or issue, or use the detail modal button, to open a linked worktree and terminal. PRs check out the existing head branch (fetching `refs/pull/<n>/head` when needed); issues mint `issue-<n>-<slug>` from the project base. |
| Sessions | Two Grok tabs in the same repo no longer inherit each other's transcript via recency pairing. Grok stays Working while monitors or child agents are still running, instead of firing "need input" at `turn_completed`. |
| History | Resume after a deleted worktree is a toast, not a persistent History-panel error. The row stays live until the toast dismisses, then shows the worktree as missing. |
| Updater | Publishes a minor update for both macOS architectures and Windows x64. |

## Design notes

- 1.35.0 is a minor release because it adds one user-visible feature on top of the session/history fixes, without changing compatibility contracts.
- Version metadata and a CI audit retry; every product change it publishes was reviewed and merged independently.
- Release notes are generated from changelog-labelled merged PRs. This version PR carries `skip-changelog` so it is excluded from them.

## Follow-up (not in this PR)

- Push annotated tag `v1.35.0` after merge.
- Verify macOS and Windows artifacts, updater signatures, `latest.json`, the Latest pointer, and release-note identity.

## Test plan

- [x] `pnpm run typecheck` — passes.
- [x] `node scripts/validate-release-version.mjs v1.35.0` — all four version sources match.
- [x] `node scripts/validate-release-version.mjs --assert-newer v1.35.0 v1.34.0` — minor ordering passes.
- [x] Locked Cargo metadata reports Acorn `1.35.0`.
- [x] Release-focused Vitest (`scripts/validate-release-version.test.mjs`, `release-notes.test.mjs`, `release-artifacts.test.mjs`) — 3 files, 19 tests pass.
- [x] `git diff --check` — passes.
- [ ] PR CI — wait for required checks (Frontend previously failed on npm audit socket timeout; retrying with a bounded audit retry).

## Changelog category

`skip-changelog`