### PR TITLE
feat(sidebar): park minimized sessions at the bottom of the list

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,7 +18,9 @@ import {
   GitPullRequest,
   Home,
   LayoutPanelLeft,
+  Maximize2,
   MessageSquareText,
+  Minimize2,
   MoreHorizontal,
   Pencil,
   PencilLine,
@@ -153,6 +155,8 @@ import {
   buildDragPriorityIndex,
   buildProjectTopLevelItems,
   orderSessionsByPriority,
+  partitionProjectTopLevelItems,
+  partitionSidebarSessions,
   planProjectTopLevelDrag,
   refuseCrossPriorityGroupDrop,
   type ProjectTopLevelFolderItem,
@@ -179,6 +183,10 @@ import {
   planTitleClick,
   type ProjectClickPlan,
 } from "../lib/sidebar-actions";
+import {
+  collectMinimizedTabIds,
+  isTabMinimizedInWorkspaces,
+} from "../lib/paneTabs";
 import { pullRequestNumberClassName } from "../lib/pullRequestPresentation";
 import type {
   Session,
@@ -273,6 +281,45 @@ type SidebarContextMenuGroup =
   | "open"
   | "copy"
   | "danger";
+
+function minimizeSessionMenuItem(
+  t: Translator,
+  minimized: boolean,
+  onToggle: () => void,
+): ContextMenuItem {
+  return {
+    label: sidebarText(
+      t,
+      minimized ? "sidebar.actions.expandTab" : "sidebar.actions.minimizeTab",
+    ),
+    icon: minimized ? <Maximize2 size={12} /> : <Minimize2 size={12} />,
+    onClick: onToggle,
+  };
+}
+
+function useMinimizedTabIdSet(): Set<string> {
+  const workspaces = useAppStore((s) => s.workspaces);
+  return useMemo(() => collectMinimizedTabIds(workspaces), [workspaces]);
+}
+
+function MinimizedSessionStrip({ children }: { children: ReactNode }) {
+  const t = useTranslation();
+  return (
+    <li className="px-0.5 py-0.5">
+      <ul
+        data-sidebar-minimized-strip=""
+        className="flex flex-wrap gap-0.5"
+        aria-label={sidebarText(t, "sidebar.aria.minimizedSessions")}
+      >
+        {children}
+      </ul>
+    </li>
+  );
+}
+
+function SessionListDivider() {
+  return <li className="mx-1.5 my-0.5 h-px bg-border" aria-hidden />;
+}
 
 function contextMenuGroupTitle(
   t: Translator,
@@ -1816,9 +1863,19 @@ function SessionRowPreview({
     sessionDisplay.metadata,
   );
   const agentProvider = resolveSessionAgentProvider(session);
+  const minimized = useAppStore((s) =>
+    isTabMinimizedInWorkspaces(s.workspaces, session.id),
+  );
 
   return (
-    <div className="flex w-full items-start gap-1.5 rounded-md bg-bg-elevated/95 px-2 py-1 shadow-lg ring-1 ring-border/60">
+    <div
+      className={cn(
+        "flex rounded-md bg-bg-elevated/95 shadow-lg ring-1 ring-border/60",
+        minimized
+          ? "size-7 items-center justify-center"
+          : "w-full items-start gap-1.5 px-2 py-1",
+      )}
+    >
       <SessionStatusMarker
         session={session}
         agentProvider={agentProvider}
@@ -1827,16 +1884,18 @@ function SessionRowPreview({
         chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
         goalLabel={sidebarText(t, "sidebar.aria.goalSession")}
       />
-      <SessionRowLabel
-        editing={false}
-        session={session}
-        titleText={titleText}
-        metadataText={metadataText}
-        currentPullRequest={null}
-        t={t}
-        onSubmitRename={() => undefined}
-        onCancelRename={() => undefined}
-      />
+      {minimized ? null : (
+        <SessionRowLabel
+          editing={false}
+          session={session}
+          titleText={titleText}
+          metadataText={metadataText}
+          currentPullRequest={null}
+          t={t}
+          onSubmitRename={() => undefined}
+          onCancelRename={() => undefined}
+        />
+      )}
     </div>
   );
 }
@@ -2489,6 +2548,11 @@ function ProjectGroupView({
       ),
     [prioritizeNeedsInputTabs, project, topLevelOrder],
   );
+  const minimizedIds = useMinimizedTabIdSet();
+  const { minimizedSessions, rest: restTopLevelItems } = useMemo(
+    () => partitionProjectTopLevelItems(topLevelItems, minimizedIds),
+    [minimizedIds, topLevelItems],
+  );
   const topLevelItemIds = useMemo(
     () => topLevelItems.map((item) => item.id),
     [topLevelItems],
@@ -2739,7 +2803,8 @@ function ProjectGroupView({
                 {sidebarText(t, "sidebar.emptyProject.createSession")}
               </li>
             ) : (
-              topLevelItems.map((item) =>
+              <>
+              {restTopLevelItems.map((item) =>
                 item.type === "session" ? (
                   <SessionRow
                     key={item.id}
@@ -2807,7 +2872,29 @@ function ProjectGroupView({
                     onMoveSessionToFolder={onMoveSessionToFolder}
                   />
                 ),
-              )
+              )}
+              {minimizedSessions.length > 0 && restTopLevelItems.length > 0 ? (
+                <SessionListDivider />
+              ) : null}
+              {minimizedSessions.length > 0 ? (
+                <MinimizedSessionStrip>
+                  {minimizedSessions.map((item) => (
+                    <SessionRow
+                      key={item.id}
+                      session={item.session}
+                      active={item.session.id === activeSessionId}
+                      onSelect={() =>
+                        onSelectSession(item.folderId, item.session.id)
+                      }
+                      onRemove={() => onRemoveSession(item.session)}
+                      projectFolders={projectFoldersForRows}
+                      currentProjectFolderId={item.folderId}
+                      onMoveToProjectFolder={onMoveSessionToFolder}
+                    />
+                  ))}
+                </MinimizedSessionStrip>
+              ) : null}
+              </>
             )}
           </SortableContext>
           {!defaultFolderGroup && namedFolderGroups.length === 0 ? (
@@ -2926,6 +3013,11 @@ function ProjectFolderView({
     () =>
       orderSessionsByPriority(folderGroup.sessions, prioritizeNeedsInputTabs),
     [folderGroup.sessions, prioritizeNeedsInputTabs],
+  );
+  const minimizedIds = useMinimizedTabIdSet();
+  const { minimized: minimizedSessions, expanded: expandedSessions } = useMemo(
+    () => partitionSidebarSessions(orderedSessions, minimizedIds),
+    [minimizedIds, orderedSessions],
   );
   const sessionIds = useMemo(
     () => orderedSessions.map((s) => sessionDragId(s.id)),
@@ -3299,18 +3391,39 @@ function ProjectFolderView({
                 {sidebarText(t, "sidebar.emptyProjectFolder.noSessions")}
               </li>
             ) : (
-              orderedSessions.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  active={session.id === activeSessionId}
-                  onSelect={() => onSelectSession(session.id)}
-                  onRemove={() => onRemoveSession(session)}
-                  projectFolders={projectFolders}
-                  currentProjectFolderId={folder.id}
-                  onMoveToProjectFolder={onMoveSessionToFolder}
-                />
-              ))
+              <>
+                {expandedSessions.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    active={session.id === activeSessionId}
+                    onSelect={() => onSelectSession(session.id)}
+                    onRemove={() => onRemoveSession(session)}
+                    projectFolders={projectFolders}
+                    currentProjectFolderId={folder.id}
+                    onMoveToProjectFolder={onMoveSessionToFolder}
+                  />
+                ))}
+                {minimizedSessions.length > 0 && expandedSessions.length > 0 ? (
+                  <SessionListDivider />
+                ) : null}
+                {minimizedSessions.length > 0 ? (
+                  <MinimizedSessionStrip>
+                    {minimizedSessions.map((session) => (
+                      <SessionRow
+                        key={session.id}
+                        session={session}
+                        active={session.id === activeSessionId}
+                        onSelect={() => onSelectSession(session.id)}
+                        onRemove={() => onRemoveSession(session)}
+                        projectFolders={projectFolders}
+                        currentProjectFolderId={folder.id}
+                        onMoveToProjectFolder={onMoveSessionToFolder}
+                      />
+                    ))}
+                  </MinimizedSessionStrip>
+                ) : null}
+              </>
             )}
           </ul>
         </SortableContext>
@@ -3350,6 +3463,10 @@ function SessionRow({
     Boolean(s.silencedSessionIds[session.id]),
   );
   const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
+  const setTabMinimized = useAppStore((s) => s.setTabMinimized);
+  const minimized = useAppStore((s) =>
+    isTabMinimizedInWorkspaces(s.workspaces, session.id),
+  );
   const createSession = useAppStore((s) => s.createSession);
   const selectSession = useAppStore((s) => s.selectSession);
   const requestArchiveSession = useAppStore((s) => s.requestArchiveSession);
@@ -3412,6 +3529,7 @@ function SessionRow({
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [agent, setAgent] = useState<SessionAgentDetection | null>(null);
+  const showMinimized = minimized && !editing;
   const {
     attributes,
     listeners,
@@ -3633,6 +3751,9 @@ function SessionRow({
       icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
       onClick: () => setSessionSilenced(session.id, !sessionSilenced),
     },
+    minimizeSessionMenuItem(t, minimized, () =>
+      setTabMinimized(session.id, !minimized),
+    ),
     ...(forkItems.length > 0
       ? [contextMenuGroupTitle(t, "fork"), ...forkItems]
       : []),
@@ -3721,6 +3842,7 @@ function SessionRow({
       }}
       onDoubleClick={(e) => {
         e.stopPropagation();
+        if (showMinimized) return;
         if (canRename) setEditing(true);
       }}
       onKeyDown={(e) => {
@@ -3745,14 +3867,20 @@ function SessionRow({
         e.stopPropagation();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
+      data-sidebar-session={session.id}
+      data-session-minimized={showMinimized ? "true" : undefined}
+      aria-label={showMinimized ? titleText : undefined}
       className={listRowClassName({
-        density: "sidebar",
+        density: showMinimized ? "none" : "sidebar",
         interactive: true,
         selected: active,
         selectedClassName: "acorn-tab-active-bg text-fg shadow-sm",
         surface: "sidebar",
         className: cn(
-          "group flex w-full cursor-pointer items-start gap-1.5 text-left",
+          "group flex cursor-pointer text-left",
+          showMinimized
+            ? "size-7 items-center justify-center"
+            : "w-full items-start gap-1.5",
           isDragging && "opacity-40",
         ),
       })}
@@ -3765,63 +3893,73 @@ function SessionRow({
         chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
         goalLabel={sidebarText(t, "sidebar.aria.goalSession")}
       />
-      <SessionRowLabel
-        editing={editing}
-        session={session}
-        titleText={titleText}
-        metadataText={metadataText}
-        currentPullRequest={currentPullRequest}
-        hideWorktreeIcon={hideWorkspaceDuplicateContext}
-        t={t}
-        onSubmitRename={async (next) => {
-          setEditing(false);
-          if (canRename && next && next !== session.name) {
-            await renameSession(session.id, next);
-            const error = useAppStore.getState().consumeError();
-            if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
-          }
-        }}
-        onCancelRename={() => setEditing(false)}
-      />
-      <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
-        <button
-          type="button"
-          aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            requestArchiveSession(session.id);
+      {showMinimized ? null : (
+        <SessionRowLabel
+          editing={editing}
+          session={session}
+          titleText={titleText}
+          metadataText={metadataText}
+          currentPullRequest={currentPullRequest}
+          hideWorktreeIcon={hideWorkspaceDuplicateContext}
+          t={t}
+          onSubmitRename={async (next) => {
+            setEditing(false);
+            if (canRename && next && next !== session.name) {
+              await renameSession(session.id, next);
+              const error = useAppStore.getState().consumeError();
+              if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
+            }
           }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-        >
-          <Archive size={12} />
-        </button>
-        <button
-          type="button"
-          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
-        >
-          <Trash2 size={12} />
-        </button>
-      </div>
+          onCancelRename={() => setEditing(false)}
+        />
+      )}
+      {showMinimized ? null : (
+        <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              requestArchiveSession(session.id);
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Archive size={12} />
+          </button>
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
     </div>
   );
 
+  const tooltipLabel = hoverDetails ?? (showMinimized ? titleText : null);
+
   return (
-    <li ref={setNodeRef} style={style}>
-      {hoverDetails ? (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={showMinimized ? "w-fit" : undefined}
+    >
+      {tooltipLabel ? (
         <Tooltip
-          label={hoverDetails}
+          label={tooltipLabel}
           side="right"
-          multiline
-          className="flex! w-full"
+          multiline={Boolean(hoverDetails)}
+          className={showMinimized ? "flex!" : "flex! w-full"}
         >
           {row}
         </Tooltip>
@@ -4299,6 +4437,11 @@ function LocalTerminalArea({
     () => sessions.map((s) => sessionDragId(s.id)),
     [sessions],
   );
+  const minimizedIds = useMinimizedTabIdSet();
+  const { minimized: minimizedSessions, expanded: expandedSessions } = useMemo(
+    () => partitionSidebarSessions(sessions, minimizedIds),
+    [minimizedIds, sessions],
+  );
 
   return (
     <section
@@ -4372,7 +4515,7 @@ function LocalTerminalArea({
                 text: "none",
               })}
             >
-              {sessions.map((session) => (
+              {expandedSessions.map((session) => (
                 <LocalSessionRow
                   key={session.id}
                   session={session}
@@ -4381,6 +4524,22 @@ function LocalTerminalArea({
                   onRemove={() => onRemoveSession(session)}
                 />
               ))}
+              {minimizedSessions.length > 0 && expandedSessions.length > 0 ? (
+                <SessionListDivider />
+              ) : null}
+              {minimizedSessions.length > 0 ? (
+                <MinimizedSessionStrip>
+                  {minimizedSessions.map((session) => (
+                    <LocalSessionRow
+                      key={session.id}
+                      session={session}
+                      active={session.id === activeSessionId}
+                      onSelect={() => onSelectSession(session.id)}
+                      onRemove={() => onRemoveSession(session)}
+                    />
+                  ))}
+                </MinimizedSessionStrip>
+              ) : null}
             </ul>
           </SortableContext>
         </div>
@@ -4858,6 +5017,11 @@ function LocalWorkspaceView({
     () => folderGroup.sessions.map((session) => sessionDragId(session.id)),
     [folderGroup.sessions],
   );
+  const minimizedIds = useMinimizedTabIdSet();
+  const { minimized: minimizedSessions, expanded: expandedSessions } = useMemo(
+    () => partitionSidebarSessions(folderGroup.sessions, minimizedIds),
+    [folderGroup.sessions, minimizedIds],
+  );
   const workspaceLabel = workspacePathLabel(folder);
 
   function submitRename(next: string) {
@@ -5065,18 +5229,39 @@ function LocalWorkspaceView({
                 {sidebarText(t, "sidebar.emptyProjectFolder.noSessions")}
               </li>
             ) : (
-              folderGroup.sessions.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  active={session.id === activeSessionId}
-                  onSelect={() => onSelectSession(session.id)}
-                  onRemove={() => onRemoveSession(session)}
-                  projectFolders={projectFolders}
-                  currentProjectFolderId={folder.id}
-                  onMoveToProjectFolder={onMoveSessionToFolder}
-                />
-              ))
+              <>
+                {expandedSessions.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    active={session.id === activeSessionId}
+                    onSelect={() => onSelectSession(session.id)}
+                    onRemove={() => onRemoveSession(session)}
+                    projectFolders={projectFolders}
+                    currentProjectFolderId={folder.id}
+                    onMoveToProjectFolder={onMoveSessionToFolder}
+                  />
+                ))}
+                {minimizedSessions.length > 0 && expandedSessions.length > 0 ? (
+                  <SessionListDivider />
+                ) : null}
+                {minimizedSessions.length > 0 ? (
+                  <MinimizedSessionStrip>
+                    {minimizedSessions.map((session) => (
+                      <SessionRow
+                        key={session.id}
+                        session={session}
+                        active={session.id === activeSessionId}
+                        onSelect={() => onSelectSession(session.id)}
+                        onRemove={() => onRemoveSession(session)}
+                        projectFolders={projectFolders}
+                        currentProjectFolderId={folder.id}
+                        onMoveToProjectFolder={onMoveSessionToFolder}
+                      />
+                    ))}
+                  </MinimizedSessionStrip>
+                ) : null}
+              </>
             )}
           </ul>
         </SortableContext>
@@ -5111,6 +5296,10 @@ function LocalSessionRow({
     Boolean(s.silencedSessionIds[session.id]),
   );
   const setSessionSilenced = useAppStore((s) => s.setSessionSilenced);
+  const setTabMinimized = useAppStore((s) => s.setTabMinimized);
+  const minimized = useAppStore((s) =>
+    isTabMinimizedInWorkspaces(s.workspaces, session.id),
+  );
   const sessionDisplay = useSettings((s) => s.settings.sessionDisplay);
   const currentPullRequest = useCurrentPullRequest(session);
   const titleText = resolveSessionTitle(session, sessionDisplay.title);
@@ -5136,6 +5325,7 @@ function LocalSessionRow({
   );
   const [editing, setEditing] = useState(false);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+  const showMinimized = minimized && !editing;
   const {
     attributes,
     listeners,
@@ -5204,6 +5394,9 @@ function LocalSessionRow({
       icon: sessionSilenced ? <Bell size={12} /> : <BellOff size={12} />,
       onClick: () => setSessionSilenced(session.id, !sessionSilenced),
     },
+    minimizeSessionMenuItem(t, minimized, () =>
+      setTabMinimized(session.id, !minimized),
+    ),
     ...(canCreateWorktreeWorkspace
       ? [
           { type: "separator" as const },
@@ -5263,6 +5456,7 @@ function LocalSessionRow({
       }}
       onDoubleClick={(e) => {
         e.stopPropagation();
+        if (showMinimized) return;
         if (canRename) setEditing(true);
       }}
       onKeyDown={(e) => {
@@ -5287,14 +5481,20 @@ function LocalSessionRow({
         e.stopPropagation();
         setMenu({ x: e.clientX, y: e.clientY });
       }}
+      data-sidebar-session={session.id}
+      data-session-minimized={showMinimized ? "true" : undefined}
+      aria-label={showMinimized ? titleText : undefined}
       className={listRowClassName({
-        density: "sidebar",
+        density: showMinimized ? "none" : "sidebar",
         interactive: true,
         selected: active,
         selectedClassName: "acorn-tab-active-bg text-fg shadow-sm",
         surface: "sidebar",
         className: cn(
-          "group flex w-full cursor-pointer items-start gap-1.5 text-left",
+          "group flex cursor-pointer text-left",
+          showMinimized
+            ? "size-7 items-center justify-center"
+            : "w-full items-start gap-1.5",
           isDragging && "opacity-40",
         ),
       })}
@@ -5307,62 +5507,72 @@ function LocalSessionRow({
         chatLabel={sidebarText(t, "sidebar.aria.chatSession")}
         goalLabel={sidebarText(t, "sidebar.aria.goalSession")}
       />
-      <SessionRowLabel
-        editing={editing}
-        session={session}
-        titleText={titleText}
-        metadataText={metadataText}
-        currentPullRequest={currentPullRequest}
-        t={t}
-        onSubmitRename={async (next) => {
-          setEditing(false);
-          if (canRename && next && next !== session.name) {
-            await renameSession(session.id, next);
-            const error = useAppStore.getState().consumeError();
-            if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
-          }
-        }}
-        onCancelRename={() => setEditing(false)}
-      />
-      <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
-        <button
-          type="button"
-          aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            requestArchiveSession(session.id);
+      {showMinimized ? null : (
+        <SessionRowLabel
+          editing={editing}
+          session={session}
+          titleText={titleText}
+          metadataText={metadataText}
+          currentPullRequest={currentPullRequest}
+          t={t}
+          onSubmitRename={async (next) => {
+            setEditing(false);
+            if (canRename && next && next !== session.name) {
+              await renameSession(session.id, next);
+              const error = useAppStore.getState().consumeError();
+              if (error) showToast(`${t("toasts.session.renameFailed")} ${error}`);
+            }
           }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
-        >
-          <Archive size={12} />
-        </button>
-        <button
-          type="button"
-          aria-label={sidebarText(t, "sidebar.actions.removeSession")}
-          onPointerDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-          onKeyDown={(e) => e.stopPropagation()}
-          className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
-        >
-          <Trash2 size={12} />
-        </button>
-      </div>
+          onCancelRename={() => setEditing(false)}
+        />
+      )}
+      {showMinimized ? null : (
+        <div className="ml-auto hidden shrink-0 items-center gap-0.5 group-hover:flex">
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.archiveSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              requestArchiveSession(session.id);
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-fg"
+          >
+            <Archive size={12} />
+          </button>
+          <button
+            type="button"
+            aria-label={sidebarText(t, "sidebar.actions.removeSession")}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            onKeyDown={(e) => e.stopPropagation()}
+            className="flex size-5 items-center justify-center rounded text-fg-muted transition hover:bg-bg-elevated hover:text-danger"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
     </div>
   );
 
+  const tooltipLabel = hoverDetails ?? (showMinimized ? titleText : null);
+
   return (
-    <li ref={setNodeRef} style={style}>
-      {hoverDetails ? (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className={showMinimized ? "w-fit" : undefined}
+    >
+      {tooltipLabel ? (
         <Tooltip
-          label={hoverDetails}
+          label={tooltipLabel}
           side="right"
-          multiline
-          className="flex! w-full"
+          multiline={Boolean(hoverDetails)}
+          className={showMinimized ? "flex!" : "flex! w-full"}
         >
           {row}
         </Tooltip>

--- a/src/lib/paneTabs.test.ts
+++ b/src/lib/paneTabs.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   applyTabMinimized,
   clampTabInsertIndex,
+  collectMinimizedTabIds,
+  isTabMinimizedInWorkspaces,
   mergeMinimizedTabIds,
   normalizeMinimizedTabIds,
   partitionTabIds,
@@ -97,5 +99,34 @@ describe("partition and merge", () => {
     expect(
       mergeMinimizedTabIds(["a"], ["c", "a"], ["a", "b", "c"]),
     ).toEqual(["a", "c"]);
+  });
+});
+
+describe("isTabMinimizedInWorkspaces", () => {
+  it("finds a minimized tab in any workspace pane", () => {
+    expect(
+      isTabMinimizedInWorkspaces(
+        {
+          a: { panes: { p1: { minimizedTabIds: ["x"] } } },
+          b: { panes: { p2: { minimizedTabIds: ["y"] } } },
+        },
+        "y",
+      ),
+    ).toBe(true);
+    expect(
+      isTabMinimizedInWorkspaces(
+        { a: { panes: { p1: { minimizedTabIds: ["x"] } } } },
+        "missing",
+      ),
+    ).toBe(false);
+  });
+
+  it("collects unique minimized ids across panes", () => {
+    expect([
+      ...collectMinimizedTabIds({
+        a: { panes: { p1: { minimizedTabIds: ["x", "y"] } } },
+        b: { panes: { p2: { minimizedTabIds: ["y", "z"] } } },
+      }),
+    ]).toEqual(["x", "y", "z"]);
   });
 });

--- a/src/lib/paneTabs.ts
+++ b/src/lib/paneTabs.ts
@@ -100,3 +100,28 @@ export function mergeMinimizedTabIds(
   ];
   return normalizeMinimizedTabIds(merged, tabIds);
 }
+
+export function collectMinimizedTabIds(
+  workspaces: Record<
+    string,
+    { panes: Record<string, { minimizedTabIds?: readonly string[] }> }
+  >,
+): Set<string> {
+  const ids = new Set<string>();
+  for (const workspace of Object.values(workspaces)) {
+    for (const pane of Object.values(workspace.panes)) {
+      for (const id of pane.minimizedTabIds ?? []) ids.add(id);
+    }
+  }
+  return ids;
+}
+
+export function isTabMinimizedInWorkspaces(
+  workspaces: Record<
+    string,
+    { panes: Record<string, { minimizedTabIds?: readonly string[] }> }
+  >,
+  tabId: string,
+): boolean {
+  return collectMinimizedTabIds(workspaces).has(tabId);
+}

--- a/src/lib/sidebarProjectItems.test.ts
+++ b/src/lib/sidebarProjectItems.test.ts
@@ -5,6 +5,8 @@ import {
   isPriorityDropAllowed,
   orderSessionsByPriority,
   orderProjectTopLevelItems,
+  partitionProjectTopLevelItems,
+  partitionSidebarSessions,
   planProjectTopLevelDrag,
   refuseCrossPriorityGroupDrop,
 } from "./sidebarProjectItems";
@@ -492,5 +494,50 @@ describe("sidebar project items", () => {
       "needs",
       "working",
     ]);
+  });
+
+  it("parks minimized sessions without reordering within each group", () => {
+    const sessions = [
+      session("a"),
+      session("b"),
+      session("c"),
+      session("d"),
+    ];
+    expect(
+      partitionSidebarSessions(sessions, new Set(["c", "a"])),
+    ).toEqual({
+      minimized: [sessions[0], sessions[2]],
+      expanded: [sessions[1], sessions[3]],
+    });
+  });
+
+  it("parks minimized top-level sessions and leaves folders in place", () => {
+    const ready = session("ready");
+    const pinned = session("pinned");
+    const items = buildProjectTopLevelItems(
+      {
+        repoPath: "/repo/app",
+        name: "app",
+        sessions: [ready, pinned],
+        folders: [
+          {
+            folder: makeDefaultProjectFolder("/repo/app"),
+            sessions: [ready, pinned],
+          },
+          folderGroup("feature", [session("other")]),
+        ],
+      },
+      [],
+    );
+    const { minimizedSessions, rest } = partitionProjectTopLevelItems(
+      items,
+      new Set(["pinned"]),
+    );
+    expect(minimizedSessions.map((item) => item.session.id)).toEqual(["pinned"]);
+    expect(
+      rest.map((item) =>
+        item.type === "session" ? item.session.id : item.folderGroup.folder.id,
+      ),
+    ).toEqual(["ready", "feature"]);
   });
 });

--- a/src/lib/sidebarProjectItems.ts
+++ b/src/lib/sidebarProjectItems.ts
@@ -231,6 +231,38 @@ export function orderSessionsByPriority(
   return stablePartition(sessions, hasPriorityStatus);
 }
 
+export function partitionSidebarSessions(
+  sessions: readonly Session[],
+  minimizedIds: ReadonlySet<string>,
+): { minimized: Session[]; expanded: Session[] } {
+  const minimized: Session[] = [];
+  const expanded: Session[] = [];
+  for (const session of sessions) {
+    if (minimizedIds.has(session.id)) minimized.push(session);
+    else expanded.push(session);
+  }
+  return { minimized, expanded };
+}
+
+export function partitionProjectTopLevelItems(
+  items: readonly ProjectTopLevelItem[],
+  minimizedIds: ReadonlySet<string>,
+): {
+  minimizedSessions: ProjectTopLevelSessionItem[];
+  rest: ProjectTopLevelItem[];
+} {
+  const minimizedSessions: ProjectTopLevelSessionItem[] = [];
+  const rest: ProjectTopLevelItem[] = [];
+  for (const item of items) {
+    if (item.type === "session" && minimizedIds.has(item.session.id)) {
+      minimizedSessions.push(item);
+    } else {
+      rest.push(item);
+    }
+  }
+  return { minimizedSessions, rest };
+}
+
 function orderItemsByPriority(
   items: readonly ProjectTopLevelItem[],
 ): ProjectTopLevelItem[] {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1323,6 +1323,8 @@
       "openWorkSummary": "Open Work Summary",
       "silenceNotifications": "Silence Notifications",
       "resumeNotifications": "Resume Notifications",
+      "minimizeTab": "Minimize Tab",
+      "expandTab": "Expand Tab",
       "forkClaudeSession": "Fork Claude Session",
       "forkSession": "Fork Session",
       "forkClaudeInNewWorktree": "Fork Claude in New Worktree",
@@ -1384,7 +1386,8 @@
       "controlSession": "control session",
       "chatSession": "chat session",
       "generatingSessionTitle": "Generating session title",
-      "notificationsSilenced": "Notifications silenced"
+      "notificationsSilenced": "Notifications silenced",
+      "minimizedSessions": "Minimized sessions"
     },
     "localTerminals": {
       "title": "Instant Sessions",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1323,6 +1323,8 @@
       "openWorkSummary": "オープンワークの概要",
       "silenceNotifications": "通知をサイレントにする",
       "resumeNotifications": "再開通知",
+      "minimizeTab": "タブを最小化",
+      "expandTab": "タブを展開",
       "forkClaudeSession": "フォーク・クロード・セッション",
       "forkSession": "フォークセッション",
       "forkClaudeInNewWorktree": "新しいワークツリーのフォーク クロード",
@@ -1384,7 +1386,8 @@
       "controlSession": "コントロールセッション",
       "chatSession": "チャットセッション",
       "generatingSessionTitle": "セッションタイトルの生成",
-      "notificationsSilenced": "通知をサイレントにしました"
+      "notificationsSilenced": "通知をサイレントにしました",
+      "minimizedSessions": "最小化されたセッション"
     },
     "localTerminals": {
       "title": "インスタントセッション",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1323,6 +1323,8 @@
       "openWorkSummary": "작업 요약 열기",
       "silenceNotifications": "알림 끄기",
       "resumeNotifications": "알림 다시 켜기",
+      "minimizeTab": "탭 최소화",
+      "expandTab": "탭 확장",
       "forkClaudeSession": "Claude 세션 포크",
       "forkSession": "세션 포크",
       "forkClaudeInNewWorktree": "새 워크트리에 Claude 포크",
@@ -1384,7 +1386,8 @@
       "controlSession": "컨트롤 세션",
       "chatSession": "채팅 세션",
       "generatingSessionTitle": "세션 제목 생성 중",
-      "notificationsSilenced": "알림 꺼짐"
+      "notificationsSilenced": "알림 꺼짐",
+      "minimizedSessions": "최소화된 세션"
     },
     "localTerminals": {
       "title": "인스턴트 세션",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1323,6 +1323,8 @@
       "openWorkSummary": "打开工作摘要",
       "silenceNotifications": "静音通知",
       "resumeNotifications": "恢复通知",
+      "minimizeTab": "最小化标签页",
+      "expandTab": "展开标签页",
       "forkClaudeSession": "派生 Claude 会话",
       "forkSession": "派生会话",
       "forkClaudeInNewWorktree": "在新工作树中派生 Claude",
@@ -1384,7 +1386,8 @@
       "controlSession": "控制会话",
       "chatSession": "聊天会话",
       "generatingSessionTitle": "生成会话标题",
-      "notificationsSilenced": "通知已静音"
+      "notificationsSilenced": "通知已静音",
+      "minimizedSessions": "已最小化的会话"
     },
     "localTerminals": {
       "title": "即时会话",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -2524,6 +2524,29 @@ describe("setTabMinimized", () => {
     expect(pane.tabIds).toEqual(["a1", "a2", "a4", "a3"]);
     expect(pane.minimizedTabIds).toEqual(["a1", "a2"]);
   });
+
+  it("minimizes a tab in a non-active workspace without switching projects", async () => {
+    await seed(
+      [project(REPO_A, 0), project(REPO_B, 1)],
+      [session("a1", REPO_A), session("b1", REPO_B), session("b2", REPO_B)],
+    );
+    useAppStore.getState().selectSession("a1");
+    expect(useAppStore.getState().activeProject).toBe(REPO_A);
+
+    useAppStore.getState().setTabMinimized("b2", true);
+
+    expect(useAppStore.getState().activeProject).toBe(REPO_A);
+    expect(
+      useAppStore.getState().panes[useAppStore.getState().focusedPaneId]
+        .minimizedTabIds,
+    ).toBeUndefined();
+    const pane = useAppStore.getState().workspaces[REPO_B]?.panes;
+    const owner = Object.values(pane ?? {}).find((candidate) =>
+      candidate.tabIds.includes("b2"),
+    );
+    expect(owner?.minimizedTabIds).toEqual(["b2"]);
+    expect(owner?.tabIds[0]).toBe("b2");
+  });
 });
 
 describe("closePane", () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -3048,34 +3048,48 @@ export const useAppStore = create<AppStateModel>()(
 
   setTabMinimized(tabId, minimized) {
     set((s) => {
-      const patch = updateActiveWorkspace(s, (ws) => {
-        const paneId = findPaneContainingTab(ws.panes, tabId);
-        if (!paneId) return ws;
-        const pane = ws.panes[paneId];
-        const next = applyTabMinimized(
-          pane.tabIds,
-          pane.minimizedTabIds ?? [],
-          tabId,
-          minimized,
-        );
-        const currentMinimized = pane.minimizedTabIds ?? [];
-        if (
-          next.tabIds.length === pane.tabIds.length &&
-          next.tabIds.every((id, index) => id === pane.tabIds[index]) &&
-          next.minimizedTabIds.length === currentMinimized.length &&
-          next.minimizedTabIds.every((id, index) => id === currentMinimized[index])
-        ) {
-          return ws;
-        }
-        return {
+      const owner = findTabOwner(s, tabId);
+      if (!owner) return s;
+      const ws = s.workspaces[owner.projectFolderId];
+      if (!ws) return s;
+      const pane = ws.panes[owner.paneId];
+      if (!pane) return s;
+      const next = applyTabMinimized(
+        pane.tabIds,
+        pane.minimizedTabIds ?? [],
+        tabId,
+        minimized,
+      );
+      const currentMinimized = pane.minimizedTabIds ?? [];
+      if (
+        next.tabIds.length === pane.tabIds.length &&
+        next.tabIds.every((id, index) => id === pane.tabIds[index]) &&
+        next.minimizedTabIds.length === currentMinimized.length &&
+        next.minimizedTabIds.every((id, index) => id === currentMinimized[index])
+      ) {
+        return s;
+      }
+      const workspaces = {
+        ...s.workspaces,
+        [owner.projectFolderId]: {
           ...ws,
           panes: {
             ...ws.panes,
-            [paneId]: withMinimizedTabIds(pane, next.tabIds, next.minimizedTabIds),
+            [owner.paneId]: withMinimizedTabIds(
+              pane,
+              next.tabIds,
+              next.minimizedTabIds,
+            ),
           },
-        };
-      });
-      return patch ?? s;
+        },
+      };
+      if (activeWorkspaceId(s) !== owner.projectFolderId) {
+        return { workspaces };
+      }
+      return {
+        workspaces,
+        ...mirrorActive(workspaces, owner.projectFolderId, s),
+      };
     });
   },
 

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -836,6 +836,16 @@ test.describe("pane / sidebar shortcuts", () => {
     await expect(betaTab).toHaveAttribute("data-tab-minimized", "true");
     await expect(betaTab.getByText("beta", { exact: true })).toHaveCount(0);
     await expect(betaTab.locator("[data-tab-close-button]")).toHaveCount(0);
+    const betaSidebar = page.locator(
+      '[data-testid="sidebar"] [data-sidebar-session="s-2"]',
+    );
+    await expect(betaSidebar).toHaveAttribute("data-session-minimized", "true");
+    await expect(betaSidebar.getByText("beta", { exact: true })).toHaveCount(0);
+    await expect(
+      page.locator(
+        '[data-testid="sidebar"] [data-sidebar-minimized-strip] [data-sidebar-session="s-2"]',
+      ),
+    ).toBeVisible();
     const box = await betaTab.boundingBox();
     expect(box).not.toBeNull();
     expect(Math.abs((box?.width ?? 0) - (box?.height ?? 0))).toBeLessThan(4);
@@ -862,5 +872,79 @@ test.describe("pane / sidebar shortcuts", () => {
     await page.getByRole("menuitem", { name: "Expand Tab" }).click();
     await expect(restored).not.toHaveAttribute("data-tab-minimized", "true");
     await expect(restored.getByText("beta", { exact: true })).toBeVisible();
+  });
+
+  test("sidebar right-click minimize collapses the session row and pane tab", async ({
+    page,
+    tauri,
+  }) => {
+    const beta = {
+      ...SESSION,
+      id: "s-2",
+      name: "beta",
+      created_at: "2026-01-01T00:00:01Z",
+      updated_at: "2026-01-01T00:00:06Z",
+    };
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION, beta]);
+
+    await page.goto("/");
+
+    await page
+      .locator('[data-testid="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Ready/ })
+      .first()
+      .click();
+
+    const betaRow = page.locator(
+      '[data-testid="sidebar"] [data-sidebar-session="s-2"]',
+    );
+    const betaTab = page.locator('[data-pane-tab-strip] [data-pane-tab="s-2"]');
+    await expect(betaRow).toBeVisible();
+    await expect(betaRow).not.toHaveAttribute("data-session-minimized", "true");
+    await expect(betaRow.getByText("beta", { exact: true })).toBeVisible();
+
+    await betaRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Minimize Tab" }).click();
+
+    await expect(betaRow).toHaveAttribute("data-session-minimized", "true");
+    await expect(betaRow.getByText("beta", { exact: true })).toHaveCount(0);
+    await expect(
+      page.locator(
+        '[data-testid="sidebar"] [data-sidebar-minimized-strip] [data-sidebar-session="s-2"]',
+      ),
+    ).toBeVisible();
+    const alphaRow = page.locator(
+      '[data-testid="sidebar"] [data-sidebar-session="s-1"]',
+    );
+    await expect
+      .poll(async () => {
+        const betaBox = await betaRow.boundingBox();
+        const alphaBox = await alphaRow.boundingBox();
+        if (!betaBox || !alphaBox) return false;
+        return betaBox.y > alphaBox.y;
+      })
+      .toBe(true);
+    await expect(betaTab).toHaveAttribute("data-tab-minimized", "true");
+    await expect(betaTab.getByText("beta", { exact: true })).toHaveCount(0);
+
+    await page.reload();
+
+    const restoredRow = page.locator(
+      '[data-testid="sidebar"] [data-sidebar-session="s-2"]',
+    );
+    await expect(restoredRow).toHaveAttribute("data-session-minimized", "true");
+    await expect(restoredRow.getByText("beta", { exact: true })).toHaveCount(0);
+
+    await restoredRow.click({ button: "right" });
+    await page.getByRole("menuitem", { name: "Expand Tab" }).click();
+    await expect(restoredRow).not.toHaveAttribute(
+      "data-session-minimized",
+      "true",
+    );
+    await expect(restoredRow.getByText("beta", { exact: true })).toBeVisible();
+    await expect(
+      page.locator('[data-pane-tab-strip] [data-pane-tab="s-2"]'),
+    ).not.toHaveAttribute("data-tab-minimized", "true");
   });
 });

--- a/tests/e2e/sidebar.spec.ts
+++ b/tests/e2e/sidebar.spec.ts
@@ -291,6 +291,9 @@ test.describe("sidebar: project lifecycle", () => {
     await expect(menu).toContainText("Open");
     await expect(menu).toContainText("Copy");
     await expect(menu).toContainText("Danger");
+    await expect(
+      page.getByRole("menuitem", { name: "Minimize Tab" }),
+    ).toBeVisible();
     await expect(menu).not.toContainText("Equalize Pane Sizes");
     await expect(menu).not.toContainText("Duplicate Session");
     await expect(menu).not.toContainText("Remove Others in Project");


### PR DESCRIPTION
## Summary
- Right-click a sidebar session to collapse it to an icon chip, matching pane-tab minimize.
- Minimized chips group under a strip at the bottom of each project or folder so named rows stay scannable.
- Minimize and expand from either surface share persisted pane state, including sessions in a non-active workspace.

## Expected impact
The left session list now reflects minimized tabs instead of keeping full named rows. Named sessions stay at the top of each group; minimized chips park at the bottom.

## Design notes
- Sidebar minimize uses the same `minimizedTabIds` on pane state as the tab strip.
- `setTabMinimized` finds the tab across workspaces so a sidebar right-click still works when that session is not in the focused workspace.
- Display-only partition: saved sidebar order is unchanged. The strip is a visual grouping.

## Test plan
- [x] Vitest: `collectMinimizedTabIds` / `isTabMinimizedInWorkspaces`, `partitionSidebarSessions`, `partitionProjectTopLevelItems`, `setTabMinimized` on a non-active workspace.
- [x] Playwright: pane-tab minimize also collapses the sidebar row into the bottom strip; sidebar right-click Minimize Tab updates both surfaces; Expand Tab restores the named row; survives reload.
- [x] `pnpm run typecheck`
- [ ] CI green on this PR.

## Notes
- Dragging a named row onto the minimized strip (or the reverse) does not toggle minimize; the next render re-parks chips at the bottom.