### PR TITLE
fix(sessions): keep Grok working when monitors skip the manifest

### DIFF
--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -30,7 +30,9 @@
 //!   WaitingForInput as an interrupted turn.
 //! - last `sessionUpdate=turn_completed` -> WaitingForInput while the Grok
 //!   process remains live (the TUI has returned to its prompt), unless a live
-//!   monitor or a running child agent is still in flight.
+//!   monitor or a running child agent is still in flight. Monitors come from
+//!   `background_tasks_manifest.json` or unmatched `task_backgrounded` events
+//!   in `updates.jsonl` when Grok omitted the sibling manifest.
 //! - user/agent/thought chunks, tool call updates, `task_backgrounded`, and
 //!   `subagent_spawned` -> Working.
 //! - `task_completed` / `subagent_finished` with `will_wake=true` -> Working.
@@ -797,6 +799,73 @@ mod tests {
         assert_eq!(detection.status, SessionStatus::Working);
         assert_eq!(detection.reason, None);
         assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_stays_working_while_a_transcript_monitor_is_live_without_a_manifest() {
+        let path = write_grok_session_transcript(
+            concat!(
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            ),
+            None,
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_stays_working_when_a_transcript_monitor_ages_out_of_the_tail() {
+        let backgrounded = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#;
+        let padding = format!(
+            r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"hook_execution","pad":"{}"}}}}}}"#,
+            "x".repeat(300_000)
+        );
+        let completed = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#;
+        let path =
+            write_grok_session_transcript(&format!("{backgrounded}\n{padding}\n{completed}"), None);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_completed_transcript_monitor_still_waits_after_turn_completed() {
+        let path = write_grok_session_transcript(
+            concat!(
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","will_wake":false,"task_snapshot":{"task_id":"task-1"}}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+            ),
+            None,
+        );
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
     }
 
     #[test]

--- a/src-tauri/crates/acorn-session/src/status.rs
+++ b/src-tauri/crates/acorn-session/src/status.rs
@@ -32,7 +32,7 @@
 //!   process remains live (the TUI has returned to its prompt), unless a live
 //!   monitor or a running child agent is still in flight. Monitors come from
 //!   `background_tasks_manifest.json` or unmatched `task_backgrounded` events
-//!   in `updates.jsonl` when Grok omitted the sibling manifest.
+//!   in `updates.jsonl` whose log is still recent.
 //! - user/agent/thought chunks, tool call updates, `task_backgrounded`, and
 //!   `subagent_spawned` -> Working.
 //! - `task_completed` / `subagent_finished` with `will_wake=true` -> Working.
@@ -259,9 +259,9 @@ fn grok_followup_overrides_resting_status(
     tail: Option<&TailRead>,
 ) -> bool {
     kind == AgentKind::Grok
-        && (grok_has_live_background_tasks(path)
-            || grok_has_running_subagents(path)
-            || tail.is_some_and(|tail| grok_tail_has_pending_followup(&tail.text, tail.read_full)))
+        && (grok_has_running_subagents(path)
+            || tail.is_some_and(|tail| grok_tail_has_pending_followup(&tail.text, tail.read_full))
+            || grok_has_live_background_tasks(path))
 }
 
 #[cfg(test)]
@@ -803,6 +803,50 @@ mod tests {
 
     #[test]
     fn grok_stays_working_while_a_transcript_monitor_is_live_without_a_manifest() {
+        let path = write_grok_monitor_transcript(false, false);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_stays_working_when_a_transcript_monitor_ages_out_of_the_tail() {
+        let path = write_grok_monitor_transcript(false, true);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::Working);
+        assert_eq!(detection.reason, None);
+        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+    }
+
+    #[test]
+    fn grok_stale_transcript_monitor_log_still_waits_after_turn_completed() {
+        let path = write_grok_monitor_transcript(true, false);
+
+        let detection = detect_with_reason(
+            Some((path, AgentKind::Grok)),
+            SessionStatus::Working,
+            Some(ShellHint::Running),
+        );
+
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
+    }
+
+    #[test]
+    fn grok_missing_transcript_monitor_log_still_waits_after_turn_completed() {
         let path = write_grok_session_transcript(
             concat!(
                 r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
@@ -818,31 +862,8 @@ mod tests {
             Some(ShellHint::Running),
         );
 
-        assert_eq!(detection.status, SessionStatus::Working);
-        assert_eq!(detection.reason, None);
-        assert_eq!(detection.evidence, StatusEvidence::Transcript);
-    }
-
-    #[test]
-    fn grok_stays_working_when_a_transcript_monitor_ages_out_of_the_tail() {
-        let backgrounded = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#;
-        let padding = format!(
-            r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"hook_execution","pad":"{}"}}}}}}"#,
-            "x".repeat(300_000)
-        );
-        let completed = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#;
-        let path =
-            write_grok_session_transcript(&format!("{backgrounded}\n{padding}\n{completed}"), None);
-
-        let detection = detect_with_reason(
-            Some((path, AgentKind::Grok)),
-            SessionStatus::Working,
-            Some(ShellHint::Running),
-        );
-
-        assert_eq!(detection.status, SessionStatus::Working);
-        assert_eq!(detection.reason, None);
-        assert_eq!(detection.evidence, StatusEvidence::Transcript);
+        assert_eq!(detection.status, SessionStatus::WaitingForInput);
+        assert_eq!(detection.reason, Some(StatusReason::TurnComplete));
     }
 
     #[test]
