### PR TITLE
chore(release): v1.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "acorn",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.36.0",
   "packageManager": "pnpm@9.15.0",
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acorn"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "acorn-agent",
  "acorn-daemon",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -74,7 +74,7 @@ strip = "debuginfo"
 
 [package]
 name = "acorn"
-version = "1.35.0"
+version = "1.36.0"
 description = "Acorn — parallel AI coding agent sessions across isolated git worktrees"
 authors = ["im-ian"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Acorn",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "identifier": "io.im-ian.acorn",
   "build": {
     "beforeDevCommand": "pnpm run dev:sidecar && pnpm run dev",


### PR DESCRIPTION
Bumps the app version to `v1.36.0` across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` so the `v1.36.0` tag passes `scripts/validate-release-version.mjs` and the Release workflow can build signed bundles.

## What ships in v1.36.0

- **Features** — GitHub panel now launches the default agent when starting work (#881).
- **Fixes** — Grok keeps working when monitors skip the manifest (#885); Grok transcripts are found during Start-work title generation (#886).
- **Build & CI** — `softprops/action-gh-release` 3.0.2 → 3.0.3 (#882), serde 1.0.229 + uuid 1.26 (#883), and 12 frontend dependency bumps (#884).

## Verification

- [x] `node scripts/validate-release-version.mjs v1.36.0` prints `1.36.0`.
- [x] CI green on this PR — Frontend, Frontend dependencies, Rust dependencies, Rust format, E2E shards 1&2, and Windows x64 NSIS smoke all SUCCESS.

Version-bump only; no product code changes.
