### PR TITLE
feat(tabs): minimize pane tabs to a leftmost icon chip

### DIFF
--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -14,7 +14,9 @@ import {
   FolderOpen,
   FolderPlus,
   GitBranch,
+  Maximize2,
   MessageSquareText,
+  Minimize2,
   Pencil,
   PencilLine,
   Sparkles,
@@ -26,6 +28,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  Fragment,
   Suspense,
   lazy,
   useCallback,
@@ -71,6 +74,7 @@ import {
   type HotkeyId,
 } from "../lib/hotkeys";
 import { EQUALIZE_PANES_EVENT } from "../lib/layoutEvents";
+import { clampTabInsertIndex } from "../lib/paneTabs";
 import { basename } from "../lib/pathUtils";
 import {
   useSettings,
@@ -589,6 +593,7 @@ export function Pane({ paneId }: PaneProps) {
           onFork={(parent, kind, parentAgentId, isolated) => {
             void forkSession(parent, kind, parentAgentId, isolated);
           }}
+          minimizedTabIds={pane?.minimizedTabIds ?? []}
         />
       ) : null}
       <div
@@ -883,6 +888,7 @@ interface TabStripProps {
     parentAgentId: string,
     isolated: boolean,
   ) => void;
+  minimizedTabIds: readonly string[];
 }
 
 function TabStrip({
@@ -895,11 +901,19 @@ function TabStrip({
   onNewTab,
   onSplitTab,
   onFork,
+  minimizedTabIds,
 }: TabStripProps) {
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
   const stripRef = useRef<HTMLDivElement | null>(null);
   const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const tabDrag = useWorkspaceTabDragSession();
+  const sourcePanes = useAppStore((s) => s.panes);
+  const insertingMinimized = Boolean(
+    tabDrag &&
+      sourcePanes[tabDrag.payload.fromPaneId]?.minimizedTabIds?.includes(
+        tabDrag.payload.tabId,
+      ),
+  );
 
   const computeInsertIndex = useCallback((clientX: number): number => {
     let idx = tabs.length;
@@ -912,8 +926,13 @@ function TabStrip({
         break;
       }
     }
-    return idx;
-  }, [tabs]);
+    return clampTabInsertIndex(
+      tabs.map((tab) => tab.id),
+      minimizedTabIds,
+      insertingMinimized,
+      idx,
+    );
+  }, [insertingMinimized, minimizedTabIds, tabs]);
 
   useEffect(() => {
     return registerTabStripFileDropTarget(
@@ -958,37 +977,49 @@ function TabStrip({
       data-pane-tab-strip={paneId}
       className="acorn-no-scrollbar relative flex h-9 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-border px-1 pt-px"
     >
-      {tabs.map((tab, i) => (
-        <TabItem
-          key={tab.id}
-          tab={tab}
-          paneId={paneId}
-          active={tab.id === activeId}
-          insertBefore={insertIndex === i}
-          onSelect={() => onSelect(tab.id)}
-          onClose={() => onClose(tab.id)}
-          onCloseOthers={() => {
-            for (const t of tabs) {
-              if (t.id !== tab.id) onClose(t.id);
-            }
-          }}
-          onCloseAll={() => {
-            for (const t of tabs) onClose(t.id);
-          }}
-          onSplitTab={(direction) => onSplitTab(tab.id, direction)}
-          onFork={
-            tab.kind === "session"
-              ? (kind, parentAgentId, isolated) =>
-                  onFork(tab.session, kind, parentAgentId, isolated)
-              : undefined
-          }
-          siblingCount={tabs.length}
-          registerRef={(el) => {
-            if (el) tabRefs.current.set(tab.id, el);
-            else tabRefs.current.delete(tab.id);
-          }}
-        />
-      ))}
+      {tabs.map((tab, i) => {
+        const minimized = minimizedTabIds.includes(tab.id);
+        const nextMinimized = minimizedTabIds.includes(tabs[i + 1]?.id ?? "");
+        return (
+          <Fragment key={tab.id}>
+            <TabItem
+              tab={tab}
+              paneId={paneId}
+              active={tab.id === activeId}
+              minimized={minimized}
+              insertBefore={insertIndex === i}
+              onSelect={() => onSelect(tab.id)}
+              onClose={() => onClose(tab.id)}
+              onCloseOthers={() => {
+                for (const t of tabs) {
+                  if (t.id !== tab.id) onClose(t.id);
+                }
+              }}
+              onCloseAll={() => {
+                for (const t of tabs) onClose(t.id);
+              }}
+              onSplitTab={(direction) => onSplitTab(tab.id, direction)}
+              onFork={
+                tab.kind === "session"
+                  ? (kind, parentAgentId, isolated) =>
+                      onFork(tab.session, kind, parentAgentId, isolated)
+                  : undefined
+              }
+              siblingCount={tabs.length}
+              registerRef={(el) => {
+                if (el) tabRefs.current.set(tab.id, el);
+                else tabRefs.current.delete(tab.id);
+              }}
+            />
+            {minimized && !nextMinimized && i < tabs.length - 1 ? (
+              <span
+                className="mx-0.5 my-1.5 w-px self-stretch bg-border"
+                aria-hidden
+              />
+            ) : null}
+          </Fragment>
+        );
+      })}
       {insertIndex === tabs.length ? (
         <span className="my-1 w-0.5 self-stretch bg-accent" aria-hidden />
       ) : null}
@@ -1026,10 +1057,94 @@ function fileTabIcon(path: string) {
   }
 }
 
+function TabGlyph({
+  tab,
+  session,
+  agentProvider,
+  isGeneratingTitle,
+  generatingLabel,
+  compact,
+}: {
+  tab: PaneTab;
+  session: Session | null;
+  agentProvider: SessionAgentProvider | null;
+  isGeneratingTitle: boolean;
+  generatingLabel: string;
+  compact: boolean;
+}) {
+  const iconSize = compact ? 14 : 12;
+  const statusClass = session ? STATUS_ICON[session.status] : undefined;
+  if (isGeneratingTitle) {
+    return <SessionTitleGeneratingIndicator label={generatingLabel} />;
+  }
+  if (tab.kind === "work-summary") {
+    return (
+      <BarChart3
+        size={iconSize}
+        className="pointer-events-none shrink-0 text-accent"
+      />
+    );
+  }
+  if (session?.graph) {
+    return (
+      <Waypoints
+        size={iconSize}
+        className={cn("pointer-events-none shrink-0", statusClass)}
+      />
+    );
+  }
+  if (session?.goal) {
+    return (
+      <Sparkles
+        size={iconSize}
+        className={cn("pointer-events-none shrink-0", statusClass)}
+      />
+    );
+  }
+  if (session?.mode === "chat") {
+    return (
+      <MessageSquareText
+        size={iconSize}
+        className={cn("pointer-events-none shrink-0", statusClass)}
+      />
+    );
+  }
+  if (agentProvider) {
+    return (
+      <AgentProviderIcon
+        provider={agentProvider}
+        className={cn(
+          "pointer-events-none",
+          compact ? "size-3.5" : "size-2.5",
+          statusClass,
+        )}
+      />
+    );
+  }
+  if (tab.kind === "code") {
+    const TabFileIcon = fileTabIcon(tab.path);
+    return (
+      <TabFileIcon
+        size={iconSize}
+        className="pointer-events-none shrink-0 text-fg-muted"
+      />
+    );
+  }
+  return (
+    <StatusDot
+      tone={session ? SESSION_STATUS_TONE[session.status] : "neutral"}
+      size={compact ? "md" : "sm"}
+      pulse={session?.status === "working"}
+      className={cn("pointer-events-none", !session && "opacity-70")}
+    />
+  );
+}
+
 interface TabItemProps {
   tab: PaneTab;
   paneId: PaneId;
   active: boolean;
+  minimized: boolean;
   insertBefore: boolean;
   onSelect: () => void;
   onClose: () => void;
@@ -1049,6 +1164,7 @@ function TabItem({
   tab,
   paneId,
   active,
+  minimized,
   insertBefore,
   onSelect,
   onClose,
@@ -1069,6 +1185,7 @@ function TabItem({
     session ? Boolean(s.silencedSessionIds[session.id]) : false,
   );
   const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
+  const setTabMinimized = useAppStore((s) => s.setTabMinimized);
   const isGeneratingTitle = useAppStore((s) =>
     session ? Boolean(s.generatingSessionTitleIds[session.id]) : false,
   );
@@ -1101,6 +1218,7 @@ function TabItem({
   const editorConfigured = editorCommand.trim().length > 0;
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [editing, setEditing] = useState(false);
+  const showMinimized = minimized && !editing;
   const pendingDragCleanupRef = useRef<(() => void) | null>(null);
   const suppressNextClickRef = useRef(false);
   const tabDrag = useWorkspaceTabDragSession();
@@ -1326,6 +1444,14 @@ function TabItem({
       : []),
     paneContextMenuGroupTitle(t, "layout"),
     {
+      label: paneT(
+        t,
+        minimized ? "pane.menu.expandTab" : "pane.menu.minimizeTab",
+      ),
+      icon: minimized ? <Maximize2 size={12} /> : <Minimize2 size={12} />,
+      onClick: () => setTabMinimized(tab.id, !minimized),
+    },
+    {
       label: paneT(t, "pane.menu.splitRight"),
       icon: <SplitSquareHorizontal size={12} />,
       shortcut: shortcutLabel(shortcuts, "splitVertical"),
@@ -1463,6 +1589,7 @@ function TabItem({
         onClick={editing ? undefined : onSelect}
         onDoubleClick={(e) => {
           e.stopPropagation();
+          if (showMinimized) return;
           if (canRename) setEditing(true);
         }}
         onContextMenu={(e) => {
@@ -1483,8 +1610,14 @@ function TabItem({
             onSelect();
           }
         }}
+        data-pane-tab={tab.id}
+        data-tab-minimized={showMinimized ? "true" : undefined}
+        aria-label={showMinimized ? tab.title : undefined}
         className={cn(
-          "group relative flex h-7 min-w-[96px] shrink-0 cursor-pointer select-none items-center rounded-md pr-0.5 text-[13px] leading-5 transition",
+          "group relative flex shrink-0 cursor-pointer select-none items-center rounded-md text-[13px] leading-5 transition",
+          showMinimized
+            ? "size-7 justify-center"
+            : "h-7 min-w-[96px] pr-0.5",
           isDraggingThisTab && "opacity-40",
           active
             ? "acorn-tab-active-bg text-fg"
@@ -1492,84 +1625,109 @@ function TabItem({
         )}
       >
         <div
-          className="flex min-w-0 flex-1 items-center gap-1.5 self-stretch pl-2"
+          className={
+            showMinimized
+              ? "flex size-full items-center justify-center"
+              : "flex min-w-0 flex-1 items-center gap-1.5 self-stretch pl-2"
+          }
           data-tab-drag-handle={tab.id}
         >
-          {isGeneratingTitle ? (
+          {showMinimized ? (
+            <Tooltip
+              label={tab.title}
+              side="bottom"
+              className="flex size-full items-center justify-center"
+            >
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={isGeneratingTitle}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact
+              />
+            </Tooltip>
+          ) : isGeneratingTitle ? (
             <SessionTitleGeneratingIndicator
               label={paneT(t, "pane.aria.generatingSessionTitle")}
             />
           ) : tab.kind === "work-summary" ? (
             <Tooltip label={paneT(t, "pane.aria.workSummary")} side="bottom">
-              <BarChart3
-                size={12}
-                className="pointer-events-none shrink-0 text-accent"
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
               />
             </Tooltip>
           ) : session?.graph ? (
             <Tooltip label={t("graphSession.label")} side="bottom">
-              <Waypoints
-                size={12}
-                className={cn(
-                  "pointer-events-none shrink-0",
-                  session && STATUS_ICON[session.status],
-                )}
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
               />
             </Tooltip>
           ) : session?.goal ? (
             <Tooltip label={paneT(t, "pane.aria.goalSession")} side="bottom">
-              <Sparkles
-                size={12}
-                className={cn(
-                  "pointer-events-none shrink-0",
-                  session && STATUS_ICON[session.status],
-                )}
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
               />
             </Tooltip>
           ) : session?.mode === "chat" ? (
             <Tooltip label={paneT(t, "pane.aria.chatSession")} side="bottom">
-              <MessageSquareText
-                size={12}
-                className={cn(
-                  "pointer-events-none shrink-0",
-                  session && STATUS_ICON[session.status],
-                )}
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
               />
             </Tooltip>
           ) : agentProvider ? (
             <Tooltip label={agentProvider} side="bottom">
-              <AgentProviderIcon
-                provider={agentProvider}
-                className={cn(
-                  "pointer-events-none size-2.5",
-                  session && STATUS_ICON[session.status],
-                )}
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
               />
             </Tooltip>
           ) : tab.kind === "code" ? (
             <Tooltip label={tabPath} side="bottom">
-              {(() => {
-                const TabFileIcon = fileTabIcon(tab.path);
-                return (
-                  <TabFileIcon
-                    size={12}
-                    className="pointer-events-none shrink-0 text-fg-muted"
-                  />
-                );
-              })()}
+              <TabGlyph
+                tab={tab}
+                session={session}
+                agentProvider={agentProvider}
+                isGeneratingTitle={false}
+                generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+                compact={false}
+              />
             </Tooltip>
           ) : (
-            <StatusDot
-              tone={session ? SESSION_STATUS_TONE[session.status] : "neutral"}
-              size="sm"
-              pulse={session?.status === "working"}
-              className={cn(
-                "pointer-events-none",
-                !session && "opacity-70",
-              )}
+            <TabGlyph
+              tab={tab}
+              session={session}
+              agentProvider={agentProvider}
+              isGeneratingTitle={false}
+              generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
+              compact={false}
             />
           )}
-          {editing ? (
+          {showMinimized ? null : editing ? (
             <TabRenameInput
               initial={tab.title}
               onSubmit={async (next) => {
@@ -1591,21 +1749,21 @@ function TabItem({
               {tab.title}
             </span>
           )}
-          {showWorktreeIcon ? (
+          {showMinimized || !showWorktreeIcon ? null : (
             <GitBranch
               size={10}
               className="pointer-events-none shrink-0 text-fg-muted"
               aria-label={paneT(t, "pane.aria.worktree")}
             />
-          ) : null}
-          {session?.kind === "control" ? (
+          )}
+          {showMinimized || session?.kind !== "control" ? null : (
             <Bot
               size={10}
               className="pointer-events-none shrink-0 text-accent"
               aria-label={paneT(t, "pane.aria.controlSession")}
             />
-          ) : null}
-          {sessionSilenced ? (
+          )}
+          {showMinimized || !sessionSilenced ? null : (
             <span
               className="pointer-events-none inline-flex shrink-0 text-fg-muted"
               aria-label={paneT(t, "pane.aria.notificationsSilenced")}
@@ -1613,51 +1771,53 @@ function TabItem({
             >
               <BellOff size={10} aria-hidden />
             </span>
-          ) : null}
+          )}
         </div>
-        <Tooltip
-          label={
-            session
-              ? paneT(t, "pane.aria.closeSession")
-              : paneT(t, "pane.aria.closeTab")
-          }
-          shortcut={shortcutLabel(shortcuts, "closeTab")}
-          side="bottom"
-        >
-          <button
-            type="button"
-            aria-label={
+        {showMinimized ? null : (
+          <Tooltip
+            label={
               session
                 ? paneT(t, "pane.aria.closeSession")
                 : paneT(t, "pane.aria.closeTab")
             }
-            data-tab-close-button={tab.id}
-            draggable={false}
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onMouseDown={(e) => {
-              e.stopPropagation();
-            }}
-            onDragStart={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            onKeyDown={(e) => e.stopPropagation()}
-            className={cn(
-              "ml-0.5 flex size-6 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
-              active
-                ? "opacity-70 hover:opacity-100"
-                : "opacity-0 group-hover:opacity-70 hover:opacity-100",
-            )}
+            shortcut={shortcutLabel(shortcuts, "closeTab")}
+            side="bottom"
           >
-            <X size={11} />
-          </button>
-        </Tooltip>
+            <button
+              type="button"
+              aria-label={
+                session
+                  ? paneT(t, "pane.aria.closeSession")
+                  : paneT(t, "pane.aria.closeTab")
+              }
+              data-tab-close-button={tab.id}
+              draggable={false}
+              onPointerDown={(e) => {
+                e.stopPropagation();
+              }}
+              onMouseDown={(e) => {
+                e.stopPropagation();
+              }}
+              onDragStart={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose();
+              }}
+              onKeyDown={(e) => e.stopPropagation()}
+              className={cn(
+                "ml-0.5 flex size-6 shrink-0 items-center justify-center rounded text-fg-muted transition hover:bg-bg-sidebar hover:text-fg",
+                active
+                  ? "opacity-70 hover:opacity-100"
+                  : "opacity-0 group-hover:opacity-70 hover:opacity-100",
+              )}
+            >
+              <X size={11} />
+            </button>
+          </Tooltip>
+        )}
         {isDraggingThisTab ? (
           <WorkspaceTabDragGhost
             drag={tabDrag}
@@ -1667,6 +1827,7 @@ function TabItem({
             isGeneratingTitle={isGeneratingTitle}
             generatingLabel={paneT(t, "pane.aria.generatingSessionTitle")}
             showWorktreeIcon={showWorktreeIcon}
+            minimized={showMinimized}
           />
         ) : null}
       </div>
@@ -1689,6 +1850,7 @@ function WorkspaceTabDragGhost({
   isGeneratingTitle,
   generatingLabel,
   showWorktreeIcon,
+  minimized,
 }: {
   drag: WorkspaceTabDragSession;
   tab: PaneTab;
@@ -1697,13 +1859,17 @@ function WorkspaceTabDragGhost({
   isGeneratingTitle: boolean;
   generatingLabel: string;
   showWorktreeIcon: boolean;
+  minimized: boolean;
 }) {
   return createPortal(
     <div
       aria-hidden
       className={cn(
-        "pointer-events-none fixed z-[9999] flex items-center gap-1.5 border px-3 text-[13px] leading-5 text-fg opacity-95 shadow-2xl",
+        "pointer-events-none fixed z-[9999] flex items-center border text-[13px] leading-5 text-fg opacity-95 shadow-2xl",
         "border-border bg-bg-elevated",
+        minimized
+          ? "justify-center"
+          : "gap-1.5 px-3",
       )}
       style={{
         left: drag.pointer.x - drag.offset.x,
@@ -1712,58 +1878,29 @@ function WorkspaceTabDragGhost({
         height: drag.sourceRect.height,
       }}
     >
-      {isGeneratingTitle ? (
-        <SessionTitleGeneratingIndicator label={generatingLabel} />
-      ) : session?.mode === "chat" ? (
-        <MessageSquareText
-          size={12}
-          className={cn(
-            "pointer-events-none shrink-0",
-            session && STATUS_ICON[session.status],
-          )}
-        />
-      ) : agentProvider ? (
-        <AgentProviderIcon
-          provider={agentProvider}
-          className={cn(
-            "pointer-events-none size-2.5",
-            session && STATUS_ICON[session.status],
-          )}
-        />
-      ) : tab.kind === "code" ? (
-        (() => {
-          const TabFileIcon = fileTabIcon(tab.path);
-          return (
-            <TabFileIcon
-              size={11}
-              className="pointer-events-none shrink-0 text-fg-muted"
-            />
-          );
-        })()
-      ) : (
-        <StatusDot
-          tone={session ? SESSION_STATUS_TONE[session.status] : "neutral"}
-          size="sm"
-          pulse={session?.status === "working"}
-          className={cn(
-            "pointer-events-none",
-            !session && "opacity-70",
-          )}
-        />
+      <TabGlyph
+        tab={tab}
+        session={session}
+        agentProvider={agentProvider}
+        isGeneratingTitle={isGeneratingTitle}
+        generatingLabel={generatingLabel}
+        compact={minimized}
+      />
+      {minimized ? null : (
+        <span className="min-w-0 truncate">{drag.title}</span>
       )}
-      <span className="min-w-0 truncate">{drag.title}</span>
-      {showWorktreeIcon ? (
+      {minimized || !showWorktreeIcon ? null : (
         <GitBranch
           size={10}
           className="pointer-events-none shrink-0 text-fg-muted"
         />
-      ) : null}
-      {session?.kind === "control" ? (
+      )}
+      {minimized || session?.kind !== "control" ? null : (
         <Bot
           size={10}
           className="pointer-events-none shrink-0 text-accent"
         />
-      ) : null}
+      )}
     </div>,
     document.body,
   );

--- a/src/lib/paneTabs.test.ts
+++ b/src/lib/paneTabs.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTabMinimized,
+  clampTabInsertIndex,
+  mergeMinimizedTabIds,
+  normalizeMinimizedTabIds,
+  partitionTabIds,
+  stackMinimizedTabIds,
+} from "./paneTabs";
+
+describe("normalizeMinimizedTabIds", () => {
+  it("drops unknown, duplicate, and non-string ids", () => {
+    expect(
+      normalizeMinimizedTabIds(["b", "b", 1, null, "missing", "a"], ["a", "b"]),
+    ).toEqual(["b", "a"]);
+  });
+
+  it("returns an empty list for non-arrays", () => {
+    expect(normalizeMinimizedTabIds(undefined, ["a"])).toEqual([]);
+    expect(normalizeMinimizedTabIds("a", ["a"])).toEqual([]);
+  });
+});
+
+describe("applyTabMinimized", () => {
+  it("moves a newly minimized tab to the end of the minimized group", () => {
+    expect(applyTabMinimized(["a", "b", "c"], ["a"], "c", true)).toEqual({
+      tabIds: ["a", "c", "b"],
+      minimizedTabIds: ["a", "c"],
+    });
+  });
+
+  it("moves a newly expanded tab to the start of the expanded group", () => {
+    expect(applyTabMinimized(["a", "c", "b"], ["a", "c"], "a", false)).toEqual({
+      tabIds: ["c", "a", "b"],
+      minimizedTabIds: ["c"],
+    });
+  });
+
+  it("is a no-op when the tab is already in the requested state", () => {
+    expect(applyTabMinimized(["a", "b", "c"], ["a"], "a", true)).toEqual({
+      tabIds: ["a", "b", "c"],
+      minimizedTabIds: ["a"],
+    });
+    expect(applyTabMinimized(["a", "b", "c"], ["a"], "b", false)).toEqual({
+      tabIds: ["a", "b", "c"],
+      minimizedTabIds: ["a"],
+    });
+  });
+
+  it("restacks mixed order when the tab is already minimized", () => {
+    expect(applyTabMinimized(["b", "a", "c"], ["a"], "a", true)).toEqual({
+      tabIds: ["a", "b", "c"],
+      minimizedTabIds: ["a"],
+    });
+  });
+
+  it("ignores unknown tab ids", () => {
+    expect(applyTabMinimized(["a"], [], "missing", true)).toEqual({
+      tabIds: ["a"],
+      minimizedTabIds: [],
+    });
+  });
+});
+
+describe("clampTabInsertIndex", () => {
+  const tabs = ["m1", "m2", "a", "b"];
+  const minimized = ["m1", "m2"];
+
+  it("keeps minimized inserts inside the left group", () => {
+    expect(clampTabInsertIndex(tabs, minimized, true, 0)).toBe(0);
+    expect(clampTabInsertIndex(tabs, minimized, true, 2)).toBe(2);
+    expect(clampTabInsertIndex(tabs, minimized, true, 4)).toBe(2);
+  });
+
+  it("keeps expanded inserts after the minimized group", () => {
+    expect(clampTabInsertIndex(tabs, minimized, false, 0)).toBe(2);
+    expect(clampTabInsertIndex(tabs, minimized, false, 3)).toBe(3);
+    expect(clampTabInsertIndex(tabs, minimized, false, 4)).toBe(4);
+  });
+});
+
+describe("partition and merge", () => {
+  it("splits tabs without reordering within each group", () => {
+    expect(partitionTabIds(["b", "a", "d", "c"], ["a", "c"])).toEqual({
+      minimized: ["a", "c"],
+      expanded: ["b", "d"],
+    });
+    expect(stackMinimizedTabIds(["b", "a", "d", "c"], ["a", "c"])).toEqual([
+      "a",
+      "c",
+      "b",
+      "d",
+    ]);
+  });
+
+  it("merges minimized ids from two panes in left-then-right order", () => {
+    expect(
+      mergeMinimizedTabIds(["a"], ["c", "a"], ["a", "b", "c"]),
+    ).toEqual(["a", "c"]);
+  });
+});

--- a/src/lib/paneTabs.ts
+++ b/src/lib/paneTabs.ts
@@ -1,0 +1,102 @@
+export function normalizeMinimizedTabIds(
+  minimizedTabIds: unknown,
+  tabIds: readonly string[],
+): string[] {
+  if (!Array.isArray(minimizedTabIds)) return [];
+  const allowed = new Set(tabIds);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of minimizedTabIds) {
+    if (typeof id !== "string" || !allowed.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+export function partitionTabIds(
+  tabIds: readonly string[],
+  minimizedTabIds: readonly string[],
+): { minimized: string[]; expanded: string[] } {
+  const minimizedSet = new Set(minimizedTabIds);
+  const minimized: string[] = [];
+  const expanded: string[] = [];
+  for (const id of tabIds) {
+    if (minimizedSet.has(id)) minimized.push(id);
+    else expanded.push(id);
+  }
+  return { minimized, expanded };
+}
+
+export function stackMinimizedTabIds(
+  tabIds: readonly string[],
+  minimizedTabIds: readonly string[],
+): string[] {
+  const { minimized, expanded } = partitionTabIds(tabIds, minimizedTabIds);
+  return [...minimized, ...expanded];
+}
+
+export function applyTabMinimized(
+  tabIds: readonly string[],
+  minimizedTabIds: readonly string[],
+  tabId: string,
+  minimized: boolean,
+): { tabIds: string[]; minimizedTabIds: string[] } {
+  const currentMinimized = normalizeMinimizedTabIds(minimizedTabIds, tabIds);
+  if (!tabIds.includes(tabId)) {
+    return {
+      tabIds: [...tabIds],
+      minimizedTabIds: currentMinimized,
+    };
+  }
+
+  const already = currentMinimized.includes(tabId);
+  if (already === minimized) {
+    return {
+      tabIds: stackMinimizedTabIds(tabIds, currentMinimized),
+      minimizedTabIds: currentMinimized,
+    };
+  }
+
+  const nextMinimized = new Set(currentMinimized);
+  if (minimized) nextMinimized.add(tabId);
+  else nextMinimized.delete(tabId);
+
+  const without = tabIds.filter((id) => id !== tabId);
+  const { minimized: minIds, expanded } = partitionTabIds(without, [
+    ...nextMinimized,
+  ]);
+  const nextTabIds = [...minIds, tabId, ...expanded];
+  return {
+    tabIds: nextTabIds,
+    minimizedTabIds: normalizeMinimizedTabIds([...nextMinimized], nextTabIds),
+  };
+}
+
+// Insert positions are relative to a left-prefix of minimized ids.
+export function clampTabInsertIndex(
+  tabIds: readonly string[],
+  minimizedTabIds: readonly string[],
+  insertingMinimized: boolean,
+  requestedIndex: number,
+): number {
+  const minimizedCount = partitionTabIds(
+    tabIds,
+    minimizedTabIds,
+  ).minimized.length;
+  const index = Math.max(0, Math.min(requestedIndex, tabIds.length));
+  if (insertingMinimized) return Math.min(index, minimizedCount);
+  return Math.max(index, minimizedCount);
+}
+
+export function mergeMinimizedTabIds(
+  left: unknown,
+  right: unknown,
+  tabIds: readonly string[],
+): string[] {
+  const merged = [
+    ...normalizeMinimizedTabIds(left, tabIds),
+    ...normalizeMinimizedTabIds(right, tabIds),
+  ];
+  return normalizeMinimizedTabIds(merged, tabIds);
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1665,6 +1665,8 @@
       "forkAntigravityInNewWorktree": "Fork Antigravity in New Worktree",
       "forkGrokSession": "Fork Grok Session",
       "forkGrokInNewWorktree": "Fork Grok in New Worktree",
+      "minimizeTab": "Minimize Tab",
+      "expandTab": "Expand Tab",
       "splitRight": "Split Right",
       "splitDown": "Split Down",
       "equalizePaneSizes": "Equalize Pane Sizes",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1665,6 +1665,8 @@
       "forkAntigravityInNewWorktree": "新しいワークツリーのフォーク反重力",
       "forkGrokSession": "Grok セッションをフォーク",
       "forkGrokInNewWorktree": "新しいワークツリーで Grok をフォーク",
+      "minimizeTab": "タブを最小化",
+      "expandTab": "タブを展開",
       "splitRight": "右に分割",
       "splitDown": "スプリットダウン",
       "equalizePaneSizes": "ペインのサイズを均等化する",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1665,6 +1665,8 @@
       "forkAntigravityInNewWorktree": "새 워크트리에 Antigravity 포크",
       "forkGrokSession": "Grok 세션 포크",
       "forkGrokInNewWorktree": "새 워크트리에 Grok 포크",
+      "minimizeTab": "탭 최소화",
+      "expandTab": "탭 확장",
       "splitRight": "오른쪽으로 분할",
       "splitDown": "아래로 분할",
       "equalizePaneSizes": "패널 크기 균등화",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1665,6 +1665,8 @@
       "forkAntigravityInNewWorktree": "在新工作树中派生 Antigravity",
       "forkGrokSession": "派生 Grok 会话",
       "forkGrokInNewWorktree": "在新工作树中派生 Grok",
+      "minimizeTab": "最小化标签页",
+      "expandTab": "展开标签页",
       "splitRight": "向右拆分",
       "splitDown": "向下拆分",
       "equalizePaneSizes": "均衡窗格大小",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2311,6 +2311,144 @@ describe("moveTab", () => {
   });
 });
 
+describe("setTabMinimized", () => {
+  it("clusters a minimized tab on the left and keeps it after session refresh", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A), session("a3", REPO_A)],
+    );
+    const paneId = useAppStore.getState().focusedPaneId;
+    expect(useAppStore.getState().panes[paneId].tabIds).toEqual([
+      "a1",
+      "a2",
+      "a3",
+    ]);
+
+    useAppStore.getState().setTabMinimized("a3", true);
+
+    let pane = useAppStore.getState().panes[paneId];
+    expect(pane.tabIds).toEqual(["a3", "a1", "a2"]);
+    expect(pane.minimizedTabIds).toEqual(["a3"]);
+
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    mockApi.listSessions.mockResolvedValueOnce([
+      session("a1", REPO_A),
+      session("a2", REPO_A),
+      session("a3", REPO_A),
+    ]);
+    await useAppStore.getState().refreshSessions();
+
+    pane = useAppStore.getState().panes[paneId];
+    expect(pane.tabIds).toEqual(["a3", "a1", "a2"]);
+    expect(pane.minimizedTabIds).toEqual(["a3"]);
+
+    useAppStore.getState().setTabMinimized("a3", false);
+    pane = useAppStore.getState().panes[paneId];
+    expect(pane.tabIds).toEqual(["a3", "a1", "a2"]);
+    expect(pane.minimizedTabIds).toBeUndefined();
+  });
+
+  it("keeps minimized state when the tab moves to another pane", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A)],
+    );
+    useAppStore.getState().setTabMinimized("a2", true);
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const fromPaneId = Object.keys(useAppStore.getState().panes).find(
+      (pid) => useAppStore.getState().panes[pid].tabIds.includes("a2"),
+    )!;
+    const toPaneId = useAppStore.getState().focusedPaneId;
+    expect(fromPaneId).not.toBe(toPaneId);
+
+    useAppStore.getState().moveTab({
+      tabId: "a2",
+      fromPaneId,
+      toPaneId,
+    });
+
+    const dest = useAppStore.getState().panes[toPaneId];
+    expect(dest.tabIds).toEqual(["a2"]);
+    expect(dest.minimizedTabIds).toEqual(["a2"]);
+    expect(
+      useAppStore.getState().panes[fromPaneId].minimizedTabIds,
+    ).toBeUndefined();
+  });
+
+  it("keeps expanded tabs after pins when moving into a pane at index 0", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A), session("a3", REPO_A)],
+    );
+    useAppStore.getState().setTabMinimized("a1", true);
+    useAppStore.getState().setTabMinimized("a3", true);
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const sourcePaneId = Object.keys(useAppStore.getState().panes).find(
+      (pid) => useAppStore.getState().panes[pid].tabIds.includes("a1"),
+    )!;
+    const destPaneId = useAppStore.getState().focusedPaneId;
+    useAppStore.getState().moveTab({
+      tabId: "a3",
+      fromPaneId: sourcePaneId,
+      toPaneId: destPaneId,
+    });
+    useAppStore.getState().moveTab({
+      tabId: "a2",
+      fromPaneId: sourcePaneId,
+      toPaneId: destPaneId,
+      toIndex: 0,
+    });
+
+    const dest = useAppStore.getState().panes[destPaneId];
+    expect(dest.tabIds).toEqual(["a3", "a2"]);
+    expect(dest.minimizedTabIds).toEqual(["a3"]);
+  });
+
+  it("merges minimized tabs to the left when closing a pane", async () => {
+    await seed(
+      [project(REPO_A, 0)],
+      [session("a1", REPO_A), session("a2", REPO_A), session("a3", REPO_A)],
+    );
+    useAppStore.getState().setTabMinimized("a1", true);
+    useAppStore.getState().splitFocusedPane("horizontal");
+    const sourcePaneId = Object.keys(useAppStore.getState().panes).find(
+      (pid) => useAppStore.getState().panes[pid].tabIds.includes("a1"),
+    )!;
+    const destPaneId = useAppStore.getState().focusedPaneId;
+    useAppStore.getState().moveTab({
+      tabId: "a2",
+      fromPaneId: sourcePaneId,
+      toPaneId: destPaneId,
+    });
+    useAppStore.getState().setTabMinimized("a2", true);
+    useAppStore.getState().closePane(destPaneId);
+
+    const surviving = useAppStore.getState().panes[sourcePaneId];
+    expect(surviving.tabIds).toEqual(["a1", "a2", "a3"]);
+    expect(surviving.minimizedTabIds).toEqual(["a1", "a2"]);
+  });
+
+  it("places a new session after the pin group, not between pins", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    const a3 = session("a3", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2, a3]);
+    useAppStore.getState().setTabMinimized("a1", true);
+    useAppStore.getState().setTabMinimized("a2", true);
+    useAppStore.getState().selectSession("a1");
+
+    const created = session("a4", REPO_A);
+    mockApi.createSession.mockResolvedValueOnce(created);
+    mockApi.listSessions.mockResolvedValueOnce([a1, a2, a3, created]);
+    mockApi.listProjects.mockResolvedValueOnce([project(REPO_A, 0)]);
+    await useAppStore.getState().createSession("new", REPO_A);
+
+    const pane = useAppStore.getState().panes[useAppStore.getState().focusedPaneId];
+    expect(pane.tabIds).toEqual(["a1", "a2", "a4", "a3"]);
+    expect(pane.minimizedTabIds).toEqual(["a1", "a2"]);
+  });
+});
+
 describe("closePane", () => {
   it("merges the closed pane's sessions into the surviving pane", async () => {
     await seed(

--- a/src/store.ts
+++ b/src/store.ts
@@ -39,6 +39,13 @@ import {
   updateSplitSizesInLayout,
 } from "./lib/layout";
 import {
+  applyTabMinimized,
+  clampTabInsertIndex,
+  mergeMinimizedTabIds,
+  normalizeMinimizedTabIds,
+  stackMinimizedTabIds,
+} from "./lib/paneTabs";
+import {
   activeSessionIdFromTabId,
   codeWorkspaceTabViewStateEqual,
   isRestorableWorkspaceTab,
@@ -349,6 +356,8 @@ export interface PaneState {
   activeTabId: string | null;
   /** Oldest -> newest activation order for tabs still known to this pane. */
   activationHistory?: string[];
+  /** Tab ids rendered as icon-only squares on the left of this pane. */
+  minimizedTabIds?: string[];
 }
 
 export interface ProjectWorkspace {
@@ -522,6 +531,7 @@ interface AppStateModel {
   closeFocusedTab: () => void;
   closePane: (paneId: PaneId) => void;
   moveTab: (args: MoveTabArgs) => void;
+  setTabMinimized: (tabId: string, minimized: boolean) => void;
   createSession: (
     name: string,
     repoPath: string,
@@ -677,6 +687,19 @@ function emptyPane(id: PaneId): PaneState {
   return { id, tabIds: [], activeTabId: null, activationHistory: [] };
 }
 
+function withMinimizedTabIds(
+  pane: PaneState,
+  tabIds: readonly string[],
+  source: unknown = pane.minimizedTabIds,
+): PaneState {
+  const { minimizedTabIds: _dropped, ...rest } = pane;
+  const minimizedTabIds = normalizeMinimizedTabIds(source, tabIds);
+  const stacked = stackMinimizedTabIds(tabIds, minimizedTabIds);
+  return minimizedTabIds.length > 0
+    ? { ...rest, tabIds: stacked, minimizedTabIds }
+    : { ...rest, tabIds: stacked };
+}
+
 type PersistedPaneState = Partial<PaneState> & {
   sessionIds?: string[];
   activeSessionId?: string | null;
@@ -753,11 +776,17 @@ function normalizePaneState(
         : null;
   const safeActiveTabId =
     activeTabId && tabIds.includes(activeTabId) ? activeTabId : null;
+  const minimizedTabIds = normalizeMinimizedTabIds(
+    pane?.minimizedTabIds,
+    tabIds,
+  );
+  const stacked = stackMinimizedTabIds(tabIds, minimizedTabIds);
   return {
     id,
-    tabIds,
+    tabIds: stacked,
     activeTabId: safeActiveTabId,
-    activationHistory: activationHistoryFor(pane, tabIds, safeActiveTabId),
+    activationHistory: activationHistoryFor(pane, stacked, safeActiveTabId),
+    ...(minimizedTabIds.length > 0 ? { minimizedTabIds } : {}),
   };
 }
 
@@ -967,11 +996,17 @@ function reconcileWorkspace(
       existing.activeTabId && filtered.includes(existing.activeTabId)
         ? existing.activeTabId
         : preferredTabId(existing, filtered);
+    const minimizedTabIds = normalizeMinimizedTabIds(
+      existing.minimizedTabIds,
+      filtered,
+    );
+    const stacked = stackMinimizedTabIds(filtered, minimizedTabIds);
     newPanes[pid] = {
       id: pid,
-      tabIds: filtered,
+      tabIds: stacked,
       activeTabId: active,
-      activationHistory: activationHistoryFor(existing, filtered, active),
+      activationHistory: activationHistoryFor(existing, stacked, active),
+      ...(minimizedTabIds.length > 0 ? { minimizedTabIds } : {}),
     };
   }
 
@@ -1592,8 +1627,7 @@ function applySessionPlacementIntent(
     changed = true;
     const tabIds = pane.tabIds.filter((id) => id !== sessionId);
     newPanes[pid as PaneId] = {
-      ...pane,
-      tabIds,
+      ...withMinimizedTabIds(pane, tabIds),
       activeTabId:
         pane.activeTabId === sessionId
           ? tabIds[tabIds.length - 1] ?? null
@@ -1603,7 +1637,12 @@ function applySessionPlacementIntent(
 
   const targetAfterRemoval = newPanes[placement.paneId] ?? targetPane;
   const targetIds = [...targetAfterRemoval.tabIds];
-  const insertAt = insertionIndexForPlacement(targetIds, placement);
+  const insertAt = clampTabInsertIndex(
+    targetIds,
+    targetAfterRemoval.minimizedTabIds ?? [],
+    false,
+    insertionIndexForPlacement(targetIds, placement),
+  );
   targetIds.splice(insertAt, 0, sessionId);
   changed =
     changed ||
@@ -1616,10 +1655,7 @@ function applySessionPlacementIntent(
     ...ws,
     panes: {
       ...newPanes,
-      [placement.paneId]: {
-        ...targetAfterRemoval,
-        tabIds: targetIds,
-      },
+      [placement.paneId]: withMinimizedTabIds(targetAfterRemoval, targetIds),
     },
   };
   const workspaces = { ...s.workspaces, [placement.projectFolderId]: newWs };
@@ -2840,22 +2876,36 @@ export const useAppStore = create<AppStateModel>()(
         const fallback = surviving[0] ?? ROOT_PANE_ID;
         if (newPanes[fallback] && pane.tabIds.length > 0) {
           const target = newPanes[fallback];
-          const mergedTabIds = [...target.tabIds, ...pane.tabIds];
+          const combinedTabIds = [...target.tabIds, ...pane.tabIds];
+          const mergedMinimized = mergeMinimizedTabIds(
+            target.minimizedTabIds,
+            pane.minimizedTabIds,
+            combinedTabIds,
+          );
+          const mergedTabIds = stackMinimizedTabIds(
+            combinedTabIds,
+            mergedMinimized,
+          );
           const mergedActive = target.activeTabId ?? pane.activeTabId;
           newPanes[fallback] = {
-            ...target,
-            tabIds: mergedTabIds,
-            activeTabId: mergedActive,
-            activationHistory: activationHistoryFor(
+            ...withMinimizedTabIds(
               {
-                activationHistory: [
-                  ...(pane.activationHistory ?? []),
-                  ...(target.activationHistory ?? []),
-                ],
+                ...target,
+                activationHistory: activationHistoryFor(
+                  {
+                    activationHistory: [
+                      ...(pane.activationHistory ?? []),
+                      ...(target.activationHistory ?? []),
+                    ],
+                  },
+                  mergedTabIds,
+                  mergedActive,
+                ),
               },
               mergedTabIds,
-              mergedActive,
+              mergedMinimized,
             ),
+            activeTabId: mergedActive,
           };
         }
         return {
@@ -2877,6 +2927,9 @@ export const useAppStore = create<AppStateModel>()(
         if (!fromPane || !fromPane.tabIds.includes(args.tabId))
           return ws;
 
+        const wasMinimized = Boolean(
+          fromPane.minimizedTabIds?.includes(args.tabId),
+        );
         const srcTabIds = fromPane.tabIds.filter(
           (id) => id !== args.tabId,
         );
@@ -2892,8 +2945,7 @@ export const useAppStore = create<AppStateModel>()(
         let newPanes: Record<PaneId, PaneState> = {
           ...ws.panes,
           [args.fromPaneId]: {
-            ...fromPane,
-            tabIds: srcTabIds,
+            ...withMinimizedTabIds(fromPane, srcTabIds),
             activeTabId: srcActive,
             activationHistory: activationHistoryFor(
               { ...fromPane, activationHistory: srcActivationHistory },
@@ -2923,16 +2975,29 @@ export const useAppStore = create<AppStateModel>()(
         const toPane = newPanes[toPaneId];
         if (!toPane) return ws;
 
-        const safeIndex =
+        const remainingMinimized = toPane.minimizedTabIds ?? [];
+        const requestedIndex =
           typeof args.toIndex === "number"
             ? Math.max(0, Math.min(args.toIndex, toPane.tabIds.length))
-            : toPane.tabIds.length;
+            : wasMinimized
+              ? remainingMinimized.length
+              : toPane.tabIds.length;
+        const safeIndex = clampTabInsertIndex(
+          toPane.tabIds,
+          remainingMinimized,
+          wasMinimized,
+          requestedIndex,
+        );
         const targetIds = [...toPane.tabIds];
         targetIds.splice(safeIndex, 0, args.tabId);
-        newPanes[toPaneId] = {
-          ...activatePaneTab(toPane, args.tabId),
-          tabIds: targetIds,
-        };
+        const destMinimized = wasMinimized
+          ? [...remainingMinimized, args.tabId]
+          : remainingMinimized;
+        newPanes[toPaneId] = withMinimizedTabIds(
+          activatePaneTab(toPane, args.tabId),
+          targetIds,
+          destMinimized,
+        );
 
         const totalPanes = Object.keys(newPanes).length;
         if (
@@ -2952,6 +3017,39 @@ export const useAppStore = create<AppStateModel>()(
           layout: newLayout,
           panes: newPanes,
           focusedPaneId: toPaneId,
+        };
+      });
+      return patch ?? s;
+    });
+  },
+
+  setTabMinimized(tabId, minimized) {
+    set((s) => {
+      const patch = updateActiveWorkspace(s, (ws) => {
+        const paneId = findPaneContainingTab(ws.panes, tabId);
+        if (!paneId) return ws;
+        const pane = ws.panes[paneId];
+        const next = applyTabMinimized(
+          pane.tabIds,
+          pane.minimizedTabIds ?? [],
+          tabId,
+          minimized,
+        );
+        const currentMinimized = pane.minimizedTabIds ?? [];
+        if (
+          next.tabIds.length === pane.tabIds.length &&
+          next.tabIds.every((id, index) => id === pane.tabIds[index]) &&
+          next.minimizedTabIds.length === currentMinimized.length &&
+          next.minimizedTabIds.every((id, index) => id === currentMinimized[index])
+        ) {
+          return ws;
+        }
+        return {
+          ...ws,
+          panes: {
+            ...ws.panes,
+            [paneId]: withMinimizedTabIds(pane, next.tabIds, next.minimizedTabIds),
+          },
         };
       });
       return patch ?? s;
@@ -4279,8 +4377,7 @@ export const useAppStore = create<AppStateModel>()(
               ? preferredTabId({ activationHistory }, ids)
               : pane.activeTabId;
           newPanes[pid as PaneId] = {
-            ...pane,
-            tabIds: ids,
+            ...withMinimizedTabIds(pane, ids),
             activeTabId: nextActive,
             activationHistory: activationHistoryFor(
               { ...pane, activationHistory },
@@ -4433,8 +4530,7 @@ export const useAppStore = create<AppStateModel>()(
                 ? normalized.activeTabId
                 : ids[ids.length - 1] ?? null;
             newPanes[pid as PaneId] = {
-              ...normalized,
-              tabIds: ids,
+              ...withMinimizedTabIds(normalized, ids),
               activeTabId: active,
               activationHistory: activationHistoryFor(normalized, ids, active),
             };

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -802,4 +802,65 @@ test.describe("pane / sidebar shortcuts", () => {
       page.getByText(/Drop a tab here or double-click/i),
     ).toBeVisible();
   });
+
+  test("right-click minimize collapses a tab to an icon and survives reload", async ({
+    page,
+    tauri,
+  }) => {
+    const beta = {
+      ...SESSION,
+      id: "s-2",
+      name: "beta",
+      created_at: "2026-01-01T00:00:01Z",
+      updated_at: "2026-01-01T00:00:06Z",
+    };
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION, beta]);
+
+    await page.goto("/");
+
+    await page
+      .locator('[data-testid="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Ready/ })
+      .first()
+      .click();
+
+    const betaTab = page.locator('[data-pane-tab-strip] [data-pane-tab="s-2"]');
+    await expect(betaTab).toBeVisible();
+    await expect(betaTab).not.toHaveAttribute("data-tab-minimized", "true");
+    await expect(betaTab.getByText("beta", { exact: true })).toBeVisible();
+
+    await betaTab.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Minimize Tab" }).click();
+
+    await expect(betaTab).toHaveAttribute("data-tab-minimized", "true");
+    await expect(betaTab.getByText("beta", { exact: true })).toHaveCount(0);
+    await expect(betaTab.locator("[data-tab-close-button]")).toHaveCount(0);
+    const box = await betaTab.boundingBox();
+    expect(box).not.toBeNull();
+    expect(Math.abs((box?.width ?? 0) - (box?.height ?? 0))).toBeLessThan(4);
+
+    const alphaTab = page.locator('[data-pane-tab-strip] [data-pane-tab="s-1"]');
+    await expect
+      .poll(async () => {
+        const betaBox = await betaTab.boundingBox();
+        const alphaBox = await alphaTab.boundingBox();
+        if (!betaBox || !alphaBox) return false;
+        return betaBox.x < alphaBox.x;
+      })
+      .toBe(true);
+
+    await page.reload();
+
+    const restored = page.locator(
+      '[data-pane-tab-strip] [data-pane-tab="s-2"]',
+    );
+    await expect(restored).toHaveAttribute("data-tab-minimized", "true");
+    await expect(restored.getByText("beta", { exact: true })).toHaveCount(0);
+
+    await restored.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Expand Tab" }).click();
+    await expect(restored).not.toHaveAttribute("data-tab-minimized", "true");
+    await expect(restored.getByText("beta", { exact: true })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Right-click a pane tab to collapse it to a square icon on the left, Chrome-style. Expand restores the full tab.
- Minimized tab ids live on persisted pane state, so the chips survive app resume, session refresh, splits, and moves between panes.
- New and expanded tabs stay after the pin group instead of landing between icon chips.

## Test plan
- [x] Vitest: `paneTabs` helpers, `setTabMinimized` refresh, move, closePane merge, create-while-pinned.
- [x] Playwright: right-click Minimize Tab → square chip, no title/close button, left of expanded tabs, survives reload, Expand Tab restores it.
- [ ] Right-click a session tab → Minimize Tab; only the icon remains on the left.
- [ ] Right-click the chip → Expand Tab; title and close button return.
- [ ] Minimize two tabs, then create a new session from the first chip; the new tab appears after both chips.
- [ ] Restart the app / resume the session; minimized chips are still minimized.