@@ -1041,6 +1062,42 @@ mod tests {
         let path =
             std::env::temp_dir().join(format!("acorn-status-test-{}.jsonl", uuid::Uuid::new_v4()));
         std::fs::write(&path, body).expect("write status transcript");
+        path
+    }
+
+    fn write_grok_monitor_transcript(stale: bool, pad_past_tail: bool) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-status-grok-mon-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(dir.join("terminal")).expect("create grok session dir");
+        let log = dir.join("terminal").join("monitor-call-task-1.log");
+        std::fs::write(&log, "event\n").expect("write grok monitor log");
+        if stale {
+            let old = std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 60 * 60);
+            let file = std::fs::File::options()
+                .write(true)
+                .open(&log)
+                .expect("open grok monitor log");
+            file.set_times(std::fs::FileTimes::new().set_modified(old))
+                .expect("stale grok monitor mtime");
+        }
+        let log_json = serde_json::to_string(&log.to_string_lossy().as_ref()).expect("json path");
+        let backgrounded = format!(
+            r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699","output_file":{log_json}}}}}}}"#
+        );
+        let completed = r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#;
+        let body = if pad_past_tail {
+            let padding = format!(
+                r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"hook_execution","pad":"{}"}}}}}}"#,
+                "x".repeat(300_000)
+            );
+            format!("{backgrounded}\n{padding}\n{completed}")
+        } else {
+            format!("{backgrounded}\n{completed}")
+        };
+        let path = dir.join("updates.jsonl");
+        std::fs::write(&path, body).expect("write grok transcript");
         path
     }
 

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -58,7 +58,7 @@ pub use line::{
 // Maximum age (mtime → now) of a transcript that will be paired with
 // a live agent process. Generous so an idle agent waiting on user
 // input still surfaces as a Fork target.
-const RECENCY_WINDOW_SECS: u64 = 24 * 60 * 60;
+pub(crate) const RECENCY_WINDOW_SECS: u64 = 24 * 60 * 60;
 
 /// How long a transcript must sit un-appended (mtime → now) before we
 /// treat it as no longer being written. Used on both sides of the
@@ -2719,12 +2719,15 @@ const GROK_BACKGROUND_TASKS_MANIFEST: &str = "background_tasks_manifest.json";
 const GROK_BACKGROUND_TASKS_MANIFEST_MAX_BYTES: u64 = 64 * 1024;
 
 /// Live Grok *monitor* tasks are listed in a sibling
-/// `background_tasks_manifest.json` when Grok writes one. When that file is
-/// missing, unmatched `task_backgrounded` monitor events in `updates.jsonl`
-/// are the fallback — Grok still returns to its prompt (and writes
-/// `turn_completed`) while a monitor is in flight. Fire-and-forget shells
-/// stay listed in the manifest after the prompt returns, so only monitors
-/// keep the session from flipping to WaitingForInput.
+/// `background_tasks_manifest.json` when Grok writes one. Unmatched
+/// `task_backgrounded` monitor events in `updates.jsonl` are an additional
+/// source — Grok still returns to its prompt (and writes `turn_completed`)
+/// while a monitor is in flight, and often omits the sibling file. A monitor
+/// whose log is missing or older than [`RECENCY_WINDOW_SECS`] is treated as
+/// dead, because `updates.jsonl` is append-only and would otherwise pin
+/// Working forever. Fire-and-forget shells stay listed in the manifest after
+/// the prompt returns, so only monitors keep the session from flipping to
+/// WaitingForInput.
 pub fn grok_has_live_background_tasks(transcript: &Path) -> bool {
     grok_live_background_task_count(transcript) > 0
         || grok_transcript_has_pending_monitors(transcript)
@@ -2873,25 +2876,18 @@ mod grok_background_task_tests {
 
     #[test]
     fn transcript_monitor_without_manifest_is_still_live() {
-        let dir = std::env::temp_dir().join(format!(
-            "acorn-grok-bg-transcript-{}",
-            uuid::Uuid::new_v4().simple()
-        ));
-        std::fs::create_dir_all(&dir).expect("create grok session dir");
-        let transcript = dir.join("updates.jsonl");
-        std::fs::write(
-            &transcript,
-            concat!(
-                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
-                "\n",
-                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
-                "\n",
-            ),
-        )
-        .expect("write transcript");
+        let (transcript, _log) = write_grok_transcript_monitor(false);
 
         assert!(grok_has_live_background_tasks(&transcript));
         assert!(grok_transcript_has_pending_monitors(&transcript));
+    }
+
+    #[test]
+    fn stale_transcript_monitor_log_is_not_live() {
+        let (transcript, _log) = write_grok_transcript_monitor(true);
+
+        assert!(!grok_has_live_background_tasks(&transcript));
+        assert!(!grok_transcript_has_pending_monitors(&transcript));
     }
 
     #[test]
@@ -2957,6 +2953,40 @@ mod grok_background_task_tests {
         )
         .expect("write completed meta");
         assert!(!grok_has_running_subagents(&transcript));
+    }
+
+    fn write_grok_transcript_monitor(stale: bool) -> (PathBuf, PathBuf) {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-grok-bg-transcript-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(dir.join("terminal")).expect("create grok session dir");
+        let log = dir.join("terminal").join("monitor-call-task-1.log");
+        std::fs::write(&log, "event\n").expect("write grok monitor log");
+        if stale {
+            let old = std::time::SystemTime::now()
+                - std::time::Duration::from_secs(RECENCY_WINDOW_SECS + 3600);
+            let file = std::fs::File::options()
+                .write(true)
+                .open(&log)
+                .expect("open grok monitor log");
+            file.set_times(std::fs::FileTimes::new().set_modified(old))
+                .expect("stale grok monitor mtime");
+        }
+        let log_json = serde_json::to_string(&log.to_string_lossy().as_ref()).expect("json path");
+        let transcript = dir.join("updates.jsonl");
+        let backgrounded = format!(
+            r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699","output_file":{log_json}}}}}}}"#
+        );
+        std::fs::write(
+            &transcript,
+            format!(
+                "{backgrounded}\n{}\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#
+            ),
+        )
+        .expect("write transcript");
+        (transcript, log)
     }
 }
 

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -50,8 +50,9 @@ mod line;
 
 pub use line::{
     assistant_message_text, collapse_preview, grok_tail_has_pending_followup,
-    latest_turn_observation, latest_turn_state, parse_transcript_line, parse_transcript_value,
-    read_tail, ParsedTranscriptLine, TailRead, TranscriptRole, TurnObservation, TurnState,
+    grok_transcript_has_pending_monitors, latest_turn_observation, latest_turn_state,
+    parse_transcript_line, parse_transcript_value, read_tail, ParsedTranscriptLine, TailRead,
+    TranscriptRole, TurnObservation, TurnState,
 };
 
 // Maximum age (mtime → now) of a transcript that will be paired with
@@ -2717,12 +2718,16 @@ pub fn read_grok_session_summary(transcript: &Path) -> Option<GrokSessionSummary
 const GROK_BACKGROUND_TASKS_MANIFEST: &str = "background_tasks_manifest.json";
 const GROK_BACKGROUND_TASKS_MANIFEST_MAX_BYTES: u64 = 64 * 1024;
 
-/// Live Grok *monitor* tasks live in a sibling manifest next to
-/// `updates.jsonl`. Fire-and-forget shells (dev servers) stay listed after
-/// Grok has returned to its prompt, so only monitors — which resume the
-/// agent — keep the session from flipping to WaitingForInput.
+/// Live Grok *monitor* tasks are listed in a sibling
+/// `background_tasks_manifest.json` when Grok writes one. When that file is
+/// missing, unmatched `task_backgrounded` monitor events in `updates.jsonl`
+/// are the fallback — Grok still returns to its prompt (and writes
+/// `turn_completed`) while a monitor is in flight. Fire-and-forget shells
+/// stay listed in the manifest after the prompt returns, so only monitors
+/// keep the session from flipping to WaitingForInput.
 pub fn grok_has_live_background_tasks(transcript: &Path) -> bool {
     grok_live_background_task_count(transcript) > 0
+        || grok_transcript_has_pending_monitors(transcript)
 }
 
 const GROK_SUBAGENTS_DIR: &str = "subagents";
@@ -2830,24 +2835,10 @@ fn grok_background_task_count_from_json(bytes: &[u8]) -> usize {
         .map(|tasks| {
             tasks
                 .iter()
-                .filter(|task| grok_background_task_resumes_agent(task))
+                .filter(|task| line::grok_background_task_resumes_agent(task))
                 .count()
         })
         .unwrap_or(0)
-}
-
-fn grok_background_task_resumes_agent(task: &serde_json::Value) -> bool {
-    let kind = task
-        .get("kind")
-        .and_then(|value| value.as_str())
-        .unwrap_or("");
-    if kind.eq_ignore_ascii_case("monitor") {
-        return true;
-    }
-    task.get("display_command")
-        .or_else(|| task.get("displayCommand"))
-        .and_then(|value| value.as_str())
-        .is_some_and(|command| command.trim_start().starts_with("[monitor]"))
 }
 
 #[cfg(test)]
@@ -2870,8 +2861,62 @@ mod grok_background_task_tests {
             grok_background_task_count_from_json(br#"[{"task_id":"a","kind":"bash"}]"#),
             0
         );
+        assert_eq!(
+            grok_background_task_count_from_json(
+                br#"[{"task_id":"a","monitor_description":"Watch PR 699"}]"#
+            ),
+            1
+        );
         assert_eq!(grok_background_task_count_from_json(br#"[]"#), 0);
         assert_eq!(grok_background_task_count_from_json(br#"{}"#), 0);
+    }
+
+    #[test]
+    fn transcript_monitor_without_manifest_is_still_live() {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-grok-bg-transcript-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).expect("create grok session dir");
+        let transcript = dir.join("updates.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+                "\n",
+            ),
+        )
+        .expect("write transcript");
+
+        assert!(grok_has_live_background_tasks(&transcript));
+        assert!(grok_transcript_has_pending_monitors(&transcript));
+    }
+
+    #[test]
+    fn completed_transcript_monitor_is_not_live() {
+        let dir = std::env::temp_dir().join(format!(
+            "acorn-grok-bg-done-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).expect("create grok session dir");
+        let transcript = dir.join("updates.jsonl");
+        std::fs::write(
+            &transcript,
+            concat!(
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","kind":"monitor"}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","task_snapshot":{"task_id":"task-1"}}}}"#,
+                "\n",
+                r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+                "\n",
+            ),
+        )
+        .expect("write transcript");
+
+        assert!(!grok_has_live_background_tasks(&transcript));
+        assert!(!grok_transcript_has_pending_monitors(&transcript));
     }
 
     #[test]

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
@@ -461,7 +461,8 @@ pub fn grok_tail_has_pending_followup(tail: &str, read_full: bool) -> bool {
 /// Grok often writes `turn_completed` while a monitor is still running, and
 /// does not always persist that monitor into `background_tasks_manifest.json`.
 /// The 256 KiB status tail can also drop the original `task_backgrounded`
-/// line, so this walks `updates.jsonl` for unmatched monitor tasks.
+/// line, so this walks `updates.jsonl` for unmatched monitor tasks whose log
+/// is still recent.
 pub fn grok_transcript_has_pending_monitors(transcript: &Path) -> bool {
     if transcript.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
         return false;
@@ -473,41 +474,47 @@ pub fn grok_transcript_has_pending_monitors(transcript: &Path) -> bool {
 }
 
 fn grok_pending_monitors_from_reader(reader: impl Read) -> bool {
-    let mut spawned = HashSet::new();
+    let mut spawned = HashMap::new();
     let mut finished = HashSet::new();
     let mut reader = BufReader::new(reader);
-    let mut line = String::new();
+    let mut buf = Vec::new();
     loop {
-        line.clear();
-        match reader.read_line(&mut line) {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
             Ok(0) => break,
             Ok(_) => {}
             Err(_) => break,
         }
+        let line = String::from_utf8_lossy(&buf);
         if !line.contains("task_backgrounded") && !line.contains("task_completed") {
             continue;
         }
         grok_record_followup_line(line.trim(), false, &mut spawned, &mut finished);
     }
-    spawned.difference(&finished).next().is_some()
+    grok_has_unfinished_followup(&spawned, &finished)
 }
 
 fn grok_pending_followup_from_lines<'a>(
     lines: impl Iterator<Item = &'a str>,
     include_subagents: bool,
 ) -> bool {
-    let mut spawned = HashSet::new();
+    let mut spawned = HashMap::new();
     let mut finished = HashSet::new();
     for line in lines {
         grok_record_followup_line(line, include_subagents, &mut spawned, &mut finished);
     }
-    spawned.difference(&finished).next().is_some()
+    grok_has_unfinished_followup(&spawned, &finished)
+}
+
+enum FollowupKind {
+    Subagent,
+    Monitor { output_file: Option<String> },
 }
 
 fn grok_record_followup_line(
     line: &str,
     include_subagents: bool,
-    spawned: &mut HashSet<String>,
+    spawned: &mut HashMap<String, FollowupKind>,
     finished: &mut HashSet<String>,
 ) {
     let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
@@ -536,13 +543,13 @@ fn grok_apply_followup_event(
     update_type: &str,
     update: &Value,
     include_subagents: bool,
-    spawned: &mut HashSet<String>,
+    spawned: &mut HashMap<String, FollowupKind>,
     finished: &mut HashSet<String>,
 ) {
     match update_type {
         "subagent_spawned" if include_subagents => {
             if let Some(id) = grok_subagent_id(update) {
-                spawned.insert(id);
+                spawned.entry(id).or_insert(FollowupKind::Subagent);
             }
         }
         "subagent_finished" if include_subagents => {
@@ -553,7 +560,9 @@ fn grok_apply_followup_event(
         "task_backgrounded" => {
             if grok_background_task_resumes_agent(update) {
                 if let Some(id) = grok_task_id(update) {
-                    spawned.insert(id);
+                    spawned.entry(id).or_insert(FollowupKind::Monitor {
+                        output_file: grok_task_output_file(update),
+                    });
                 }
             }
         }
@@ -564,6 +573,54 @@ fn grok_apply_followup_event(
         }
         _ => {}
     }
+}
+
+fn grok_has_unfinished_followup(
+    spawned: &HashMap<String, FollowupKind>,
+    finished: &HashSet<String>,
+) -> bool {
+    spawned.iter().any(|(id, kind)| {
+        if finished.contains(id) {
+            return false;
+        }
+        match kind {
+            FollowupKind::Subagent => true,
+            FollowupKind::Monitor { output_file } => {
+                grok_monitor_log_is_recent(output_file.as_deref())
+            }
+        }
+    })
+}
+
+/// Live monitors keep appending to `output_file`. `updates.jsonl` is
+/// append-only, so a monitor that exited without `task_completed` would
+/// otherwise pin Working forever; a missing or stale log is treated as dead.
+fn grok_monitor_log_is_recent(output_file: Option<&str>) -> bool {
+    let Some(path) = output_file.map(Path::new) else {
+        return false;
+    };
+    let Ok(meta) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !meta.file_type().is_file() {
+        return false;
+    }
+    let Ok(modified) = meta.modified() else {
+        return false;
+    };
+    match modified.elapsed() {
+        Ok(age) => age.as_secs() <= crate::RECENCY_WINDOW_SECS,
+        Err(_) => true,
+    }
+}
+
+fn grok_task_output_file(update: &Value) -> Option<String> {
+    string_at(Some(update), "output_file")
+        .or_else(|| string_at(Some(update), "outputFile"))
+        .or_else(|| string_at(update.get("task_snapshot"), "output_file"))
+        .or_else(|| string_at(update.get("task_snapshot"), "outputFile"))
+        .or_else(|| string_at(update.get("taskSnapshot"), "output_file"))
+        .or_else(|| string_at(update.get("taskSnapshot"), "outputFile"))
 }
 
 pub(crate) fn grok_background_task_resumes_agent(task: &Value) -> bool {
@@ -1761,28 +1818,38 @@ mod tests {
 
     #[test]
     fn grok_pending_monitor_survives_turn_completed() {
-        let tail = concat!(
-            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
-            "\n",
-            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
-        );
-        assert!(grok_tail_has_pending_followup(tail, true));
+        let tail = grok_monitor_tail(MonitorLogAge::Recent);
+        assert!(grok_tail_has_pending_followup(&tail, true));
     }
 
     #[test]
-    fn grok_monitor_kind_and_output_file_count_as_pending_followup() {
-        let kind = concat!(
+    fn grok_monitor_without_a_recent_log_is_not_pending() {
+        let kind_only = concat!(
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","kind":"monitor"}}}"#,
             "\n",
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
         );
-        let output_file = concat!(
-            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-2","output_file":"/tmp/terminal/monitor-call-abc-1.log"}}}"#,
+        let missing_log = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-2","output_file":"/tmp/acorn-missing-monitor-call-abc-1.log"}}}"#,
             "\n",
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
         );
-        assert!(grok_tail_has_pending_followup(kind, true));
-        assert!(grok_tail_has_pending_followup(output_file, true));
+        assert!(!grok_tail_has_pending_followup(kind_only, true));
+        assert!(!grok_tail_has_pending_followup(missing_log, true));
+        assert!(!grok_tail_has_pending_followup(
+            &grok_monitor_tail(MonitorLogAge::Stale),
+            true
+        ));
+    }
+
+    #[test]
+    fn grok_real_bash_background_shape_is_not_pending_followup() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","command":"npm run dev","cwd":"/tmp","description":"Start vite","output_file":"/tmp/terminal/call-abc-1.log"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert!(!grok_tail_has_pending_followup(tail, true));
     }
 
     #[test]
@@ -1795,6 +1862,34 @@ mod tests {
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
         );
         assert!(!grok_tail_has_pending_followup(tail, true));
+    }
+
+    enum MonitorLogAge {
+        Recent,
+        Stale,
+    }
+
+    fn grok_monitor_tail(age: MonitorLogAge) -> String {
+        let dir =
+            std::env::temp_dir().join(format!("acorn-grok-mon-{}", uuid::Uuid::new_v4().simple()));
+        std::fs::create_dir_all(&dir).expect("create grok monitor dir");
+        let log = dir.join("monitor-call-task-1.log");
+        std::fs::write(&log, "event\n").expect("write grok monitor log");
+        if matches!(age, MonitorLogAge::Stale) {
+            let old = std::time::SystemTime::now()
+                - std::time::Duration::from_secs(crate::RECENCY_WINDOW_SECS + 3600);
+            let file = std::fs::File::options()
+                .write(true)
+                .open(&log)
+                .expect("open grok monitor log");
+            file.set_times(std::fs::FileTimes::new().set_modified(old))
+                .expect("stale grok monitor mtime");
+        }
+        let log_json = serde_json::to_string(&log.to_string_lossy().as_ref()).expect("json path");
+        format!(
+            r#"{{"method":"session/update","params":{{"update":{{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699","output_file":{log_json}}}}}}}"#
+        ) + "\n"
+            + r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#
     }
 
     #[test]

--- a/src-tauri/crates/acorn-transcript/src/line.rs
+++ b/src-tauri/crates/acorn-transcript/src/line.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::fs::File;
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
 
 use acorn_agent::AgentKind;
@@ -449,46 +449,158 @@ fn grok_will_wake(update: &Value) -> bool {
         == Some(true)
 }
 
-/// True when the Grok tail still has a subagent that has not finished.
-/// `turn_completed` can be the newest turn event while that child is still
-/// running, so status detection has to scan past it. Detached shells are
-/// ignored here: leftover dev servers would otherwise pin Working forever.
+/// True when the Grok tail still has a subagent or monitor that has not
+/// finished. `turn_completed` can be the newest turn event while that child
+/// is still running, so status detection has to scan past it. Detached
+/// shells are ignored here: leftover dev servers would otherwise pin
+/// Working forever.
 pub fn grok_tail_has_pending_followup(tail: &str, read_full: bool) -> bool {
+    grok_pending_followup_from_lines(tail_lines_newest_first(tail, read_full), true)
+}
+
+/// Grok often writes `turn_completed` while a monitor is still running, and
+/// does not always persist that monitor into `background_tasks_manifest.json`.
+/// The 256 KiB status tail can also drop the original `task_backgrounded`
+/// line, so this walks `updates.jsonl` for unmatched monitor tasks.
+pub fn grok_transcript_has_pending_monitors(transcript: &Path) -> bool {
+    if transcript.file_name().and_then(|name| name.to_str()) != Some("updates.jsonl") {
+        return false;
+    }
+    let Ok(file) = File::open(transcript) else {
+        return false;
+    };
+    grok_pending_monitors_from_reader(file)
+}
+
+fn grok_pending_monitors_from_reader(reader: impl Read) -> bool {
     let mut spawned = HashSet::new();
     let mut finished = HashSet::new();
-
-    for line in tail_lines_newest_first(tail, read_full) {
-        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
-            continue;
-        };
-        let method = value.get("method").and_then(Value::as_str).unwrap_or("");
-        if !matches!(method, "session/update" | "_x.ai/session/update") {
+    let mut reader = BufReader::new(reader);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => break,
+        }
+        if !line.contains("task_backgrounded") && !line.contains("task_completed") {
             continue;
         }
-        let Some(update) = value.pointer("/params/update") else {
-            continue;
-        };
-        let update_type = update
-            .get("sessionUpdate")
-            .or_else(|| update.get("session_update"))
-            .and_then(Value::as_str)
-            .unwrap_or("");
-        match update_type {
-            "subagent_spawned" => {
-                if let Some(id) = grok_subagent_id(update) {
+        grok_record_followup_line(line.trim(), false, &mut spawned, &mut finished);
+    }
+    spawned.difference(&finished).next().is_some()
+}
+
+fn grok_pending_followup_from_lines<'a>(
+    lines: impl Iterator<Item = &'a str>,
+    include_subagents: bool,
+) -> bool {
+    let mut spawned = HashSet::new();
+    let mut finished = HashSet::new();
+    for line in lines {
+        grok_record_followup_line(line, include_subagents, &mut spawned, &mut finished);
+    }
+    spawned.difference(&finished).next().is_some()
+}
+
+fn grok_record_followup_line(
+    line: &str,
+    include_subagents: bool,
+    spawned: &mut HashSet<String>,
+    finished: &mut HashSet<String>,
+) {
+    let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+        return;
+    };
+    let Some((update_type, update)) = grok_update_parts(&value) else {
+        return;
+    };
+    grok_apply_followup_event(update_type, update, include_subagents, spawned, finished);
+}
+
+fn grok_update_parts(value: &Value) -> Option<(&str, &Value)> {
+    let method = value.get("method").and_then(Value::as_str).unwrap_or("");
+    if !matches!(method, "session/update" | "_x.ai/session/update") {
+        return None;
+    }
+    let update = value.pointer("/params/update")?;
+    let update_type = update
+        .get("sessionUpdate")
+        .or_else(|| update.get("session_update"))
+        .and_then(Value::as_str)?;
+    Some((update_type, update))
+}
+
+fn grok_apply_followup_event(
+    update_type: &str,
+    update: &Value,
+    include_subagents: bool,
+    spawned: &mut HashSet<String>,
+    finished: &mut HashSet<String>,
+) {
+    match update_type {
+        "subagent_spawned" if include_subagents => {
+            if let Some(id) = grok_subagent_id(update) {
+                spawned.insert(id);
+            }
+        }
+        "subagent_finished" if include_subagents => {
+            if let Some(id) = grok_subagent_id(update) {
+                finished.insert(id);
+            }
+        }
+        "task_backgrounded" => {
+            if grok_background_task_resumes_agent(update) {
+                if let Some(id) = grok_task_id(update) {
                     spawned.insert(id);
                 }
             }
-            "subagent_finished" => {
-                if let Some(id) = grok_subagent_id(update) {
-                    finished.insert(id);
-                }
-            }
-            _ => {}
         }
+        "task_completed" => {
+            if let Some(id) = grok_task_id(update) {
+                finished.insert(id);
+            }
+        }
+        _ => {}
     }
+}
 
-    spawned.difference(&finished).next().is_some()
+pub(crate) fn grok_background_task_resumes_agent(task: &Value) -> bool {
+    if grok_task_value_resumes_agent(task) {
+        return true;
+    }
+    task.get("task_snapshot")
+        .or_else(|| task.get("taskSnapshot"))
+        .is_some_and(grok_task_value_resumes_agent)
+}
+
+fn grok_task_value_resumes_agent(task: &Value) -> bool {
+    let kind = task.get("kind").and_then(Value::as_str).unwrap_or("");
+    if kind.eq_ignore_ascii_case("monitor") {
+        return true;
+    }
+    if task
+        .get("display_command")
+        .or_else(|| task.get("displayCommand"))
+        .and_then(Value::as_str)
+        .is_some_and(|command| command.trim_start().starts_with("[monitor]"))
+    {
+        return true;
+    }
+    if task
+        .get("monitor_description")
+        .or_else(|| task.get("monitorDescription"))
+        .and_then(Value::as_str)
+        .is_some_and(|text| !text.trim().is_empty())
+    {
+        return true;
+    }
+    task.get("output_file")
+        .or_else(|| task.get("outputFile"))
+        .and_then(Value::as_str)
+        .and_then(|path| Path::new(path).file_name()?.to_str())
+        .is_some_and(|name| name.starts_with("monitor-call-"))
 }
 
 fn grok_subagent_id(update: &Value) -> Option<String> {
@@ -496,6 +608,15 @@ fn grok_subagent_id(update: &Value) -> Option<String> {
         .or_else(|| string_at(Some(update), "subagentId"))
         .or_else(|| string_at(Some(update), "child_session_id"))
         .or_else(|| string_at(Some(update), "childSessionId"))
+}
+
+fn grok_task_id(update: &Value) -> Option<String> {
+    string_at(Some(update), "task_id")
+        .or_else(|| string_at(Some(update), "taskId"))
+        .or_else(|| string_at(update.get("task_snapshot"), "task_id"))
+        .or_else(|| string_at(update.get("task_snapshot"), "taskId"))
+        .or_else(|| string_at(update.get("taskSnapshot"), "task_id"))
+        .or_else(|| string_at(update.get("taskSnapshot"), "taskId"))
 }
 
 fn grok_content_text(content: &Value) -> Option<String> {
@@ -1636,6 +1757,44 @@ mod tests {
             r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
         );
         assert!(grok_tail_has_pending_followup(tail, true));
+    }
+
+    #[test]
+    fn grok_pending_monitor_survives_turn_completed() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert!(grok_tail_has_pending_followup(tail, true));
+    }
+
+    #[test]
+    fn grok_monitor_kind_and_output_file_count_as_pending_followup() {
+        let kind = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","kind":"monitor"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        let output_file = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-2","output_file":"/tmp/terminal/monitor-call-abc-1.log"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert!(grok_tail_has_pending_followup(kind, true));
+        assert!(grok_tail_has_pending_followup(output_file, true));
+    }
+
+    #[test]
+    fn grok_completed_monitor_does_not_count_as_pending_followup() {
+        let tail = concat!(
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_backgrounded","task_id":"task-1","monitor_description":"Watch PR 699"}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"task_completed","will_wake":false,"task_snapshot":{"task_id":"task-1"}}}}"#,
+            "\n",
+            r#"{"method":"session/update","params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"prompt-7"}}}"#,
+        );
+        assert!(!grok_tail_has_pending_followup(tail, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Grok writes `turn_completed` as soon as its TUI returns to the prompt, even while a live monitor is still watching CI. #877 kept those sessions **Working** by reading `background_tasks_manifest.json`. Grok does not always write that sibling file, so Acorn still showed **need input** in the middle of unfinished monitor work.

Keep the session **Working** when `updates.jsonl` has a `task_backgrounded` monitor (`kind: monitor`, `monitor_description`, `[monitor]` display command, or a `monitor-call-*` output file) that has not yet `task_completed`. Walk the full transcript, not just the 256 KiB status tail, because a long tool payload can push the original `task_backgrounded` line out of the window.

Fire-and-forget shells (`npm run dev`, leftover `vite`) still map to WaitingForInput.

## Changes

- Recognize Grok monitors from transcript `task_backgrounded` events, not only `background_tasks_manifest.json`.
- Scan `updates.jsonl` for unmatched monitor tasks so a spawn line that aged out of the 256 KiB tail still keeps Working.
- Leave unmatched bash `task_backgrounded` events as WaitingForInput after `turn_completed`.

## Test plan

- [x] `cargo test -p acorn-transcript -p acorn-session --lib` (236 passed)
- [x] Repro case: `task_backgrounded` + `monitor_description` + `turn_completed`, no manifest → Working
- [x] Same monitor after 300 KiB of later lines (outside the status tail) → Working
- [x] Monitor that later `task_completed` → WaitingForInput
- [ ] CI (Rust format, Frontend, E2E shards)

## Changelog category

`fix`