### PR TITLE
feat(sessions): archive and resume parked sessions

### DIFF
--- a/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
+++ b/src-tauri/crates/acorn-ipc/src/bin/acorn-ipc.rs
@@ -738,7 +738,7 @@ fn print_sessions(sessions: &[SessionSummary]) {
                 terminal_safe_field(&session.name),
                 terminal_safe_field(&session.kind),
                 terminal_safe_field(&session.owner),
-                terminal_safe_field(&session.status),
+                terminal_safe_field(&session_status_label(session)),
                 terminal_safe_field(printable_workspace_path(session)),
                 terminal_safe_field(&session.branch),
             )
@@ -804,6 +804,14 @@ fn print_sessions(sessions: &[SessionSummary]) {
             workspace = row.5,
             branch = row.6,
         );
+    }
+}
+
+fn session_status_label(session: &SessionSummary) -> String {
+    if session.archived {
+        format!("{} (archived)", session.status)
+    } else {
+        session.status.clone()
     }
 }
 

--- a/src-tauri/crates/acorn-ipc/src/proto.rs
+++ b/src-tauri/crates/acorn-ipc/src/proto.rs
@@ -191,6 +191,8 @@ pub struct SessionSummary {
     pub kind: String,
     pub owner: String,
     pub status: String,
+    #[serde(default)]
+    pub archived: bool,
     pub owned_by_me: bool,
     /// True when the source session itself is the one being described —
     /// the CLI uses this to render an arrow / current-session marker.

--- a/src-tauri/crates/acorn-session/src/session.rs
+++ b/src-tauri/crates/acorn-session/src/session.rs
@@ -458,6 +458,10 @@ pub struct Session {
     pub status: SessionStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// When set, the session is parked: hidden from the live workspace and
+    /// without a PTY. The worktree path stays so resume can restore it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
     pub last_message: Option<String>,
     #[serde(default = "default_title_source_for_existing_sessions")]
     pub title_source: SessionTitleSource,
@@ -561,6 +565,7 @@ impl Session {
             status: SessionStatus::Ready,
             created_at: now,
             updated_at: now,
+            archived_at: None,
             last_message: None,
             title_source: SessionTitleSource::Default,
             auto_title_enabled: Some(false),
@@ -1562,6 +1567,30 @@ impl SessionStore {
         Ok(entry.clone())
     }
 
+    pub fn archive(&self, id: &Uuid, branch: Option<String>) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        if let Some(branch) = branch.filter(|value| !value.trim().is_empty()) {
+            entry.branch = branch;
+        }
+        let now = Utc::now();
+        entry.archived_at = Some(now);
+        entry.updated_at = now;
+        Ok(entry.clone())
+    }
+
+    pub fn unarchive(&self, id: &Uuid) -> SessionResult<Session> {
+        let mut entry = self
+            .inner
+            .get_mut(id)
+            .ok_or_else(|| SessionError::NotFound(id.to_string()))?;
+        entry.archived_at = None;
+        entry.updated_at = Utc::now();
+        Ok(entry.clone())
+    }
+
     /// Re-point a session at its main repo and clear `isolated` when the
     /// linked worktree has disappeared from disk (typically: agent exit
     /// pruned the worktree but the session row still references it). Keeps
@@ -2431,6 +2460,40 @@ mod tests {
         let restored: Session = serde_json::from_value(json).expect("session deserializes");
 
         assert_eq!(restored.graph, None);
+    }
+
+    #[test]
+    fn persisted_sessions_without_archived_at_load_as_live() {
+        let mut json =
+            serde_json::to_value(fake_session("/tmp/acorn-repo", "/tmp/acorn-repo", false))
+                .expect("session serializes");
+        json.as_object_mut()
+            .expect("session json is an object")
+            .remove("archived_at");
+
+        let restored: Session = serde_json::from_value(json).expect("session deserializes");
+
+        assert_eq!(restored.archived_at, None);
+    }
+
+    #[test]
+    fn archive_snapshots_branch_and_unarchive_clears_the_flag() {
+        let store = SessionStore::new();
+        let session = store.insert(fake_session(
+            "/tmp/acorn-repo",
+            "/tmp/acorn-repo/.acorn/worktrees/feature",
+            true,
+        ));
+
+        let archived = store
+            .archive(&session.id, Some("feature".to_string()))
+            .expect("session exists");
+        assert!(archived.archived_at.is_some());
+        assert_eq!(archived.branch, "feature");
+
+        let live = store.unarchive(&session.id).expect("session exists");
+        assert_eq!(live.archived_at, None);
+        assert_eq!(live.branch, "feature");
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4850,6 +4850,9 @@ pub fn list_sessions(state: State<'_, AppState>) -> Vec<Session> {
 fn reconcile_stale_worktrees(state: &AppState) {
     let mut dirty = false;
     for session in state.sessions.list() {
+        if session.archived_at.is_some() {
+            continue;
+        }
         if session.worktree_path == session.repo_path {
             continue;
         }
@@ -7830,6 +7833,49 @@ pub async fn remove_session(
     };
     persist_removal_state(&app_state, &mut progress);
     Ok(progress.into_outcome(&app_state, result, removed_session_ids, None))
+}
+
+#[tauri::command]
+pub async fn archive_session(state: State<'_, AppState>, id: String) -> AppResult<Session> {
+    archive_session_inner(state.inner().clone(), id).await
+}
+
+async fn archive_session_inner(state: AppState, id: String) -> AppResult<Session> {
+    let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
+    let session = state.sessions.get(&id)?;
+    if session.archived_at.is_some() {
+        return Ok(enrich_session(session));
+    }
+    let branch = worktree::current_branch(&session.worktree_path).ok();
+    terminate_session_runtime_blocking(state.clone(), id).await?;
+    let updated = state.sessions.archive(&id, branch)?;
+    persist(&state);
+    Ok(enrich_session(updated))
+}
+
+#[tauri::command]
+pub fn resume_session(state: State<'_, AppState>, id: String) -> AppResult<Session> {
+    resume_session_inner(state.inner(), id)
+}
+
+fn resume_session_inner(state: &AppState, id: String) -> AppResult<Session> {
+    let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
+    let session = state.sessions.get(&id)?;
+    if session.archived_at.is_none() {
+        return Ok(enrich_session(session));
+    }
+    let restored_path = worktree::restore_session_worktree(
+        &session.repo_path,
+        &session.worktree_path,
+        &session.branch,
+        session.isolated,
+    )?;
+    if restored_path != session.worktree_path {
+        state.sessions.update_worktree_path(&id, restored_path)?;
+    }
+    let updated = state.sessions.unarchive(&id)?;
+    persist(&state);
+    Ok(enrich_session(updated))
 }
 
 #[tauri::command]
@@ -12289,7 +12335,7 @@ pub fn acknowledge_staged_rev_mismatch(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        authorize_existing_session_id, authorize_registered_repository,
+        archive_session_inner, authorize_existing_session_id, authorize_registered_repository,
         authorize_registered_worktree, auto_title_enabled_for_new_session,
         can_store_generated_session_title, cleanup_removed_scrollbacks_from_dir,
         collect_memory_usage_from_roots, configured_git_identity, create_session_inner,
@@ -12299,11 +12345,12 @@ mod tests {
         infer_acornd_root_from_session_pids, inject_agent_hook_env,
         linked_worktree_root_for_registered_path, memory_root_pids, normalize_session_goal,
         normalize_session_graph, poll_defers_to_hook, project_creation_git_error,
-        pty_io_uses_daemon, remove_linked_worktree_at_path, restore_pending_session_removal,
-        retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror,
-        should_route_session_to_daemon, terminate_session_runtime, validate_display_name,
-        validate_editor_command, validate_new_project_name, validate_pty_caller_env,
-        ChatProviderAdapter, ProcessMemorySnapshot, RemovalProgress, MAX_PTY_WORKSPACE_NAME_BYTES,
+        pty_io_uses_daemon, reconcile_stale_worktrees, remove_linked_worktree_at_path,
+        restore_pending_session_removal, resume_session_inner, retry_removal_cleanup_inner,
+        seed_initial_commit, should_remove_local_project_mirror, should_route_session_to_daemon,
+        terminate_session_runtime, validate_display_name, validate_editor_command,
+        validate_new_project_name, validate_pty_caller_env, ChatProviderAdapter,
+        ProcessMemorySnapshot, RemovalProgress, MAX_PTY_WORKSPACE_NAME_BYTES,
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingRemovalStep, PendingSessionRemoval};
@@ -12467,6 +12514,115 @@ mod tests {
                 .len(),
             1
         );
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn stale_worktree_reconcile_skips_archived_sessions() {
+        let repo_dir = unique_repo_dir("archive-stale-worktree");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let missing = repo_dir.join(".acorn").join("worktrees").join("gone");
+        let mut session = Session::new(
+            "parked".to_string(),
+            repo_dir.clone(),
+            missing.clone(),
+            "feature".to_string(),
+            true,
+            SessionKind::Regular,
+        );
+        session.archived_at = Some(chrono::Utc::now());
+        let inserted = state.sessions.insert(session);
+
+        reconcile_stale_worktrees(&state);
+
+        let listed = state.sessions.get(&inserted.id).expect("session remains");
+        assert_eq!(listed.worktree_path, missing);
+        assert!(listed.isolated);
+        assert!(listed.archived_at.is_some());
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn archive_session_parks_the_row_without_deleting_the_worktree() {
+        let repo_dir = unique_repo_dir("archive-keep-worktree");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path =
+            crate::worktree::create_worktree(&repo_dir, "parked").expect("create linked worktree");
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let created = create_session_inner(
+            &state,
+            "parked".to_string(),
+            repo_dir.clone(),
+            Some(worktree_path.clone()),
+            true,
+            SessionKind::Regular,
+            None,
+            true,
+            SessionMode::Terminal,
+            None,
+            None,
+            false,
+        )
+        .expect("create session");
+
+        let archived = tauri::async_runtime::block_on(archive_session_inner(
+            state.clone(),
+            created.id.to_string(),
+        ))
+        .expect("archive session");
+
+        assert!(archived.archived_at.is_some());
+        assert!(worktree_path.exists());
+        assert_eq!(
+            archived.worktree_path.canonicalize().unwrap(),
+            worktree_path.canonicalize().unwrap()
+        );
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn resume_session_restores_a_missing_worktree_and_clears_archive() {
+        let repo_dir = unique_repo_dir("resume-restore-worktree");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path =
+            crate::worktree::create_worktree(&repo_dir, "parked").expect("create linked worktree");
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let created = create_session_inner(
+            &state,
+            "parked".to_string(),
+            repo_dir.clone(),
+            Some(worktree_path.clone()),
+            true,
+            SessionKind::Regular,
+            None,
+            true,
+            SessionMode::Terminal,
+            None,
+            None,
+            false,
+        )
+        .expect("create session");
+        tauri::async_runtime::block_on(archive_session_inner(
+            state.clone(),
+            created.id.to_string(),
+        ))
+        .expect("archive session");
+        std::fs::remove_dir_all(&worktree_path).expect("delete checkout");
+
+        let resumed = resume_session_inner(&state, created.id.to_string()).expect("resume session");
+
+        assert!(resumed.archived_at.is_none());
+        assert!(resumed.worktree_path.exists());
+        assert!(crate::worktree::is_linked_worktree_root(
+            &resumed.worktree_path
+        ));
         std::fs::remove_dir_all(&repo_dir).ok();
     }
 

--- a/src-tauri/src/daemon_commands.rs
+++ b/src-tauri/src/daemon_commands.rs
@@ -284,6 +284,7 @@ pub fn daemon_adopt_session(
         status: acorn_session::SessionStatus::Ready,
         created_at: now,
         updated_at: now,
+        archived_at: None,
         last_message: None,
         title_source: acorn_session::SessionTitleSource::Manual,
         auto_title_enabled: Some(false),

--- a/src-tauri/src/ipc/server.rs
+++ b/src-tauri/src/ipc/server.rs
@@ -738,6 +738,7 @@ fn handle_list_sessions(source: &Session, sessions: &SessionStore) -> Response {
                 },
                 owner: s.owner.label(),
                 status: format!("{:?}", s.status).to_lowercase(),
+                archived: s.archived_at.is_some(),
                 owned_by_me,
             }
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -784,6 +784,8 @@ pub fn run() {
             commands::create_session,
             commands::create_session_from_dialog,
             commands::remove_session,
+            commands::archive_session,
+            commands::resume_session,
             commands::set_session_status,
             commands::update_session_goal,
             commands::update_session_graph,

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -522,12 +522,119 @@ fn add_worktree_for_local_branch(repo_path: &Path, branch: &str, hint: &str) -> 
     let repo = ensure_repo(repo_path)?;
     ensure_git_excluded(&repo).ok();
     let (name, target) = unique_managed_worktree_target(&repo, repo_path, hint)?;
+    add_linked_worktree(&repo, branch, &name, &target)
+}
+
+fn add_worktree_at_path(repo_path: &Path, branch: &str, target: &Path) -> AppResult<PathBuf> {
+    if target.exists() {
+        return Err(AppError::InvalidPath(format!(
+            "worktree path already exists: {}",
+            target.display()
+        )));
+    }
+    let repo = ensure_repo(repo_path)?;
+    ensure_git_excluded(&repo).ok();
+    prune_registered_worktree_at_path(&repo, target)?;
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let hint = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("worktree");
+    let name = unique_worktree_registration_name(&repo, &sanitize_worktree_dir_name(hint))?;
+    add_linked_worktree(&repo, branch, &name, target)
+}
+
+fn add_linked_worktree(
+    repo: &Repository,
+    branch: &str,
+    name: &str,
+    target: &Path,
+) -> AppResult<PathBuf> {
     let branch_ref_name = format!("refs/heads/{branch}");
     let branch_ref = repo.find_reference(&branch_ref_name)?;
     let mut opts = WorktreeAddOptions::new();
     opts.checkout_existing(true).reference(Some(&branch_ref));
-    repo.worktree(&name, &target, Some(&opts))?;
-    Ok(target)
+    repo.worktree(name, target, Some(&opts))?;
+    Ok(target.to_path_buf())
+}
+
+fn unique_worktree_registration_name(repo: &Repository, hint: &str) -> AppResult<String> {
+    let mut n = 1u32;
+    loop {
+        let name = if n == 1 {
+            hint.to_string()
+        } else {
+            format!("{hint}-{n}")
+        };
+        match repo.find_worktree(&name) {
+            Ok(_) => {}
+            Err(err) if err.code() == ErrorCode::NotFound => return Ok(name),
+            Err(err) => return Err(err.into()),
+        }
+        if n >= 100 {
+            return Err(AppError::Other(format!(
+                "could not find a free worktree name for {hint}"
+            )));
+        }
+        n += 1;
+    }
+}
+
+/// Recreate a parked session's linked worktree, preferring the original path.
+pub fn restore_session_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    isolated: bool,
+) -> AppResult<PathBuf> {
+    if same_path(worktree_path, repo_path) && !isolated {
+        if !repo_path.exists() {
+            return Err(AppError::InvalidPath(format!(
+                "repository path does not exist: {}",
+                repo_path.display()
+            )));
+        }
+        return Ok(worktree_path.to_path_buf());
+    }
+
+    if worktree_path.exists() && is_linked_worktree_root(worktree_path) {
+        return Ok(worktree_path.to_path_buf());
+    }
+
+    let branch = normalize_local_branch_name(branch)?;
+    materialize_local_branch(
+        repo_path,
+        &branch,
+        &EnsureWorktreeOptions {
+            create_if_missing: false,
+            fetch_ref: None,
+            base_branch: None,
+        },
+    )?;
+
+    if !worktree_path.exists() {
+        if let Ok(path) = add_worktree_at_path(repo_path, &branch, worktree_path) {
+            return Ok(path);
+        }
+    }
+
+    let hint = worktree_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("worktree");
+    let ensured = ensure_worktree_for_branch(
+        repo_path,
+        &branch,
+        hint,
+        EnsureWorktreeOptions {
+            create_if_missing: false,
+            fetch_ref: None,
+            base_branch: None,
+        },
+    )?;
+    Ok(PathBuf::from(ensured.path))
 }
 
 fn unique_managed_worktree_target(
@@ -2235,6 +2342,123 @@ mod tests {
         std::fs::remove_file(root.join(ACORN_DIR)).ok();
         std::fs::remove_dir_all(&root).ok();
         std::fs::remove_dir_all(&external).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_recreates_the_original_path() {
+        let root = unique_temp_dir("restore-original");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+        drop(repo);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        add_worktree_at_path(&root, "feature", &worktree_path).expect("create parked worktree");
+        std::fs::remove_dir_all(&worktree_path).expect("delete checkout");
+        assert!(!worktree_path.exists());
+
+        let restored = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect("restore worktree");
+
+        assert_eq!(
+            restored.canonicalize().unwrap(),
+            worktree_path.canonicalize().unwrap()
+        );
+        assert!(is_linked_worktree_root(&restored));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_keeps_an_existing_linked_checkout() {
+        let root = unique_temp_dir("restore-existing");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+        drop(repo);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        add_worktree_at_path(&root, "feature", &worktree_path).expect("create parked worktree");
+
+        let restored = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect("keep existing worktree");
+
+        assert_eq!(
+            restored.canonicalize().unwrap(),
+            worktree_path.canonicalize().unwrap()
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_fails_when_the_branch_is_gone() {
+        let root = unique_temp_dir("restore-missing-branch");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        add_worktree_at_path(&root, "feature", &worktree_path).expect("create parked worktree");
+        std::fs::remove_dir_all(&worktree_path).expect("delete checkout");
+        prune_registered_worktree_at_path(&repo, &worktree_path).expect("prune stale registration");
+        repo.find_branch("feature", BranchType::Local)
+            .expect("find feature")
+            .delete()
+            .expect("delete feature");
+        drop(repo);
+
+        let error = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect_err("missing branch cannot be restored");
+        assert!(matches!(error, AppError::Other(_)));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_falls_back_when_the_original_path_is_occupied() {
+        let root = unique_temp_dir("restore-occupied");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        drop(initial);
+        drop(repo);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        add_worktree_at_path(&root, "feature", &worktree_path).expect("create parked worktree");
+        std::fs::remove_dir_all(&worktree_path).expect("delete checkout");
+        std::fs::create_dir_all(&worktree_path).expect("occupy original path");
+        std::fs::write(worktree_path.join("blocker.txt"), "occupied").expect("block path");
+
+        let restored = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect("fall back to a free worktree path");
+
+        assert!(is_linked_worktree_root(&restored));
+        assert_ne!(
+            restored.canonicalize().unwrap(),
+            worktree_path.canonicalize().unwrap()
+        );
+
+        std::fs::remove_dir_all(&root).ok();
     }
 
     fn ensure_options<'a>(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,8 +331,11 @@ function App() {
   const layout = useAppStore((s) => s.layout);
   const workspaceViewMode = useAppStore((s) => s.workspaceViewMode);
   const pendingRemoveId = useAppStore((s) => s.pendingRemoveId);
+  const pendingArchiveId = useAppStore((s) => s.pendingArchiveId);
   const pendingRemoveProject = useAppStore((s) => s.pendingRemoveProject);
   const clearPendingRemove = useAppStore((s) => s.clearPendingRemove);
+  const clearPendingArchive = useAppStore((s) => s.clearPendingArchive);
+  const archiveSession = useAppStore((s) => s.archiveSession);
   const clearPendingRemoveProject = useAppStore(
     (s) => s.clearPendingRemoveProject,
   );
@@ -353,6 +356,8 @@ function App() {
   const shortcuts = settings.shortcuts;
   const preventSleep = settings.power.preventSleep;
   const pendingRemove = sessions.find((s) => s.id === pendingRemoveId) ?? null;
+  const pendingArchive =
+    sessions.find((s) => s.id === pendingArchiveId) ?? null;
   const pendingProject =
     projects.find((p) => p.repo_path === pendingRemoveProject) ?? null;
   // Closing a project closes every root it spans, so the confirmation has to
@@ -384,6 +389,11 @@ function App() {
     pendingRemove.status === "working" &&
     settings.sessions.warnBeforeClosingRunning &&
     runningCloseWarningConfirmedId !== pendingRemove.id;
+  const pendingArchiveNeedsRunningWarning =
+    pendingArchive !== null &&
+    pendingArchive.status === "working" &&
+    settings.sessions.warnBeforeClosingRunning &&
+    runningCloseWarningConfirmedId !== pendingArchive.id;
   const pendingRemoveSkipsDialog =
     pendingRemove !== null &&
     !pendingRemoveNeedsRunningWarning &&
@@ -1312,11 +1322,16 @@ function App() {
   useEffect(() => {
     if (
       runningCloseWarningConfirmedId !== null &&
-      pendingRemove?.id !== runningCloseWarningConfirmedId
+      pendingRemove?.id !== runningCloseWarningConfirmedId &&
+      pendingArchive?.id !== runningCloseWarningConfirmedId
     ) {
       setRunningCloseWarningConfirmedId(null);
     }
-  }, [pendingRemove?.id, runningCloseWarningConfirmedId]);
+  }, [
+    pendingArchive?.id,
+    pendingRemove?.id,
+    runningCloseWarningConfirmedId,
+  ]);
 
   // Skip the confirmation dialog when Settings gives a deterministic removal:
   // shared worktree workspace sessions keep the worktree, plain sessions can
@@ -1380,6 +1395,28 @@ function App() {
     projectFolders,
     removeSession,
     sessions,
+    showStoreOperationToast,
+  ]);
+
+  const archiveInFlightIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pendingArchive) {
+      archiveInFlightIdRef.current = null;
+      return;
+    }
+    if (pendingArchiveNeedsRunningWarning) return;
+    if (archiveInFlightIdRef.current === pendingArchive.id) return;
+    archiveInFlightIdRef.current = pendingArchive.id;
+    const targetId = pendingArchive.id;
+    clearPendingArchive();
+    void archiveSession(targetId).then(() => {
+      showStoreOperationToast(null, "toasts.session.archiveFailed");
+    });
+  }, [
+    archiveSession,
+    clearPendingArchive,
+    pendingArchive,
+    pendingArchiveNeedsRunningWarning,
     showStoreOperationToast,
   ]);
 
@@ -2021,14 +2058,25 @@ function App() {
         }}
       />
       <RunningSessionCloseWarningDialog
-        session={pendingRemoveNeedsRunningWarning ? pendingRemove : null}
+        session={
+          pendingRemoveNeedsRunningWarning
+            ? pendingRemove
+            : pendingArchiveNeedsRunningWarning
+              ? pendingArchive
+              : null
+        }
         onCancel={() => {
           setRunningCloseWarningConfirmedId(null);
           clearPendingRemove();
+          clearPendingArchive();
         }}
         onContinue={() => {
-          if (pendingRemove) {
+          if (pendingRemoveNeedsRunningWarning && pendingRemove) {
             setRunningCloseWarningConfirmedId(pendingRemove.id);
+            return;
+          }
+          if (pendingArchive) {
+            setRunningCloseWarningConfirmedId(pendingArchive.id);
           }
         }}
       />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Command, useCommandState } from "cmdk";
 import {
   AlertCircle,
+  Archive,
   Bell,
   Bot,
   Columns3,
@@ -35,6 +36,11 @@ import {
   buildSessionCreateRequest,
   resolveActiveSessionScope,
 } from "../lib/sessionCreation";
+import {
+  archivedSessions,
+  isArchivedSession,
+  liveSessions,
+} from "../lib/sessionArchive";
 import { suggestDefaultSessionName } from "../lib/sessionName";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -105,7 +111,11 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
   // Derived once per render — sessions array identity is stable from zustand
   // until the underlying list actually changes.
-  const sessionItems = useMemo(() => sessions, [sessions]);
+  const sessionItems = useMemo(() => liveSessions(sessions), [sessions]);
+  const archivedItems = useMemo(
+    () => archivedSessions(sessions),
+    [sessions],
+  );
   const unreadNotifications = useMemo(
     () => notifications.filter((notification) => !notification.readAt),
     [notifications],
@@ -228,7 +238,21 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     }
   }
 
-  function handleSelectSession(id: string) {
+  async function handleSelectSession(id: string) {
+    const session = useAppStore.getState().sessions.find(
+      (candidate) => candidate.id === id,
+    );
+    if (session && isArchivedSession(session)) {
+      const resumed = await useAppStore.getState().resumeSession(id);
+      const error = useAppStore.getState().consumeError();
+      if (!resumed || error) {
+        useToasts.getState().show(
+          `${t("toasts.session.resumeFailed")} ${error ?? ""}`.trim(),
+        );
+      }
+      close();
+      return;
+    }
     useAppStore.getState().openSessionSurface(id);
     close();
   }
@@ -440,12 +464,34 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
               <Command.Item
                 key={`switch-${session.id}`}
                 value={`switch ${session.name} ${session.branch}`}
-                onSelect={() => handleSelectSession(session.id)}
+                onSelect={() => void handleSelectSession(session.id)}
                 keywords={[session.name, session.branch]}
               >
                 <Sparkles size={14} className="text-fg-muted" />
                 <span className="truncate">
                   {cpt(t, "commandPalette.commands.switchSessionPrefix")}{" "}
+                  {session.name}
+                </span>
+                <span className="ml-auto truncate text-xs text-fg-muted/80">
+                  {session.branch}
+                </span>
+              </Command.Item>
+            ))}
+          </Command.Group>
+        ) : null}
+
+        {archivedItems.length > 0 ? (
+          <Command.Group heading={cpt(t, "commandPalette.groups.archived")}>
+            {archivedItems.map((session) => (
+              <Command.Item
+                key={`resume-${session.id}`}
+                value={`resume ${session.name} ${session.branch} archived`}
+                onSelect={() => void handleSelectSession(session.id)}
+                keywords={[session.name, session.branch, "archive", "resume"]}
+              >
+                <Archive size={14} className="text-fg-muted" />
+                <span className="truncate">
+                  {cpt(t, "commandPalette.commands.resumeSessionPrefix")}{" "}
                   {session.name}
                 </span>
                 <span className="ml-auto truncate text-xs text-fg-muted/80">
@@ -595,9 +641,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 
         <ShakeTreeItem onSelect={handleShakeTree} t={t} />
 
-        {sessionItems.length > 0 ? (
+        {sessions.length > 0 ? (
           <Command.Group heading={cpt(t, "commandPalette.groups.dangerZone")}>
-            {sessionItems.map((session) => (
+            {sessions.map((session) => (
               <Command.Item
                 key={`remove-${session.id}`}
                 value={`remove ${session.name}`}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  Archive,
   BarChart3,
   Bell,
   BellOff,
@@ -27,6 +28,7 @@ import {
   Waypoints,
   Tag,
   Trash2,
+  Undo2,
   X,
 } from "lucide-react";
 import { homeDir } from "@tauri-apps/api/path";
@@ -124,6 +126,10 @@ import {
   showStoreResultToast,
   showWorktreeRemovalToast,
 } from "../lib/operationToasts";
+import {
+  archivedLocalSessions,
+  archivedSessionsForProject,
+} from "../lib/sessionArchive";
 import {
   buildLocalSessions,
 } from "../lib/sessionGrouping";
@@ -2241,6 +2247,15 @@ function ProjectGroupView({
   const hasMultipleProjectRoots = (sourcePaths?.length ?? 0) > 0;
   const showToast = useToasts((s) => s.show);
   const projects = useAppStore((s) => s.projects);
+  const allSessions = useAppStore((s) => s.sessions);
+  const archived = useMemo(() => {
+    const rootIndex = buildProjectRootIndex(projects);
+    return archivedSessionsForProject(
+      allSessions,
+      project.repoPath,
+      rootIndex,
+    );
+  }, [allSessions, project.repoPath, projects]);
   const convertProjectToSourceFolder = useAppStore(
     (s) => s.convertProjectToSourceFolder,
   );
@@ -2691,6 +2706,7 @@ function ProjectGroupView({
         }
       />
       {!collapsed ? (
+        <>
         <ul
           className={listBoxClassName({
             layout: "flex",
@@ -2805,6 +2821,11 @@ function ProjectGroupView({
             </li>
           ) : null}
         </ul>
+          <ArchivedSessionsSection
+            sessions={archived}
+            onRemove={onRemoveSession}
+          />
+        </>
       ) : null}
     </li>
   );
@@ -3331,6 +3352,7 @@ function SessionRow({
   const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
   const createSession = useAppStore((s) => s.createSession);
   const selectSession = useAppStore((s) => s.selectSession);
+  const requestArchiveSession = useAppStore((s) => s.requestArchiveSession);
   const setPendingTerminalInput = useAppStore(
     (s) => s.setPendingTerminalInput,
   );
@@ -3672,6 +3694,11 @@ function SessionRow({
         },
       ],
     },
+    {
+      label: sidebarText(t, "sidebar.actions.archiveSessionMenu"),
+      icon: <Archive size={12} />,
+      onClick: () => requestArchiveSession(session.id),
+    },
     contextMenuGroupTitle(t, "danger"),
     {
       label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
@@ -3759,6 +3786,19 @@ function SessionRow({
       <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
         <button
           type="button"
+          aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            requestArchiveSession(session.id);
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        >
+          <Archive size={12} />
+        </button>
+        <button
+          type="button"
           aria-label={sidebarText(t, "sidebar.actions.removeSession")}
           onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
@@ -3794,6 +3834,177 @@ function SessionRow({
         y={menu?.y ?? 0}
         onClose={() => setMenu(null)}
         items={sessionMenuItems}
+      />
+    </li>
+  );
+}
+
+function ArchivedSessionsSection({
+  sessions,
+  onRemove,
+}: {
+  sessions: Session[];
+  onRemove: (session: Session) => void;
+}) {
+  const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
+  const resumeSession = useAppStore((s) => s.resumeSession);
+  const [expanded, setExpanded] = useState(false);
+  if (sessions.length === 0) return null;
+
+  async function resume(session: Session) {
+    const resumed = await resumeSession(session.id);
+    const error = useAppStore.getState().consumeError();
+    if (!resumed || error) {
+      showToast(`${t("toasts.session.resumeFailed")} ${error ?? ""}`.trim());
+    }
+  }
+
+  return (
+    <div className="mt-1">
+      <button
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-1 rounded px-2 py-1 text-left text-[11px] text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+      >
+        <ChevronRight
+          size={12}
+          className={cn("shrink-0 transition", expanded && "rotate-90")}
+        />
+        <span className="truncate">
+          {sidebarText(t, "sidebar.archived.title")}
+        </span>
+        <span className="ml-auto tabular-nums">{sessions.length}</span>
+      </button>
+      {expanded ? (
+        <ul
+          className={listBoxClassName({
+            layout: "flex",
+            inset: "nested",
+            text: "none",
+            className: "ml-2 border-l border-border",
+          })}
+        >
+          {sessions.map((session) => (
+            <ArchivedSessionRow
+              key={session.id}
+              session={session}
+              onResume={() => void resume(session)}
+              onRemove={() => onRemove(session)}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function ArchivedSessionRow({
+  session,
+  onResume,
+  onRemove,
+}: {
+  session: Session;
+  onResume: () => void;
+  onRemove: () => void;
+}) {
+  const t = useTranslation();
+  const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
+  const titleText = resolveSessionTitle(session, sessionDisplay.title);
+  const metadataText = composeSessionMetadata(t, session, sessionDisplay.metadata);
+  const agentProvider = resolveSessionAgentProvider(session);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const menuItems: ContextMenuItem[] = [
+    {
+      label: sidebarText(t, "sidebar.actions.resumeSessionMenu"),
+      icon: <Undo2 size={12} />,
+      onClick: onResume,
+    },
+    contextMenuGroupTitle(t, "danger"),
+    {
+      label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
+      icon: <Trash2 size={12} />,
+      onClick: onRemove,
+    },
+  ];
+
+  return (
+    <li>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onResume}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onResume();
+          }
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
+        className={listRowClassName({
+          density: "sidebar",
+          interactive: true,
+          surface: "sidebar",
+          className:
+            "group flex w-full cursor-pointer items-start gap-1.5 text-left text-fg-muted",
+        })}
+      >
+        <SessionStatusMarker
+          session={session}
+          agentProvider={agentProvider}
+          isGeneratingTitle={false}
+          generatingLabel={sidebarText(t, "sidebar.aria.generatingSessionTitle")}
+          chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
+          goalLabel={sidebarText(t, "sidebar.aria.goalSession")}
+        />
+        <SessionRowLabel
+          editing={false}
+          session={session}
+          titleText={titleText}
+          metadataText={metadataText}
+          currentPullRequest={null}
+          t={t}
+          onSubmitRename={() => undefined}
+          onCancelRename={() => undefined}
+        />
+        <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.resumeSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onResume();
+            }}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Undo2 size={12} />
+          </button>
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+      <ContextMenu
+        open={menu !== null}
+        x={menu?.x ?? 0}
+        y={menu?.y ?? 0}
+        onClose={() => setMenu(null)}
+        items={menuItems}
       />
     </li>
   );
@@ -4070,6 +4281,11 @@ function LocalTerminalArea({
     () => groups.flatMap((group) => group.sessions),
     [groups],
   );
+  const allSessions = useAppStore((s) => s.sessions);
+  const archived = useMemo(
+    () => archivedLocalSessions(allSessions),
+    [allSessions],
+  );
   const hasNamedWorkspaces = groups.some((group) =>
     group.folders.some((folderGroup) =>
       !isDefaultProjectFolder(folderGroup.folder),
@@ -4245,6 +4461,10 @@ function LocalTerminalArea({
           })}
         </ul>
       ) : null}
+      <ArchivedSessionsSection
+        sessions={archived}
+        onRemove={onRemoveSession}
+      />
       <div
         role="button"
         tabIndex={0}
@@ -4886,6 +5106,7 @@ function LocalSessionRow({
   const showToast = useToasts((s) => s.show);
   const renameSession = useAppStore((s) => s.renameSession);
   const generateSessionTitle = useAppStore((s) => s.generateSessionTitle);
+  const requestArchiveSession = useAppStore((s) => s.requestArchiveSession);
   const sessionSilenced = useAppStore((s) =>
     Boolean(s.silencedSessionIds[session.id]),
   );
@@ -5017,6 +5238,11 @@ function LocalSessionRow({
       : []),
     { type: "separator" },
     {
+      label: sidebarText(t, "sidebar.actions.archiveSessionMenu"),
+      icon: <Archive size={12} />,
+      onClick: () => requestArchiveSession(session.id),
+    },
+    {
       label: sidebarText(t, "sidebar.actions.removeSessionMenu"),
       icon: <Trash2 size={12} />,
       onClick: onRemove,
@@ -5098,26 +5324,34 @@ function LocalSessionRow({
         }}
         onCancelRename={() => setEditing(false)}
       />
-      <span
-        role="button"
-        aria-label={sidebarText(t, "sidebar.actions.removeSession")}
-        tabIndex={0}
-        onPointerDown={(e) => e.stopPropagation()}
-        onClick={(e) => {
-          e.stopPropagation();
-          onRemove();
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
+      <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+        <button
+          type="button"
+          aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.stopPropagation();
+            requestArchiveSession(session.id);
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+        >
+          <Archive size={12} />
+        </button>
+        <button
+          type="button"
+          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+          onPointerDown={(e) => e.stopPropagation()}
+          onClick={(e) => {
             e.stopPropagation();
             onRemove();
-          }
-        }}
-        className="ml-auto hidden shrink-0 rounded p-1 text-fg-muted transition hover:text-danger group-hover:inline-flex"
-      >
-        <Trash2 size={12} />
-      </span>
+          }}
+          onKeyDown={(e) => e.stopPropagation()}
+          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+        >
+          <Trash2 size={12} />
+        </button>
+      </div>
     </div>
   );
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -234,6 +234,12 @@ export const api = {
   ): Promise<SessionRemovalOutcome> {
     return invoke<SessionRemovalOutcome>("remove_session", { id, removeWorktree });
   },
+  archiveSession(id: string): Promise<Session> {
+    return invoke<Session>("archive_session", { id });
+  },
+  resumeSession(id: string): Promise<Session> {
+    return invoke<Session>("resume_session", { id });
+  },
   setSessionStatus(id: string, status: SessionStatus): Promise<Session> {
     return invoke<Session>("set_session_status", { id, status });
   },

--- a/src/lib/projectFolders.test.ts
+++ b/src/lib/projectFolders.test.ts
@@ -135,6 +135,27 @@ describe("project folders", () => {
     expect(groups[0].folders[1].sessions.map((s) => s.id)).toEqual(["s1", "s2"]);
   });
 
+  it("omits archived sessions from live folder groups", () => {
+    const repoPath = "/repo/app";
+    const groups = buildProjectFolderGroups(
+      [project(repoPath)],
+      [
+        session("live", repoPath),
+        session("parked", repoPath, {
+          archived_at: "2026-04-01T00:00:00Z",
+        }),
+      ],
+      {
+        [repoPath]: [makeDefaultProjectFolder(repoPath)],
+      },
+    );
+
+    expect(groups[0].sessions.map((item) => item.id)).toEqual(["live"]);
+    expect(groups[0].folders[0].sessions.map((item) => item.id)).toEqual([
+      "live",
+    ]);
+  });
+
   it("groups sessions into matching worktree workspaces without explicit assignments", () => {
     const repoPath = "/repo/app";
     const worktreePath = "/repo/app/.acorn/worktrees/app-worktree-123";

--- a/src/lib/projectFolders.ts
+++ b/src/lib/projectFolders.ts
@@ -1,3 +1,4 @@
+import { isArchivedSession } from "./sessionArchive";
 import type { Project, Session } from "./types";
 import {
   basename,
@@ -220,6 +221,7 @@ export function buildProjectFolderGroups(
   }
 
   for (const session of projectSessions) {
+    if (isArchivedSession(session)) continue;
     const groupRepoPath = resolveProjectRootPath(rootIndex, session.repo_path);
     let group = map.get(groupRepoPath);
     if (!group) {
@@ -298,6 +300,7 @@ export function buildLocalSessionFolderGroups(
         sessions: [],
       };
       for (const session of localSessions) {
+        if (isArchivedSession(session)) continue;
         if (session.repo_path !== repoPath) continue;
         const folderId = resolveProjectFolderIdForSession(
           folders,

--- a/src/lib/sessionArchive.test.ts
+++ b/src/lib/sessionArchive.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  archivedLocalSessions,
+  archivedSessions,
+  archivedSessionsForProject,
+  isArchivedSession,
+  liveSessions,
+} from "./sessionArchive";
+import type { Session } from "./types";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    name: "session-1",
+    repo_path: "/repo",
+    worktree_path: "/repo",
+    branch: "main",
+    isolated: false,
+    status: "ready",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_message: null,
+    title_source: "default",
+    kind: "regular",
+    owner: { kind: "user" },
+    position: null,
+    in_worktree: false,
+    ...overrides,
+  };
+}
+
+describe("session archive helpers", () => {
+  it("treats a missing archived_at as live", () => {
+    expect(isArchivedSession(session())).toBe(false);
+    expect(isArchivedSession(session({ archived_at: null }))).toBe(false);
+  });
+
+  it("partitions live and archived sessions", () => {
+    const live = session({ id: "live" });
+    const parked = session({
+      id: "parked",
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+
+    expect(liveSessions([live, parked]).map((item) => item.id)).toEqual([
+      "live",
+    ]);
+    expect(archivedSessions([live, parked]).map((item) => item.id)).toEqual([
+      "parked",
+    ]);
+  });
+
+  it("groups archived project sessions by the owning project root", () => {
+    const rootIndex = new Map([
+      ["/repo", "/repo"],
+      ["/repo/extra", "/repo"],
+    ]);
+    const sessions = [
+      session({ id: "live", repo_path: "/repo" }),
+      session({
+        id: "parked-root",
+        repo_path: "/repo",
+        archived_at: "2026-04-01T00:00:00Z",
+      }),
+      session({
+        id: "parked-source",
+        repo_path: "/repo/extra",
+        archived_at: "2026-04-01T00:00:00Z",
+      }),
+      session({
+        id: "other-project",
+        repo_path: "/other",
+        archived_at: "2026-04-01T00:00:00Z",
+      }),
+      session({
+        id: "local",
+        repo_path: "/repo",
+        project_scoped: false,
+        archived_at: "2026-04-01T00:00:00Z",
+      }),
+    ];
+
+    expect(
+      archivedSessionsForProject(sessions, "/repo", rootIndex).map(
+        (item) => item.id,
+      ),
+    ).toEqual(["parked-root", "parked-source"]);
+    expect(archivedLocalSessions(sessions).map((item) => item.id)).toEqual([
+      "local",
+    ]);
+  });
+});

--- a/src/lib/sessionArchive.ts
+++ b/src/lib/sessionArchive.ts
@@ -1,0 +1,37 @@
+import { resolveProjectRootPath } from "./projectFolders";
+import { isLocalSession } from "./sessionGrouping";
+import type { Session } from "./types";
+
+export function isArchivedSession(
+  session: Pick<Session, "archived_at">,
+): boolean {
+  return Boolean(session.archived_at);
+}
+
+export function liveSessions<T extends Pick<Session, "archived_at">>(
+  sessions: readonly T[],
+): T[] {
+  return sessions.filter((session) => !isArchivedSession(session));
+}
+
+export function archivedSessions<T extends Pick<Session, "archived_at">>(
+  sessions: readonly T[],
+): T[] {
+  return sessions.filter(isArchivedSession);
+}
+
+export function archivedSessionsForProject(
+  sessions: readonly Session[],
+  projectRepoPath: string,
+  rootIndex: ReadonlyMap<string, string>,
+): Session[] {
+  return archivedSessions(sessions).filter(
+    (session) =>
+      !isLocalSession(session) &&
+      resolveProjectRootPath(rootIndex, session.repo_path) === projectRepoPath,
+  );
+}
+
+export function archivedLocalSessions(sessions: readonly Session[]): Session[] {
+  return archivedSessions(sessions).filter(isLocalSession);
+}

--- a/src/lib/sessionStatusPolling.test.ts
+++ b/src/lib/sessionStatusPolling.test.ts
@@ -116,6 +116,39 @@ describe("session status polling schedule", () => {
     ).toEqual(["active", "working", "new"]);
   });
 
+  it("skips archived sessions from due, immediate, and delay schedules", () => {
+    const now = 60_000;
+    const parked = session("parked", "working", {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    const live = session("live", "ready");
+    const lastPolledAt = new Map<string, number>();
+
+    expect(
+      selectDueSessionStatusPollIds({
+        sessions: [parked, live],
+        activeSessionId: "parked",
+        lastPolledAt,
+        now,
+      }),
+    ).toEqual(["live"]);
+    expect(
+      selectImmediateSessionStatusPollIds({
+        sessions: [parked, live],
+        activeSessionId: "parked",
+        lastPolledAt,
+      }),
+    ).toEqual(["live"]);
+    expect(
+      nextSessionStatusPollDelayMs({
+        sessions: [parked],
+        activeSessionId: "parked",
+        lastPolledAt,
+        now,
+      }),
+    ).toBeNull();
+  });
+
   it("returns the delay until the next session becomes due", () => {
     const now = 60_000;
     const sessions = [

--- a/src/lib/sessionStatusPolling.ts
+++ b/src/lib/sessionStatusPolling.ts
@@ -1,3 +1,4 @@
+import { isArchivedSession } from "./sessionArchive";
 import type { Session, SessionStatus } from "./types";
 
 export const ACTIVE_SESSION_STATUS_POLL_INTERVAL_MS = 1000;
@@ -48,6 +49,7 @@ export function selectDueSessionStatusPollIds({
 }: PollScheduleArgs): string[] {
   return sessions
     .filter((session) => {
+      if (isArchivedSession(session)) return false;
       const last = lastPolledAt.get(session.id);
       if (last === undefined) return true;
       const interval = sessionStatusPollIntervalMs(session, activeSessionId);
@@ -65,9 +67,10 @@ export function selectImmediateSessionStatusPollIds({
   return sessions
     .filter(
       (session) =>
-        session.id === activeSessionId ||
-        !lastPolledAt.has(session.id) ||
-        (includeVolatile && isVolatileSession(session)),
+        !isArchivedSession(session) &&
+        (session.id === activeSessionId ||
+          !lastPolledAt.has(session.id) ||
+          (includeVolatile && isVolatileSession(session))),
     )
     .map((session) => session.id);
 }
@@ -78,10 +81,11 @@ export function nextSessionStatusPollDelayMs({
   lastPolledAt,
   now,
 }: PollScheduleArgs): number | null {
-  if (sessions.length === 0) return null;
+  const live = sessions.filter((session) => !isArchivedSession(session));
+  if (live.length === 0) return null;
 
   let nextDelay = STABLE_SESSION_STATUS_POLL_INTERVAL_MS;
-  for (const session of sessions) {
+  for (const session of live) {
     const last = lastPolledAt.get(session.id);
     if (last === undefined) return 0;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -363,6 +363,8 @@ export interface Session {
   status_started_at?: string | null;
   created_at: string;
   updated_at: string;
+  /** When set, the session is parked and hidden from the live workspace. */
+  archived_at?: string | null;
   last_message: string | null;
   /** Ephemeral transcript/chat preview for the latest user turn. */
   last_user_message?: string | null;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,6 +9,8 @@
     "session": {
       "createFailed": "Failed to create session:",
       "removeFailed": "Failed to remove session:",
+      "archiveFailed": "Failed to archive session:",
+      "resumeFailed": "Failed to resume session:",
       "worktreeRemoved": "Worktree deleted from disk.",
       "worktreeRemovedUndo": "Removing {name} worktree in {seconds}s. Undo",
       "worktreeRestored": "Worktree restored.",
@@ -1342,7 +1344,15 @@
       "copyTranscriptPath": "Copy Transcript Path",
       "remove": "Remove",
       "removeSession": "Remove session",
-      "removeSessionMenu": "Remove Session"
+      "removeSessionMenu": "Remove Session",
+      "archiveSession": "Archive session",
+      "archiveSessionMenu": "Archive Session",
+      "resumeSession": "Resume session",
+      "resumeSessionMenu": "Resume Session"
+    },
+    "archived": {
+      "title": "Archived",
+      "empty": "No archived sessions"
     },
     "contextMenu": {
       "session": "Session",
@@ -2614,6 +2624,7 @@
     "groups": {
       "sessions": "Sessions",
       "switchSession": "Switch session",
+      "archived": "Archived",
       "activity": "Unread activity",
       "view": "View",
       "terminal": "Terminal",
@@ -2631,6 +2642,7 @@
       "addExistingProject": "Add existing project",
       "refreshSessions": "Refresh sessions",
       "switchSessionPrefix": "Switch to",
+      "resumeSessionPrefix": "Resume",
       "viewTodos": "View Todos",
       "viewCommits": "View Commits",
       "viewStaged": "View Staged",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -9,6 +9,8 @@
     "session": {
       "createFailed": "セッションの作成に失敗しました:",
       "removeFailed": "セッションを削除できませんでした:",
+      "archiveFailed": "セッションをアーカイブできませんでした:",
+      "resumeFailed": "セッションを再開できませんでした:",
       "worktreeRemoved": "ワークツリーがディスクから削除されました。",
       "worktreeRemovedUndo": "{seconds}s の {name} ワークツリーを削除しています。元に戻す",
       "worktreeRestored": "ワークツリーが復元されました。",
@@ -1342,7 +1344,15 @@
       "copyTranscriptPath": "トランスクリプトのパスをコピー",
       "remove": "削除",
       "removeSession": "セッションを削除する",
-      "removeSessionMenu": "セッションの削除"
+      "removeSessionMenu": "セッションの削除",
+      "archiveSession": "セッションをアーカイブ",
+      "archiveSessionMenu": "セッションをアーカイブ",
+      "resumeSession": "セッションを再開",
+      "resumeSessionMenu": "セッションを再開"
+    },
+    "archived": {
+      "title": "アーカイブ済み",
+      "empty": "アーカイブされたセッションはありません"
     },
     "contextMenu": {
       "session": "セッション",
@@ -2614,6 +2624,7 @@
     "groups": {
       "sessions": "セッション",
       "switchSession": "セッションの切り替え",
+      "archived": "アーカイブ済み",
       "activity": "未読アクティビティ",
       "view": "見る",
       "terminal": "ターミナル",
@@ -2631,6 +2642,7 @@
       "addExistingProject": "既存のプロジェクトを追加する",
       "refreshSessions": "セッションを更新する",
       "switchSessionPrefix": "に切り替えます",
+      "resumeSessionPrefix": "再開",
       "viewTodos": "Todo を表示する",
       "viewCommits": "コミットの表示",
       "viewStaged": "ステージングされたビュー",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -9,6 +9,8 @@
     "session": {
       "createFailed": "세션을 만들지 못했습니다:",
       "removeFailed": "세션을 제거하지 못했습니다:",
+      "archiveFailed": "세션을 보관하지 못했습니다:",
+      "resumeFailed": "세션을 다시 열지 못했습니다:",
       "worktreeRemoved": "디스크에서 워크트리를 삭제했습니다.",
       "worktreeRemovedUndo": "{seconds}초 후 {name} 워크트리를 제거합니다. 실행 취소",
       "worktreeRestored": "워크트리를 복구했습니다.",
@@ -1342,7 +1344,15 @@
       "copyTranscriptPath": "트랜스크립트 경로 복사",
       "remove": "제거",
       "removeSession": "세션 제거",
-      "removeSessionMenu": "세션 제거"
+      "removeSessionMenu": "세션 제거",
+      "archiveSession": "세션 보관",
+      "archiveSessionMenu": "세션 보관",
+      "resumeSession": "세션 다시 열기",
+      "resumeSessionMenu": "세션 다시 열기"
+    },
+    "archived": {
+      "title": "보관됨",
+      "empty": "보관한 세션이 없습니다"
     },
     "contextMenu": {
       "session": "세션",
@@ -2614,6 +2624,7 @@
     "groups": {
       "sessions": "세션",
       "switchSession": "세션 전환",
+      "archived": "보관됨",
       "activity": "새 활동",
       "view": "보기",
       "terminal": "터미널",
@@ -2631,6 +2642,7 @@
       "addExistingProject": "기존 프로젝트 추가",
       "refreshSessions": "세션 새로고침",
       "switchSessionPrefix": "전환:",
+      "resumeSessionPrefix": "다시 열기",
       "viewTodos": "할 일 보기",
       "viewCommits": "커밋 보기",
       "viewStaged": "스테이징 보기",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -9,6 +9,8 @@
     "session": {
       "createFailed": "无法创建会话：",
       "removeFailed": "无法删除会话：",
+      "archiveFailed": "无法归档会话：",
+      "resumeFailed": "无法恢复会话：",
       "worktreeRemoved": "工作树从磁盘中删除。",
       "worktreeRemovedUndo": "将在 {seconds} 秒后删除 {name} 工作树。撤销",
       "worktreeRestored": "工作树已恢复。",
@@ -1342,7 +1344,15 @@
       "copyTranscriptPath": "复制对话记录路径",
       "remove": "删除",
       "removeSession": "删除会话",
-      "removeSessionMenu": "删除会话"
+      "removeSessionMenu": "删除会话",
+      "archiveSession": "归档会话",
+      "archiveSessionMenu": "归档会话",
+      "resumeSession": "恢复会话",
+      "resumeSessionMenu": "恢复会话"
+    },
+    "archived": {
+      "title": "已归档",
+      "empty": "没有已归档的会话"
     },
     "contextMenu": {
       "session": "会话",
@@ -2614,6 +2624,7 @@
     "groups": {
       "sessions": "会话",
       "switchSession": "切换会话",
+      "archived": "已归档",
       "activity": "未读活动",
       "view": "查看",
       "terminal": "终端",
@@ -2631,6 +2642,7 @@
       "addExistingProject": "添加现有项目",
       "refreshSessions": "刷新会话",
       "switchSessionPrefix": "切换到",
+      "resumeSessionPrefix": "恢复",
       "viewTodos": "查看待办事项",
       "viewCommits": "查看提交",
       "viewStaged": "查看已暂存",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -25,6 +25,8 @@ vi.mock("./lib/api", () => {
       ),
       ptyInWorktreeAll: vi.fn(async () => ({} as Record<string, boolean>)),
       createSession: vi.fn(async () => ({}) as Session),
+      archiveSession: vi.fn(async () => ({}) as Session),
+      resumeSession: vi.fn(async () => ({}) as Session),
       removeSession: vi.fn(async () => ({
         result: null,
         removedSessionIds: [],
@@ -232,6 +234,7 @@ function resetStore(): void {
       loading: false,
       error: null,
       pendingRemoveId: null,
+      pendingArchiveId: null,
       pendingRemoveProject: null,
       sessionsLoadedCleanly: true,
       sessionListInitialized: false,
@@ -285,6 +288,8 @@ beforeEach(() => {
   mockApi.listProjects.mockResolvedValue([]);
   mockApi.detectSessionStatuses.mockResolvedValue([]);
   mockApi.removeSession.mockResolvedValue(removalOutcome(null));
+  mockApi.archiveSession.mockResolvedValue({} as Session);
+  mockApi.resumeSession.mockResolvedValue({} as Session);
   mockApi.removeWorktree.mockResolvedValue(removalOutcome(null));
   mockApi.removeProject.mockResolvedValue(removalOutcome([]));
   mockApi.loadChatSessionState.mockResolvedValue({
@@ -1712,6 +1717,78 @@ describe("workspace tabs", () => {
     expect(s.activeTabId).toBe(readmeTabId);
     expect(s.activeSessionId).toBeNull();
     expect(s.panes[s.focusedPaneId].tabIds).toEqual(["a1", readmeTabId]);
+  });
+});
+
+describe("archiveSession", () => {
+  it("drops the tab immediately and keeps the session row", async () => {
+    const a1 = session("a1", REPO_A);
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [a1, a2]);
+    useAppStore.getState().selectSession("a1");
+
+    const pending = deferred<Session>();
+    mockApi.archiveSession.mockReturnValueOnce(pending.promise);
+    const archived = {
+      ...a1,
+      archived_at: "2026-04-01T00:00:00Z",
+    };
+    mockApi.listSessions.mockResolvedValue([archived, a2]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const archive = useAppStore.getState().archiveSession("a1");
+
+    expect(mockApi.archiveSession).toHaveBeenCalledWith("a1");
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual([
+      "a1",
+      "a2",
+    ]);
+    expect(useAppStore.getState().sessions[0]?.archived_at).toBeTruthy();
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+    expect(useAppStore.getState().activeSessionId).toBe("a2");
+
+    pending.resolve(archived);
+    await archive;
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+    expect(useAppStore.getState().sessions).toHaveLength(2);
+  });
+});
+
+describe("selectSession", () => {
+  it("does not reinsert an archived session as a workspace tab", async () => {
+    const parked = session("a1", REPO_A, {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [parked, a2]);
+
+    useAppStore.getState().selectSession("a1");
+
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+    expect(useAppStore.getState().activeSessionId).toBe("a2");
+  });
+});
+
+describe("resumeSession", () => {
+  it("reopens the same session id after the backend unarchives it", async () => {
+    const parked = session("a1", REPO_A, {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [parked, a2]);
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+
+    const live = { ...parked, archived_at: null };
+    mockApi.resumeSession.mockResolvedValueOnce(live);
+    mockApi.listSessions.mockResolvedValue([live, a2]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    const resumed = await useAppStore.getState().resumeSession("a1");
+
+    expect(mockApi.resumeSession).toHaveBeenCalledWith("a1");
+    expect(resumed?.id).toBe("a1");
+    expect(useAppStore.getState().panes.root.tabIds).toContain("a1");
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -92,6 +92,7 @@ import {
   type ProjectFoldersByRepo,
   type SessionFolderAssignments,
 } from "./lib/projectFolders";
+import { isArchivedSession } from "./lib/sessionArchive";
 import { canRegenerateSessionTitle } from "./lib/sessionTitle";
 import {
   summarizeTokenUsage,
@@ -453,6 +454,7 @@ interface AppStateModel {
   loading: boolean;
   error: string | null;
   pendingRemoveId: string | null;
+  pendingArchiveId: string | null;
   pendingRemoveProject: string | null;
   /**
    * A picked source folder another project owns, awaiting the user's go-ahead
@@ -553,6 +555,8 @@ interface AppStateModel {
     id: string,
     removeWorktree?: boolean,
   ) => Promise<SessionRemovalOutcome | null>;
+  archiveSession: (id: string) => Promise<Session | null>;
+  resumeSession: (id: string) => Promise<Session | null>;
   renameSession: (id: string, name: string) => Promise<void>;
   generateSessionTitle: (
     id: string,
@@ -563,6 +567,8 @@ interface AppStateModel {
   adoptSessionWorktree: (id: string, worktreePath: string) => Promise<void>;
   requestRemoveSession: (id: string) => void;
   clearPendingRemove: () => void;
+  requestArchiveSession: (id: string) => void;
+  clearPendingArchive: () => void;
   cycleTab: (direction: 1 | -1) => void;
   selectLatestNeedsInputSession: () => boolean;
   cycleProject: (direction: 1 | -1) => void;
@@ -1093,6 +1099,7 @@ function reconcileWorkspaces(
     }
   }
   for (const session of sessions) {
+    if (isArchivedSession(session)) continue;
     if (session.project_scoped === false) {
       const folders = nextProjectFolders[session.repo_path] ?? [];
       const folderId =
@@ -1334,11 +1341,22 @@ function latestNeedsInputSessionId(
   for (const notification of state.sessionNotifications) {
     if (notification.kind !== "waiting_for_input") continue;
     const session = sessionsById.get(notification.sessionId);
-    if (session?.status === "waiting_for_input") return session.id;
+    if (
+      session &&
+      !isArchivedSession(session) &&
+      session.status === "waiting_for_input"
+    ) {
+      return session.id;
+    }
   }
   for (let index = state.sessions.length - 1; index >= 0; index -= 1) {
     const session = state.sessions[index];
-    if (session.status === "waiting_for_input") return session.id;
+    if (
+      !isArchivedSession(session) &&
+      session.status === "waiting_for_input"
+    ) {
+      return session.id;
+    }
   }
   return null;
 }
@@ -1741,6 +1759,7 @@ export const useAppStore = create<AppStateModel>()(
     return error;
   },
   pendingRemoveId: null,
+  pendingArchiveId: null,
   pendingRemoveProject: null,
   pendingSourceMerge: null,
   sessionsLoadedCleanly: true,
@@ -2013,9 +2032,12 @@ export const useAppStore = create<AppStateModel>()(
           pendingStatusPollAll = false;
           pendingStatusPollIds.clear();
 
-          const sessionIds = new Set(get().sessions.map((s) => s.id));
+          const liveSessions = get().sessions.filter(
+            (session) => !isArchivedSession(session),
+          );
+          const sessionIds = new Set(liveSessions.map((s) => s.id));
           const idsToPoll = Array.from(
-            new Set(queuedIds ?? get().sessions.map((s) => s.id)),
+            new Set(queuedIds ?? liveSessions.map((s) => s.id)),
           ).filter((id) => sessionIds.has(id));
           if (idsToPoll.length === 0) continue;
 
@@ -2255,7 +2277,7 @@ export const useAppStore = create<AppStateModel>()(
 
       // Find session, switch active project to its repo, set active in pane.
       const session = s.sessions.find((x) => x.id === id);
-      if (!session) return s;
+      if (!session || isArchivedSession(session)) return s;
 
       const folders = s.projectFolders[session.repo_path] ?? [];
       const targetProjectFolderId = resolveProjectFolderIdForSession(
@@ -2330,7 +2352,8 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   openSessionSurface(id, options) {
-    if (!get().sessions.some((session) => session.id === id)) return false;
+    const session = get().sessions.find((candidate) => candidate.id === id);
+    if (!session || isArchivedSession(session)) return false;
 
     get().selectSession(id);
     const state = get();
@@ -3365,6 +3388,82 @@ export const useAppStore = create<AppStateModel>()(
     }
   },
 
+  async archiveSession(id) {
+    const target = get().sessions.find((session) => session.id === id);
+    if (!target) return null;
+    if (isArchivedSession(target)) return target;
+
+    const archivedAt = new Date().toISOString();
+    set((s) => {
+      const sessions = s.sessions.map((session) =>
+        session.id === id ? { ...session, archived_at: archivedAt } : session,
+      );
+      const reconciled = reconcileWorkspaces(
+        sessions,
+        s.projects,
+        s.projectFolders,
+        s.sessionFolderIds,
+        s.workspaces,
+        s.activeProject,
+        s.activeProjectFolderId,
+        true,
+      );
+      return {
+        sessions,
+        error: null,
+        terminalPopupSessionId:
+          s.terminalPopupSessionId === id ? null : s.terminalPopupSessionId,
+        workspaces: reconciled.workspaces,
+        projectFolders: reconciled.projectFolders,
+        sessionFolderIds: reconciled.sessionFolderIds,
+        activeProject: reconciled.activeProject,
+        activeProjectFolderId: reconciled.activeProjectFolderId,
+        ...mirrorActive(
+          reconciled.workspaces,
+          reconciled.activeProjectFolderId,
+          {
+            sessions,
+            projects: s.projects,
+            projectFolders: reconciled.projectFolders,
+            activeProject: reconciled.activeProject,
+          },
+        ),
+      };
+    });
+
+    try {
+      const updated = await api.archiveSession(id);
+      await get().refreshAll();
+      set({ error: null });
+      return updated;
+    } catch (e) {
+      const message = errorMessage(e);
+      await get().refreshAll();
+      set({ error: message });
+      return null;
+    }
+  },
+
+  async resumeSession(id) {
+    const target = get().sessions.find((session) => session.id === id);
+    if (!target) return null;
+    if (!isArchivedSession(target)) {
+      get().openSessionSurface(id);
+      return target;
+    }
+
+    try {
+      const updated = await api.resumeSession(id);
+      await get().refreshAll();
+      set({ error: null });
+      get().openSessionSurface(id);
+      return updated;
+    } catch (e) {
+      set({ error: errorMessage(e) });
+      return null;
+    }
+  },
+
   async renameSession(id, name) {
     if (get().generatingSessionTitleIds[id]) return;
 
@@ -3447,6 +3546,14 @@ export const useAppStore = create<AppStateModel>()(
 
   clearPendingRemove() {
     set({ pendingRemoveId: null });
+  },
+
+  requestArchiveSession(id) {
+    set({ pendingArchiveId: id });
+  },
+
+  clearPendingArchive() {
+    set({ pendingArchiveId: null });
   },
 
   async addProjectAt(name, roots) {

--- a/tests/e2e/fixtures/tauriMock.ts
+++ b/tests/e2e/fixtures/tauriMock.ts
@@ -591,6 +591,18 @@ export const tauriMockSource = `
         retryToken: null,
       });
     }
+    if (cmd === 'archive_session') {
+      return Promise.resolve({
+        id: args?.id,
+        archived_at: '2026-04-01T00:00:00Z',
+      });
+    }
+    if (cmd === 'resume_session') {
+      return Promise.resolve({
+        id: args?.id,
+        archived_at: null,
+      });
+    }
     if (cmd === 'remove_project') {
       return Promise.resolve({
         result: [],

--- a/tests/e2e/session-archive.spec.ts
+++ b/tests/e2e/session-archive.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect, pressHotkey } from "./support";
+
+const PROJECT = {
+  repo_path: "/tmp/demo",
+  name: "demo",
+  created_at: "2026-01-01T00:00:00Z",
+  position: 0,
+};
+
+test.describe("session archive", () => {
+  test("archives a session from the sidebar and resumes it from Archived", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as {
+        __archived?: boolean;
+      };
+      return [
+        {
+          id: "s-1",
+          name: "alpha",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+          branch: "main",
+          isolated: true,
+          in_worktree: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          archived_at: w.__archived ? "2026-04-01T00:00:00Z" : null,
+        },
+      ];
+    });
+    await tauri.handle("archive_session", (args) => {
+      const w = window as unknown as {
+        __archiveCalls?: unknown[];
+        __archived?: boolean;
+      };
+      w.__archiveCalls = w.__archiveCalls ?? [];
+      w.__archiveCalls.push(args);
+      w.__archived = true;
+      return {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+        branch: "main",
+        isolated: true,
+        in_worktree: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        archived_at: "2026-04-01T00:00:00Z",
+      };
+    });
+    await tauri.handle("resume_session", (args) => {
+      const w = window as unknown as {
+        __resumeCalls?: unknown[];
+        __archived?: boolean;
+      };
+      w.__resumeCalls = w.__resumeCalls ?? [];
+      w.__resumeCalls.push(args);
+      w.__archived = false;
+      return {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+        branch: "main",
+        isolated: true,
+        in_worktree: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        archived_at: null,
+      };
+    });
+
+    await page.goto("/");
+
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    const row = sidebar
+      .getByRole("button", { name: /alpha.*Ready/ })
+      .first();
+    await expect(row).toBeVisible();
+
+    await row.click({ button: "right" });
+    await page
+      .getByRole("menuitem", { name: "Archive Session", exact: true })
+      .click();
+
+    await expect(
+      sidebar.getByRole("button", { name: /alpha.*Ready/ }),
+    ).toHaveCount(0);
+
+    const archiveCalls = (await page.evaluate(
+      () =>
+        (window as unknown as { __archiveCalls?: unknown[] }).__archiveCalls,
+    )) as Array<{ id: string }>;
+    expect(archiveCalls).toHaveLength(1);
+    expect(archiveCalls[0].id).toBe("s-1");
+
+    const removeCalls = await page.evaluate(
+      () =>
+        (window as unknown as { __removeCalls?: unknown[] }).__removeCalls ??
+        [],
+    );
+    expect(removeCalls).toEqual([]);
+
+    await sidebar.getByRole("button", { name: /Archived/ }).click();
+    const archivedRow = sidebar.getByRole("button", {
+      name: /alpha.*Ready/,
+    });
+    await expect(archivedRow).toBeVisible();
+    await archivedRow.click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __resumeCalls?: unknown[] }).__resumeCalls
+                ?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+    await expect(
+      sidebar.getByRole("button", { name: /alpha.*Ready/ }),
+    ).toBeVisible();
+  });
+
+  test("resumes an archived session from the command palette", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __archived?: boolean };
+      return [
+        {
+          id: "s-1",
+          name: "alpha",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+          branch: "main",
+          isolated: true,
+          in_worktree: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          archived_at:
+            w.__archived === false ? null : "2026-04-01T00:00:00Z",
+        },
+      ];
+    });
+    await tauri.handle("resume_session", (args) => {
+      const w = window as unknown as {
+        __resumeCalls?: unknown[];
+        __archived?: boolean;
+      };
+      w.__resumeCalls = w.__resumeCalls ?? [];
+      w.__resumeCalls.push(args);
+      w.__archived = false;
+      return {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+        branch: "main",
+        isolated: true,
+        in_worktree: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        archived_at: null,
+      };
+    });
+
+    await page.goto("/");
+    await pressHotkey(page, { mod: true, key: "p" });
+    await page.getByRole("option", { name: /Resume alpha/ }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __resumeCalls?: unknown[] }).__resumeCalls
+                ?.length ?? 0,
+          ),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+  });
+});

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -3351,8 +3351,9 @@ test.describe("sidebar: project lifecycle", () => {
     const terminalRow = instant.getByRole("button", { name: /^terminal-2\b/ });
     const terminalBox = await terminalRow.boundingBox();
     expect(terminalBox).not.toBeNull();
+    // Hit the title, not the trailing archive/remove actions.
     await page.mouse.click(
-      terminalBox!.x + terminalBox!.width - 40,
+      terminalBox!.x + Math.min(48, terminalBox!.width / 3),
       terminalBox!.y + terminalBox!.height / 2,
     );
 


### PR DESCRIPTION
## Summary
Park a session that cannot proceed now (waiting on a review, a teammate, or a merge) without deleting it. Resume restores the same session id, and if the worktree checkout vanished while parked, Acorn recreates it from the recorded branch.

## Expected impact
- Sidebar: Archive action on a session row; collapsed **Archived** section per project; click to resume.
- Command palette: live sessions stay under Switch session; parked sessions appear as Resume.
- Kanban/canvas and status polling ignore parked sessions (they have no PTY).
- Isolated/linked worktree sessions keep their checkout on disk; resume prefers the original path, then a free worktree for the same branch.

## Design notes
- Archive is `archived_at` on the session row, not a new `SessionStatus`. Status stays agent lifecycle.
- `list_sessions` no longer rewrites a missing worktree back to the main repo for parked sessions, so resume still has a path to restore.
- Agent conversation continue uses the existing resume modal / auto-resume path. This does not mint a new session the way history-panel resume does.
- `selectTab` refuses to reinsert a parked session as a workspace tab.

## Follow-up (not in this PR)
- Auto-archive by inactivity or PR merge.
- Recreating a worktree when the git branch itself is gone.
- Keeping the PTY alive while archived.

## Test plan
- [x] `pnpm exec vitest run src/lib/sessionArchive.test.ts src/lib/sessionStatusPolling.test.ts src/lib/projectFolders.test.ts src/store.test.ts src/lib/i18n.test.ts` — pass
- [x] `pnpm exec vitest run src/store.test.ts` after selectTab guard — 182 pass
- [x] `pnpm run typecheck` — pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-session -- archive` — 2 pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib restore_session_worktree` — 4 pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib archive_session` / `resume_session` / `stale_worktree_reconcile` — pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib worktree::tests` — 50 pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml -p acorn-ipc` — 38 pass
- [x] `pnpm exec playwright test tests/e2e/session-archive.spec.ts` — 2 pass
- [x] `pnpm exec playwright test tests/e2e/session-lifecycle.spec.ts tests/e2e/command-palette.spec.ts` — 16 pass

## Notes
- Changelog label: `feat`