### PR TITLE
fix(tabs): focus the terminal when selecting a pane tab

### DIFF
--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -1422,6 +1422,49 @@ describe("Pane empty state", () => {
     expect(useAppStore.getState().activeTabId).toBe(second.id);
   });
 
+  it("focuses the terminal of a tab selected from the tab strip", async () => {
+    const first = session("tab-focus-first");
+    const second = session("tab-focus-second");
+    seedActivePaneWithTabs([first, second], first.id);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+    // Drain frames queued by earlier tests so only this click's dispatch
+    // reaches the listener below.
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    const focused: string[] = [];
+    const onFocusSession = (event: Event) => {
+      focused.push(
+        (event as CustomEvent<{ sessionId: string }>).detail.sessionId,
+      );
+    };
+    window.addEventListener("acorn:focus-session", onFocusSession);
+    try {
+      const secondTab = container
+        .querySelector(`[data-tab-drag-handle="${second.id}"]`)
+        ?.closest('[role="button"]');
+      expect(secondTab).toBeInstanceOf(HTMLElement);
+
+      act(() => {
+        secondTab!.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+      });
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+    } finally {
+      window.removeEventListener("acorn:focus-session", onFocusSession);
+    }
+
+    expect(useAppStore.getState().activeTabId).toBe(second.id);
+    expect(focused).toEqual([second.id]);
+  });
+
   it("starts tab drag from the title text area without native draggable", () => {
     const active = session("active-session");
     seedActivePaneWithTab(active);

--- a/src/components/Pane.test.tsx
+++ b/src/components/Pane.test.tsx
@@ -1465,6 +1465,54 @@ describe("Pane empty state", () => {
     expect(focused).toEqual([second.id]);
   });
 
+  it("activates a right-clicked tab without focusing its terminal", async () => {
+    const first = session("tab-menu-first");
+    const second = session("tab-menu-second");
+    seedActivePaneWithTabs([first, second], first.id);
+
+    act(() => {
+      root.render(<Pane paneId="root" />);
+    });
+    await act(async () => {
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+    });
+
+    const focused: string[] = [];
+    const onFocusSession = (event: Event) => {
+      focused.push(
+        (event as CustomEvent<{ sessionId: string }>).detail.sessionId,
+      );
+    };
+    window.addEventListener("acorn:focus-session", onFocusSession);
+    try {
+      const secondTab = container
+        .querySelector(`[data-tab-drag-handle="${second.id}"]`)
+        ?.closest('[role="button"]');
+      expect(secondTab).toBeInstanceOf(HTMLElement);
+
+      act(() => {
+        secondTab!.dispatchEvent(
+          new MouseEvent("contextmenu", {
+            bubbles: true,
+            cancelable: true,
+            clientX: 40,
+            clientY: 50,
+          }),
+        );
+      });
+      await act(async () => {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+    } finally {
+      window.removeEventListener("acorn:focus-session", onFocusSession);
+    }
+
+    // The menu opens over the newly active tab, and the context menu does not
+    // trap focus — a focused xterm would eat the keys aimed at the menu.
+    expect(useAppStore.getState().activeTabId).toBe(second.id);
+    expect(focused).toEqual([]);
+  });
+
   it("starts tab drag from the title text area without native draggable", () => {
     const active = session("active-session");
     seedActivePaneWithTab(active);

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -212,6 +212,7 @@ export function Pane({ paneId }: PaneProps) {
   const focusedPaneId = useAppStore((s) => s.focusedPaneId);
   const setFocusedPane = useAppStore((s) => s.setFocusedPane);
   const selectTab = useAppStore((s) => s.selectTab);
+  const selectSession = useAppStore((s) => s.selectSession);
   const createSession = useAppStore((s) => s.createSession);
   const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
   const closeWorkspaceTab = useAppStore((s) => s.closeWorkspaceTab);
@@ -562,7 +563,13 @@ export function Pane({ paneId }: PaneProps) {
           activeId={active?.id ?? null}
           onSelect={(id) => {
             setFocusedPane(paneId);
-            selectTab(id);
+            // `selectSession` — not the raw `selectTab` — so the shown
+            // terminal also takes keyboard focus. Switching tabs moves the
+            // outgoing session's portal slot into limbo, which blurs its
+            // helper textarea; without the focus dispatch nothing refocuses
+            // the incoming terminal and the next keystroke goes nowhere
+            // until the user clicks into the terminal body.
+            selectSession(id);
           }}
           onClose={(id) => {
             const tab = tabs.find((t) => t.id === id);

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -561,7 +561,7 @@ export function Pane({ paneId }: PaneProps) {
           paneId={paneId}
           tabs={tabs}
           activeId={active?.id ?? null}
-          onSelect={(id) => {
+          onSelect={(id, options) => {
             setFocusedPane(paneId);
             // `selectSession` — not the raw `selectTab` — so the shown
             // terminal also takes keyboard focus. Switching tabs moves the
@@ -569,7 +569,13 @@ export function Pane({ paneId }: PaneProps) {
             // helper textarea; without the focus dispatch nothing refocuses
             // the incoming terminal and the next keystroke goes nowhere
             // until the user clicks into the terminal body.
-            selectSession(id);
+            //
+            // Right-click activation opts out: the context menu does not trap
+            // focus, so a focused xterm would swallow the keys aimed at the
+            // menu — Escape would close it *and* interrupt the agent running
+            // in the session the user only meant to right-click.
+            if (options?.focusTerminal === false) selectTab(id);
+            else selectSession(id);
           }}
           onClose={(id) => {
             const tab = tabs.find((t) => t.id === id);
@@ -877,11 +883,20 @@ function rectContainsPoint(rect: DOMRect, point: PointerPoint): boolean {
   );
 }
 
+/**
+ * Tab activation carries whether the shown terminal should also take keyboard
+ * focus. Click and Enter/Space focus it; right-click only activates, because
+ * the context menu that follows does not trap focus.
+ */
+interface TabSelectOptions {
+  focusTerminal?: boolean;
+}
+
 interface TabStripProps {
   paneId: PaneId;
   tabs: PaneTab[];
   activeId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (id: string, options?: TabSelectOptions) => void;
   onClose: (id: string) => void;
   onDropReorder: (
     payload: { tabId: string; fromPaneId: PaneId },
@@ -995,7 +1010,7 @@ function TabStrip({
               active={tab.id === activeId}
               minimized={minimized}
               insertBefore={insertIndex === i}
-              onSelect={() => onSelect(tab.id)}
+              onSelect={(options) => onSelect(tab.id, options)}
               onClose={() => onClose(tab.id)}
               onCloseOthers={() => {
                 for (const t of tabs) {
@@ -1153,7 +1168,7 @@ interface TabItemProps {
   active: boolean;
   minimized: boolean;
   insertBefore: boolean;
-  onSelect: () => void;
+  onSelect: (options?: TabSelectOptions) => void;
   onClose: () => void;
   onCloseOthers: () => void;
   onCloseAll: () => void;
@@ -1593,7 +1608,7 @@ function TabItem({
             e.stopPropagation();
           }
         }}
-        onClick={editing ? undefined : onSelect}
+        onClick={editing ? undefined : () => onSelect()}
         onDoubleClick={(e) => {
           e.stopPropagation();
           if (showMinimized) return;
@@ -1604,7 +1619,7 @@ function TabItem({
           e.stopPropagation();
           // Activate the tab on right-click so the visible context matches the
           // menu target — mirrors VS Code / browser tab behavior.
-          if (!active) onSelect();
+          if (!active) onSelect({ focusTerminal: false });
           setMenu({ x: e.clientX, y: e.clientY });
         }}
         onKeyDown={(e) => {


### PR DESCRIPTION
## TL;DR

Selecting a tab in the pane tab strip now moves keyboard focus into the terminal it reveals, so the first keystroke after a tab switch lands instead of being swallowed.

## Problem

The tab strip's `onSelect` called the raw `selectTab`, which only updates store state. Switching tabs also makes `TerminalHost` `appendChild`-move the outgoing session's portal slot into the hidden limbo container, and moving a DOM node blurs the xterm helper textarea inside it — so `document.activeElement` dropped to `<body>` and nothing refocused the incoming terminal. Typing did nothing until the user clicked into the terminal body, which reads as "the terminal never focuses on the first click". Every other entry point (sidebar, session create, `Cmd`+arrow pane moves) already restores focus; the tab strip was the one path that did not.

## Change

`Pane`'s tab strip routes through `selectSession` instead of `selectTab`. `selectSession` calls `selectTab` and then dispatches `acorn:focus-session` on the next animation frame — past `TerminalHost`'s portal reattach — which is the focus path added in #640 for the sidebar. Workspace tabs (file viewer, work summary, diff) still select normally: the dispatch carries a non-session id that no terminal listens for and `WorkspaceCanvas.revealSession` no-ops on.

Tab activation carries a `focusTerminal` flag so the context-menu path can opt out. The tab strip activates an inactive tab on right-click before opening its menu, and `ContextMenu` neither traps focus nor stops the keydown it listens for — a focused xterm underneath would eat the keys aimed at the menu, so Escape would close the menu *and* write `\x1b` into the PTY, interrupting an agent in a session the user only meant to right-click. Click and `Enter`/`Space` focus the terminal; right-click only activates.

## Verification

- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run` — 1547 passed, 0 failed
- [x] Two regression tests in `Pane.test.tsx`, each verified to fail without its fix: tab click dispatches `acorn:focus-session`; right-click activates the tab and dispatches nothing
