### PR TITLE
fix(sessions): pin Grok transcript pairing from active_sessions.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,39 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  rust-tests:
+    name: Rust tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          workspaces: src-tauri
+          shared-key: linux-x86_64
+          cache-on-failure: true
+
+      # Agent-to-transcript pairing decides which JSONL a live claude/codex/
+      # antigravity/grok process owns; getting it wrong silently breaks tab
+      # titles and resume. It is pure host-filesystem logic with no Tauri or
+      # sidecar dependency, so it runs without a frontend build. The Windows
+      # job covers the transport crates; no job compiled this one.
+      - name: Test transcript pairing
+        run: >-
+          cargo test --manifest-path src-tauri/Cargo.toml --locked
+          -p acorn-transcript
+
   rustfmt:
     name: Rust format
     runs-on: ubuntu-latest

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -651,6 +651,7 @@ fn scan_live_mappings(
                                 grok_root.as_deref(),
                                 process_match.pid.as_u32(),
                                 &cwd,
+                                start_time,
                             )
                         }),
                     };
@@ -1387,12 +1388,20 @@ const GROK_ACTIVE_SESSIONS_MAX_BYTES: u64 = 1024 * 1024;
 /// The session id grok's `active_sessions.json` manifest declares for a live
 /// grok process. This pins the conversation even when several groks share one
 /// cwd and no `--resume` / `--session-id` argument names it — the case where
-/// recency pairing must give up. The cwd cross-check rejects a stale row
-/// whose pid the OS has since reused for an unrelated grok.
+/// recency pairing must give up.
+///
+/// Rows outlive the processes that wrote them, because grok does not reliably
+/// prune the manifest on exit. A row therefore only describes this process
+/// when it names this cwd *and* was opened no earlier than the process
+/// started; without the second check a recycled pid would inherit a dead
+/// session's conversation and pin the tab to the wrong transcript. A row
+/// missing `opened_at` cannot clear that bar and is skipped, which costs at
+/// worst the pairing we would not have had anyway.
 fn grok_manifest_transcript_id(
     sessions_root: Option<&Path>,
     pid: u32,
     cwd: &Path,
+    process_start: SystemTime,
 ) -> Option<String> {
     let manifest = sessions_root?.parent()?.join(GROK_ACTIVE_SESSIONS_FILE);
     let meta = std::fs::symlink_metadata(&manifest).ok()?;
@@ -1409,12 +1418,29 @@ fn grok_manifest_transcript_id(
         if Path::new(entry.get("cwd")?.as_str()?) != cwd {
             return None;
         }
+        if !grok_row_opened_after(entry.get("opened_at")?.as_str()?, process_start) {
+            return None;
+        }
         entry
             .get("session_id")?
             .as_str()
             .filter(|id| is_uuid_v4_shape(id))
             .map(str::to_string)
     })
+}
+
+/// True when RFC 3339 `opened_at` is at or after `process_start`. Process
+/// start times arrive from the OS at second granularity, so this compares
+/// whole seconds rather than rejecting a row grok wrote in the same second it
+/// launched.
+fn grok_row_opened_after(opened_at: &str, process_start: SystemTime) -> bool {
+    let Ok(opened) = chrono::DateTime::parse_from_rfc3339(opened_at) else {
+        return false;
+    };
+    let Ok(started) = process_start.duration_since(SystemTime::UNIX_EPOCH) else {
+        return false;
+    };
+    opened.timestamp() >= started.as_secs() as i64
 }
 
 fn claude_resume_id_from_args(args: &[String]) -> Option<String> {
@@ -6116,33 +6142,54 @@ mod tests {
         std::fs::create_dir_all(&sessions).unwrap();
         let cwd = Path::new("/repo");
         let ours = "0198c151-f3ee-7991-9768-741923bb6b50";
+        let started = SystemTime::UNIX_EPOCH + Duration::from_secs(1_760_000_000);
+        let opened = "2025-10-09T08:53:20Z"; // the same second the process started
         std::fs::write(
             root.join(GROK_ACTIVE_SESSIONS_FILE),
             serde_json::to_vec(&serde_json::json!([
-                {"session_id": "0198c151-f3ee-7991-9768-741923bb6b51", "pid": 41, "cwd": "/repo"},
-                {"session_id": ours, "pid": 42, "cwd": "/repo"},
-                {"session_id": "../../escape", "pid": 43, "cwd": "/repo"},
+                {"session_id": "0198c151-f3ee-7991-9768-741923bb6b51", "pid": 41,
+                 "cwd": "/repo", "opened_at": opened},
+                {"session_id": ours, "pid": 42, "cwd": "/repo", "opened_at": opened},
+                {"session_id": "../../escape", "pid": 43, "cwd": "/repo", "opened_at": opened},
+                {"session_id": "0198c151-f3ee-7991-9768-741923bb6b52", "pid": 44,
+                 "cwd": "/repo", "opened_at": "2020-01-01T00:00:00Z"},
+                {"session_id": "0198c151-f3ee-7991-9768-741923bb6b53", "pid": 45, "cwd": "/repo"},
             ]))
             .unwrap(),
         )
         .unwrap();
 
         assert_eq!(
-            grok_manifest_transcript_id(Some(&sessions), 42, cwd).as_deref(),
+            grok_manifest_transcript_id(Some(&sessions), 42, cwd, started).as_deref(),
             Some(ours)
         );
         assert_eq!(
-            grok_manifest_transcript_id(Some(&sessions), 42, Path::new("/elsewhere")),
+            grok_manifest_transcript_id(Some(&sessions), 42, Path::new("/elsewhere"), started),
             None,
             "a reused pid running in another cwd must not steal the pin"
         );
         assert_eq!(
-            grok_manifest_transcript_id(Some(&sessions), 43, cwd),
+            grok_manifest_transcript_id(Some(&sessions), 43, cwd, started),
             None,
             "a non-uuid session id must not become a path component"
         );
-        assert_eq!(grok_manifest_transcript_id(Some(&sessions), 99, cwd), None);
-        assert_eq!(grok_manifest_transcript_id(None, 42, cwd), None);
+        // Grok leaves rows behind for processes that have exited, so a pid the
+        // OS recycled must not inherit the dead session's conversation.
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 44, cwd, started),
+            None,
+            "a row opened before this process started belongs to a dead grok"
+        );
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 45, cwd, started),
+            None,
+            "a row with no opened_at cannot be proven to be ours"
+        );
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 99, cwd, started),
+            None
+        );
+        assert_eq!(grok_manifest_transcript_id(None, 42, cwd, started), None);
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/src-tauri/crates/acorn-transcript/src/lib.rs
+++ b/src-tauri/crates/acorn-transcript/src/lib.rs
@@ -646,7 +646,13 @@ fn scan_live_mappings(
                         AgentKind::Claude => claude_resume_id_from_process(proc),
                         AgentKind::Codex => codex_resume_id_from_process(proc),
                         AgentKind::Antigravity => None,
-                        AgentKind::Grok => grok_transcript_id_from_process(proc),
+                        AgentKind::Grok => grok_transcript_id_from_process(proc).or_else(|| {
+                            grok_manifest_transcript_id(
+                                grok_root.as_deref(),
+                                process_match.pid.as_u32(),
+                                &cwd,
+                            )
+                        }),
                     };
                     let codex_resume_requested = process_match.kind == AgentKind::Codex
                         && codex_resume_requested_from_process(proc);
@@ -1367,6 +1373,45 @@ fn grok_transcript_id_from_args(args: &[String]) -> Option<String> {
                 .or_else(|| arg.strip_prefix("-s").filter(|value| !value.is_empty()))
         };
         candidate
+            .filter(|id| is_uuid_v4_shape(id))
+            .map(str::to_string)
+    })
+}
+
+/// Grok's own registry of live interactive sessions, kept beside the
+/// `sessions/` tree: `{session_id, pid, cwd, opened_at}` rows written on
+/// boot and pruned on clean exit.
+const GROK_ACTIVE_SESSIONS_FILE: &str = "active_sessions.json";
+const GROK_ACTIVE_SESSIONS_MAX_BYTES: u64 = 1024 * 1024;
+
+/// The session id grok's `active_sessions.json` manifest declares for a live
+/// grok process. This pins the conversation even when several groks share one
+/// cwd and no `--resume` / `--session-id` argument names it — the case where
+/// recency pairing must give up. The cwd cross-check rejects a stale row
+/// whose pid the OS has since reused for an unrelated grok.
+fn grok_manifest_transcript_id(
+    sessions_root: Option<&Path>,
+    pid: u32,
+    cwd: &Path,
+) -> Option<String> {
+    let manifest = sessions_root?.parent()?.join(GROK_ACTIVE_SESSIONS_FILE);
+    let meta = std::fs::symlink_metadata(&manifest).ok()?;
+    if !meta.is_file() || meta.len() > GROK_ACTIVE_SESSIONS_MAX_BYTES {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_slice(&std::fs::read(&manifest).ok()?).ok()?;
+    // Later rows are newer appends; walk backwards so the freshest claim on a
+    // pid wins.
+    value.as_array()?.iter().rev().find_map(|entry| {
+        if entry.get("pid")?.as_u64()? != u64::from(pid) {
+            return None;
+        }
+        if Path::new(entry.get("cwd")?.as_str()?) != cwd {
+            return None;
+        }
+        entry
+            .get("session_id")?
+            .as_str()
             .filter(|id| is_uuid_v4_shape(id))
             .map(str::to_string)
     })
@@ -6057,6 +6102,47 @@ mod tests {
         )
         .unwrap();
         assert!(sole.is_some(), "a sole grok may still pair by recency");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn grok_manifest_pins_transcript_id_by_pid_and_cwd() {
+        let root = std::env::temp_dir().join(format!(
+            "acorn-grok-manifest-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        let sessions = root.join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        let cwd = Path::new("/repo");
+        let ours = "0198c151-f3ee-7991-9768-741923bb6b50";
+        std::fs::write(
+            root.join(GROK_ACTIVE_SESSIONS_FILE),
+            serde_json::to_vec(&serde_json::json!([
+                {"session_id": "0198c151-f3ee-7991-9768-741923bb6b51", "pid": 41, "cwd": "/repo"},
+                {"session_id": ours, "pid": 42, "cwd": "/repo"},
+                {"session_id": "../../escape", "pid": 43, "cwd": "/repo"},
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 42, cwd).as_deref(),
+            Some(ours)
+        );
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 42, Path::new("/elsewhere")),
+            None,
+            "a reused pid running in another cwd must not steal the pin"
+        );
+        assert_eq!(
+            grok_manifest_transcript_id(Some(&sessions), 43, cwd),
+            None,
+            "a non-uuid session id must not become a path component"
+        );
+        assert_eq!(grok_manifest_transcript_id(Some(&sessions), 99, cwd), None);
+        assert_eq!(grok_manifest_transcript_id(None, 42, cwd), None);
 
         std::fs::remove_dir_all(root).unwrap();
     }


### PR DESCRIPTION
## TL;DR

Some Grok sessions were stuck on `No transcript is available for this session yet.` Acorn refuses to recency-pair a Grok process to a transcript when two Groks share one cwd, which is correct but left the second session with no marker at all. Grok already publishes the authoritative `pid → session_id` mapping in `~/.grok/active_sessions.json`; this reads it as an explicit pin. Also adds the Linux CI job that would have caught a regression here.

## The bug

Reproduced against session `79644612-359f-416a-8154-8d936e93c1ed`, whose `agent-state/<uuid>/` directory was empty — no `grok.id` marker had ever been written.

Two Grok processes were running in `/Users/jthefloor/Documents/GitHub/jtf_frontend`. The first one to start was alone at the time, so recency pairing bound it normally. When the second started, `pair_live_grok_transcript` saw `sole_grok_in_cwd == false` and, with no `--resume` / `--session-id` argument to pin on, returned `None` rather than risk claiming the sibling's conversation. That refusal is the right call — but the persister only writes `grok.id` when a mapping comes back, so the session never got a marker, and everything downstream that resolves through it (`resolve_native_session` → title generation, the resume modal, transcript lookup) stalled silently and permanently.

The planner retries this state forever, so the tab stays on `new session` with no error surfaced anywhere.

## The fix

Grok writes `~/.grok/active_sessions.json` on startup: an array of `{session_id, pid, cwd, opened_at}` rows for live interactive sessions. Nothing in the codebase read it. `grok_manifest_transcript_id()` now looks up the live process's pid there and feeds the declared `session_id` into the same `explicit_transcript_id` slot `--resume` uses, so the ambiguous-cwd case resolves without weakening recency pairing.

Guards on the lookup, in order: the row's `cwd` must match the live process's cwd; the row's `opened_at` must be at or after the process start time; the id must pass `is_uuid_v4_shape` before it is ever used as a path component; the manifest is size-capped and read through `symlink_metadata`; and rows are scanned newest-first so the freshest claim on a pid wins. The existing `summary.json` cwd/hidden/subagent checks in `grok_visible_transcript` still apply on top.

The `opened_at` check is load-bearing rather than defensive. Grok does not prune the manifest when a session exits — while writing this PR both rows for this machine's two Groks were still listed minutes after the processes were gone. Matching on pid and cwd alone would therefore let a recycled pid inherit a dead session and pin the tab to the wrong transcript, during the startup window before the new Grok appends its own row. Process start times arrive from the OS at second granularity, so the comparison is on whole seconds; a row with no `opened_at` cannot clear the bar and is skipped, which costs at worst a pairing that would not have happened anyway.

This lands in the shared pairing function, so the marker, tab titles, status detection and resume all recover from the one change.

## CI

Rust coverage was a single Windows job compiling `acorn-local-ipc`, `acorn-platform` and `acorn-daemon`. Every other crate — `acorn-transcript` included — was only ever parsed by `cargo fmt`, so none of its tests ran anywhere. Given that this crate decides which JSONL a live agent owns and fails silently when it is wrong, that is the worst blind spot to have. It has no Tauri or sidecar dependency, so a plain Linux job runs it without a frontend build.

## Verification

- `cargo test -p acorn-transcript` — 136 passed locally on macOS (135 before this PR), including a new test covering the pid/cwd match, the recycled-pid rejection via `opened_at`, the missing-`opened_at` case, the non-UUID path-injection rejection, and the absent-manifest case.
- `cargo fmt --all -- --check` — clean; `cargo clippy` surfaces nothing on the new code.
- The new `Rust tests` job proves the suite on Linux in this PR.

Note that the marker is written by a 2 s poll against *live* processes, so an affected session only recovers if its Grok is still running under the new build; sessions whose Grok has already exited stay unmarked.
