### PR TITLE
feat(sessions): preview archived sessions in a restore modal

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -43,6 +43,10 @@ use tauri_plugin_dialog::DialogExt;
 const CHAT_SESSION_STATE_CHANGED_EVENT: &str = "acorn:chat-session-state-changed";
 const WORKTREE_IN_USE_BY_OTHER_SESSIONS: &str =
     "Close other sessions using this worktree before removing it.";
+const WORKTREE_HELD_BY_ARCHIVED_SESSION: &str =
+    "Resume or permanently remove the archived session using this worktree before deleting it.";
+const SESSION_IS_ARCHIVED: &str =
+    "Cannot start a terminal or adopt a worktree for an archived session.";
 const CODEX_TOOL_PROCESS_START_TOLERANCE: std::time::Duration = std::time::Duration::from_secs(1);
 const MAX_CODEX_REPAIR_TAIL_BYTES: u64 = 8 * 1024 * 1024;
 const MAX_CLAUDE_FORK_PROJECT_ENTRIES: usize = 10_000;
@@ -7605,6 +7609,28 @@ fn ensure_no_sessions_using_worktree_path_except_ids(
     Ok(())
 }
 
+fn ensure_session_is_live(session: &Session) -> AppResult<()> {
+    if session.archived_at.is_some() {
+        return Err(AppError::Other(SESSION_IS_ARCHIVED.to_string()));
+    }
+    Ok(())
+}
+
+fn ensure_worktree_not_held_by_archived_session(
+    state: &AppState,
+    worktree_path: &Path,
+) -> AppResult<()> {
+    let held = sessions_using_worktree_path(state, worktree_path)
+        .iter()
+        .any(|session| session.archived_at.is_some());
+    if held {
+        return Err(AppError::Other(
+            WORKTREE_HELD_BY_ARCHIVED_SESSION.to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn worktree_path_used_outside_project(
     state: &AppState,
     repo_path: &Path,
@@ -7767,6 +7793,7 @@ pub async fn remove_session(
         .map(|session| session.id)
         .collect();
     if remove_worktree.unwrap_or(false) {
+        ensure_worktree_not_held_by_archived_session(&app_state, &session.worktree_path)?;
         ensure_no_sessions_using_worktree_path_except_ids(
             &app_state,
             &session.worktree_path,
@@ -7843,12 +7870,27 @@ pub async fn archive_session(state: State<'_, AppState>, id: String) -> AppResul
 async fn archive_session_inner(state: AppState, id: String) -> AppResult<Session> {
     let id = Uuid::parse_str(&id).map_err(|e| AppError::Other(e.to_string()))?;
     let session = state.sessions.get(&id)?;
-    if session.archived_at.is_some() {
+    let sessions_to_archive = session_removal_cascade(&state, &session);
+    if sessions_to_archive
+        .iter()
+        .all(|candidate| candidate.archived_at.is_some())
+    {
         return Ok(enrich_session(session));
     }
-    let branch = worktree::current_branch(&session.worktree_path).ok();
-    terminate_session_runtime_blocking(state.clone(), id).await?;
-    let updated = state.sessions.archive(&id, branch)?;
+    for candidate in &sessions_to_archive {
+        terminate_session_runtime_blocking(state.clone(), candidate.id).await?;
+    }
+    let mut updated = session;
+    for candidate in &sessions_to_archive {
+        if candidate.archived_at.is_some() {
+            continue;
+        }
+        let branch = worktree::current_branch(&candidate.worktree_path).ok();
+        let next = state.sessions.archive(&candidate.id, branch)?;
+        if next.id == id {
+            updated = next;
+        }
+    }
     persist(&state);
     Ok(enrich_session(updated))
 }
@@ -7864,17 +7906,39 @@ fn resume_session_inner(state: &AppState, id: String) -> AppResult<Session> {
     if session.archived_at.is_none() {
         return Ok(enrich_session(session));
     }
-    let restored_path = worktree::restore_session_worktree(
-        &session.repo_path,
-        &session.worktree_path,
-        &session.branch,
-        session.isolated,
-    )?;
-    if restored_path != session.worktree_path {
-        state.sessions.update_worktree_path(&id, restored_path)?;
+    let mut to_resume = vec![session];
+    if to_resume[0].kind == SessionKind::Control {
+        to_resume.extend(
+            state
+                .sessions
+                .list_control_owned_descendants(id)
+                .into_iter()
+                .filter(|candidate| candidate.archived_at.is_some()),
+        );
     }
-    let updated = state.sessions.unarchive(&id)?;
+    for candidate in &to_resume {
+        let restored_path = worktree::restore_session_worktree(
+            &candidate.repo_path,
+            &candidate.worktree_path,
+            &candidate.branch,
+            candidate.isolated,
+        )?;
+        if restored_path != candidate.worktree_path {
+            state
+                .sessions
+                .update_worktree_path(&candidate.id, restored_path)?;
+        }
+    }
+    let mut updated = None;
+    for candidate in &to_resume {
+        let next = state.sessions.unarchive(&candidate.id)?;
+        if next.id == id {
+            updated = Some(next);
+        }
+    }
     persist(&state);
+    let updated = updated
+        .ok_or_else(|| AppError::Other("resumed session is missing from the store".to_string()))?;
     Ok(enrich_session(updated))
 }
 
@@ -8256,6 +8320,7 @@ pub fn update_session_worktree(
     let id = parse_id(&id)?;
     let path = PathBuf::from(worktree_path);
     let session = state.sessions.get(&id)?;
+    ensure_session_is_live(&session)?;
     if session.project_scoped == false {
         return Err(AppError::InvalidPath(
             "local sessions cannot adopt project worktrees".into(),
@@ -8288,6 +8353,7 @@ pub fn prepare_chat_session_worktree(
     session_id: String,
 ) -> AppResult<Session> {
     let session = authorize_chat_session(state.inner(), &session_id)?;
+    ensure_session_is_live(&session)?;
     if session.project_scoped == false {
         return Err(AppError::InvalidPath(
             "local chat sessions cannot create project worktrees".into(),
@@ -8715,6 +8781,16 @@ pub async fn remove_worktree(
         Path::new(&worktree_path),
     )?;
     let remove_sessions = remove_sessions.unwrap_or(false);
+    remove_worktree_inner(app_state, repo_path, worktree_path, remove_sessions).await
+}
+
+async fn remove_worktree_inner(
+    app_state: AppState,
+    repo_path: PathBuf,
+    worktree_path: PathBuf,
+    remove_sessions: bool,
+) -> AppResult<RemovalOutcome<Option<worktree::RemovedWorktree>>> {
+    ensure_worktree_not_held_by_archived_session(&app_state, &worktree_path)?;
     if remove_sessions {
         let matching_sessions = sessions_using_worktree_path(&app_state, &worktree_path);
         if matching_sessions.len() > 1
@@ -8926,6 +9002,10 @@ fn pty_spawn_blocking<R: Runtime + 'static>(
 ) -> AppResult<()> {
     let id = parse_id(&session_id)?;
     let session = state.sessions.get(&id)?;
+    if session.archived_at.is_some() {
+        terminate_session_pty(&state, &id);
+        return Err(AppError::Other(SESSION_IS_ARCHIVED.to_string()));
+    }
     let cwd = authorize_session_cwd(&state, &session, &PathBuf::from(cwd))?;
     let output_token = output_token.or_else(|| state.pty_output.current_token(&id));
     // Either an in-process PTY or a daemon-side stream attachment for
@@ -12346,11 +12426,11 @@ mod tests {
         linked_worktree_root_for_registered_path, memory_root_pids, normalize_session_goal,
         normalize_session_graph, poll_defers_to_hook, project_creation_git_error,
         pty_io_uses_daemon, reconcile_stale_worktrees, remove_linked_worktree_at_path,
-        restore_pending_session_removal, resume_session_inner, retry_removal_cleanup_inner,
-        seed_initial_commit, should_remove_local_project_mirror, should_route_session_to_daemon,
-        terminate_session_runtime, validate_display_name, validate_editor_command,
-        validate_new_project_name, validate_pty_caller_env, ChatProviderAdapter,
-        ProcessMemorySnapshot, RemovalProgress, MAX_PTY_WORKSPACE_NAME_BYTES,
+        remove_worktree_inner, restore_pending_session_removal, resume_session_inner,
+        retry_removal_cleanup_inner, seed_initial_commit, should_remove_local_project_mirror,
+        should_route_session_to_daemon, terminate_session_runtime, validate_display_name,
+        validate_editor_command, validate_new_project_name, validate_pty_caller_env,
+        ChatProviderAdapter, ProcessMemorySnapshot, RemovalProgress, MAX_PTY_WORKSPACE_NAME_BYTES,
     };
     use crate::error::{AppError, AppResult};
     use crate::state::{AppState, PendingRemovalStep, PendingSessionRemoval};
@@ -12360,7 +12440,7 @@ mod tests {
         Session, SessionAgentProvider, SessionGoal, SessionGoalModelConfig, SessionGoalPolicies,
         SessionGoalPreset, SessionGoalProgress, SessionGoalStagePolicy, SessionGraph,
         SessionGraphAgent, SessionGraphCanvas, SessionGraphNodePosition, SessionKind, SessionMode,
-        SessionTitleSource, WorkGraphGroupDirection,
+        SessionOwner, SessionTitleSource, WorkGraphGroupDirection,
     };
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
@@ -12623,6 +12703,133 @@ mod tests {
         assert!(crate::worktree::is_linked_worktree_root(
             &resumed.worktree_path
         ));
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn archive_session_parks_control_owned_descendants() {
+        let repo_dir = unique_repo_dir("archive-control-cascade");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path =
+            crate::worktree::create_worktree(&repo_dir, "shared").expect("create linked worktree");
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let mut control = Session::new(
+            "control".to_string(),
+            repo_dir.clone(),
+            worktree_path.clone(),
+            "shared".to_string(),
+            true,
+            SessionKind::Control,
+        );
+        control.in_worktree = true;
+        let control = state.sessions.insert(control);
+        let mut worker = Session::new(
+            "worker".to_string(),
+            repo_dir.clone(),
+            worktree_path.clone(),
+            "shared".to_string(),
+            true,
+            SessionKind::Regular,
+        );
+        worker.owner = SessionOwner::control(control.id);
+        worker.in_worktree = true;
+        let worker = state.sessions.insert(worker);
+
+        tauri::async_runtime::block_on(archive_session_inner(
+            state.clone(),
+            control.id.to_string(),
+        ))
+        .expect("archive control session");
+
+        assert!(state
+            .sessions
+            .get(&control.id)
+            .unwrap()
+            .archived_at
+            .is_some());
+        assert!(state
+            .sessions
+            .get(&worker.id)
+            .unwrap()
+            .archived_at
+            .is_some());
+
+        resume_session_inner(&state, control.id.to_string()).expect("resume control session");
+        assert!(state
+            .sessions
+            .get(&control.id)
+            .unwrap()
+            .archived_at
+            .is_none());
+        assert!(state
+            .sessions
+            .get(&worker.id)
+            .unwrap()
+            .archived_at
+            .is_none());
+
+        std::fs::remove_dir_all(&repo_dir).ok();
+    }
+
+    #[test]
+    fn remove_worktree_rejects_an_archived_session_occupant() {
+        let repo_dir = unique_repo_dir("archive-block-worktree-delete");
+        let repo = init_repo_with_commit(&repo_dir);
+        drop(repo);
+        let worktree_path =
+            crate::worktree::create_worktree(&repo_dir, "parked").expect("create linked worktree");
+        let state = AppState::new();
+        state.projects.ensure(repo_dir.clone(), "demo".to_string());
+        let created = create_session_inner(
+            &state,
+            "parked".to_string(),
+            repo_dir.clone(),
+            Some(worktree_path.clone()),
+            true,
+            SessionKind::Regular,
+            None,
+            true,
+            SessionMode::Terminal,
+            None,
+            None,
+            false,
+        )
+        .expect("create session");
+        tauri::async_runtime::block_on(archive_session_inner(
+            state.clone(),
+            created.id.to_string(),
+        ))
+        .expect("archive session");
+
+        let err = tauri::async_runtime::block_on(remove_worktree_inner(
+            state.clone(),
+            repo_dir.clone(),
+            worktree_path.clone(),
+            false,
+        ))
+        .expect_err("archived occupant must block worktree deletion");
+        assert_eq!(err.to_string(), super::WORKTREE_HELD_BY_ARCHIVED_SESSION);
+        assert!(worktree_path.exists());
+        assert!(state
+            .sessions
+            .get(&created.id)
+            .unwrap()
+            .archived_at
+            .is_some());
+
+        let err = tauri::async_runtime::block_on(remove_worktree_inner(
+            state.clone(),
+            repo_dir.clone(),
+            worktree_path.clone(),
+            true,
+        ))
+        .expect_err("remove_sessions must not delete an archived occupant");
+        assert_eq!(err.to_string(), super::WORKTREE_HELD_BY_ARCHIVED_SESSION);
+        assert!(worktree_path.exists());
+        assert!(state.sessions.get(&created.id).is_ok());
+
         std::fs::remove_dir_all(&repo_dir).ok();
     }
 

--- a/src-tauri/src/worktree.rs
+++ b/src-tauri/src/worktree.rs
@@ -599,11 +599,18 @@ pub fn restore_session_worktree(
         return Ok(worktree_path.to_path_buf());
     }
 
-    if worktree_path.exists() && is_linked_worktree_root(worktree_path) {
+    let branch = normalize_local_branch_name(branch)?;
+    if worktree_path.exists() {
+        if !is_linked_worktree_root(worktree_path) {
+            return Err(AppError::InvalidPath(format!(
+                "cannot restore session worktree: {} exists but is not a linked git worktree",
+                worktree_path.display()
+            )));
+        }
+        checkout_local_branch_at_path(worktree_path, &branch)?;
         return Ok(worktree_path.to_path_buf());
     }
 
-    let branch = normalize_local_branch_name(branch)?;
     materialize_local_branch(
         repo_path,
         &branch,
@@ -614,27 +621,44 @@ pub fn restore_session_worktree(
         },
     )?;
 
-    if !worktree_path.exists() {
-        if let Ok(path) = add_worktree_at_path(repo_path, &branch, worktree_path) {
-            return Ok(path);
-        }
+    if let Ok(path) = add_worktree_at_path(repo_path, &branch, worktree_path) {
+        return Ok(path);
     }
 
+    // Never reuse another checkout of `branch` (including the main repo).
+    // A collision here means the recorded path is gone and git will not
+    // check the branch out a second time.
     let hint = worktree_path
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("worktree");
-    let ensured = ensure_worktree_for_branch(
-        repo_path,
-        &branch,
-        hint,
-        EnsureWorktreeOptions {
-            create_if_missing: false,
-            fetch_ref: None,
-            base_branch: None,
-        },
-    )?;
-    Ok(PathBuf::from(ensured.path))
+    add_worktree_for_local_branch(repo_path, &branch, hint)
+}
+
+fn checkout_local_branch_at_path(path: &Path, branch: &str) -> AppResult<()> {
+    if current_branch(path).ok().as_deref() == Some(branch) {
+        return Ok(());
+    }
+    let repo = ensure_repo(path)?;
+    let refname = format!("refs/heads/{branch}");
+    let object = repo
+        .find_reference(&refname)
+        .map_err(|error| {
+            AppError::Other(format!(
+                "recorded branch {branch} is missing at {}: {error}",
+                path.display()
+            ))
+        })?
+        .peel_to_commit()?
+        .into_object();
+    repo.checkout_tree(&object, None).map_err(|error| {
+        AppError::Other(format!(
+            "cannot check out recorded branch {branch} at {}: {error}",
+            path.display()
+        ))
+    })?;
+    repo.set_head(&refname)?;
+    Ok(())
 }
 
 fn unique_managed_worktree_target(
@@ -2431,7 +2455,7 @@ mod tests {
     }
 
     #[test]
-    fn restore_session_worktree_falls_back_when_the_original_path_is_occupied() {
+    fn restore_session_worktree_rejects_a_non_linked_path() {
         let root = unique_temp_dir("restore-occupied");
         let repo = init_repo_with_tracked_file(&root);
         let initial = repo
@@ -2449,14 +2473,78 @@ mod tests {
         std::fs::create_dir_all(&worktree_path).expect("occupy original path");
         std::fs::write(worktree_path.join("blocker.txt"), "occupied").expect("block path");
 
-        let restored = restore_session_worktree(&root, &worktree_path, "feature", true)
-            .expect("fall back to a free worktree path");
+        let error = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect_err("occupied non-worktree path must not be abandoned");
+        assert!(matches!(error, AppError::InvalidPath(_)));
+        assert_eq!(
+            std::fs::read_to_string(worktree_path.join("blocker.txt")).unwrap(),
+            "occupied"
+        );
 
-        assert!(is_linked_worktree_root(&restored));
-        assert_ne!(
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_checks_out_the_recorded_branch() {
+        let root = unique_temp_dir("restore-wrong-branch");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        repo.branch("other", &initial, false)
+            .expect("create other branch");
+        drop(initial);
+        drop(repo);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        add_worktree_at_path(&root, "feature", &worktree_path).expect("create parked worktree");
+        let parked = Repository::open(&worktree_path).expect("open parked worktree");
+        checkout_branch(&parked, "other");
+        drop(parked);
+        assert_eq!(current_branch(&worktree_path).unwrap(), "other");
+
+        let restored = restore_session_worktree(&root, &worktree_path, "feature", true)
+            .expect("check out recorded branch");
+
+        assert_eq!(
             restored.canonicalize().unwrap(),
             worktree_path.canonicalize().unwrap()
         );
+        assert_eq!(current_branch(&worktree_path).unwrap(), "feature");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn restore_session_worktree_does_not_reuse_the_main_checkout() {
+        let root = unique_temp_dir("restore-no-reuse-root");
+        let repo = init_repo_with_tracked_file(&root);
+        let initial = repo
+            .head()
+            .and_then(|head| head.peel_to_commit())
+            .expect("initial commit");
+        repo.branch("feature", &initial, false)
+            .expect("create feature branch");
+        checkout_branch(&repo, "feature");
+        drop(initial);
+        drop(repo);
+
+        let worktree_path = worktree_root(&root).join("parked");
+        match restore_session_worktree(&root, &worktree_path, "feature", true) {
+            Ok(restored) => {
+                assert!(is_linked_worktree_root(&restored));
+                assert_ne!(
+                    restored.canonicalize().unwrap(),
+                    root.canonicalize().unwrap()
+                );
+            }
+            Err(_) => {
+                assert!(!worktree_path.exists() || !is_linked_worktree_root(&worktree_path));
+            }
+        }
 
         std::fs::remove_dir_all(&root).ok();
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ import {
   retainSessionMapEntries,
 } from "./lib/sessionTracking";
 import { projectRootPaths } from "./lib/projectFolders";
+import { isArchivedSession } from "./lib/sessionArchive";
 import { useAppStore } from "./store";
 import type { TranslationKey, Translator } from "./lib/i18n";
 import type { Session } from "./lib/types";
@@ -285,6 +286,10 @@ function focusKanbanSessionCard(sessionId: string) {
 
 function closeTerminalPopoverFromHotkey(): boolean {
   const state = useAppStore.getState();
+  if (state.archivedPreviewSessionId) {
+    state.dismissArchivedPreview();
+    return true;
+  }
   const sessionId = state.terminalPopupSessionId;
   if (!sessionId) return false;
   state.closeTerminalPopup();
@@ -378,7 +383,10 @@ function App() {
       : 0;
   const pendingRemoveHasOwnedSessions = pendingRemoveOwnedSessionCount > 0;
   const pendingRemoveKeepsSharedWorktree =
-    pendingRemoveRecordedWorktree && !pendingRemoveCanDeleteWorktree;
+    pendingRemoveRecordedWorktree &&
+    !pendingRemoveCanDeleteWorktree &&
+    pendingRemove !== null &&
+    !isArchivedSession(pendingRemove);
   const pendingRemoveAutoDeletesWorktree =
     pendingRemove !== null &&
     shouldAutoDeleteSessionWorktree(pendingRemove, projectFolders, sessions);
@@ -548,6 +556,7 @@ function App() {
   const primedResumeSessionsRef = useRef<Set<string>>(new Set());
   const [resumePrimeVersion, setResumePrimeVersion] = useState(0);
   const probedSessionsRef = useRef<Set<string>>(new Set());
+  const previouslyArchivedSessionIdsRef = useRef<Set<string>>(new Set());
   const resumeCandidatesRef = useRef(resumeCandidates);
   resumeCandidatesRef.current = resumeCandidates;
   useEffect(() => {
@@ -628,6 +637,18 @@ function App() {
         return changed ? next : prev;
       });
     }
+    const archivedIds = new Set(
+      effectiveSessions
+        .filter(isArchivedSession)
+        .map((session) => session.id),
+    );
+    if (!autoResumeEnabled) {
+      for (const id of previouslyArchivedSessionIdsRef.current) {
+        if (!archivedIds.has(id)) probedSessionsRef.current.add(id);
+      }
+    }
+    previouslyArchivedSessionIdsRef.current = archivedIds;
+
     const toProbe = effectiveSessions
       .filter(
         (session) =>
@@ -729,7 +750,14 @@ function App() {
         // Per-provider failures are reported above; this only catches an
         // unexpected orchestration failure. The next launch retries.
       });
-  }, [sessions, resumeProbeEnabled, resumePrimeVersion, showToast, t]);
+  }, [
+    autoResumeEnabled,
+    sessions,
+    resumeProbeEnabled,
+    resumePrimeVersion,
+    showToast,
+    t,
+  ]);
 
   useEffect(() => {
     if (!autoResumeEnabled) return;
@@ -1346,7 +1374,11 @@ function App() {
       projectFolders,
       sessions,
     );
-    if (recordedWorktree && !canDeleteWorktree) {
+    if (
+      recordedWorktree &&
+      !canDeleteWorktree &&
+      !isArchivedSession(pendingRemove)
+    ) {
       clearPendingRemove();
       void removeSession(pendingRemove.id, false).then((outcome) => {
         showStoreOperationToast(null, "toasts.session.removeFailed");
@@ -2219,9 +2251,10 @@ function pickResumeCandidate(
 }
 
 function shouldSkipResumeProbeForSession(
-  session: Pick<Session, "status" | "agent_provider">,
+  session: Pick<Session, "status" | "agent_provider" | "archived_at">,
 ): boolean {
   return (
+    isArchivedSession(session) ||
     session.agent_provider != null ||
     session.status === "working" ||
     session.status === "waiting_for_input"

--- a/src/components/ArchivedSessionPreviewModal.tsx
+++ b/src/components/ArchivedSessionPreviewModal.tsx
@@ -1,0 +1,128 @@
+import { X } from "lucide-react";
+import { lazy, Suspense, useEffect, useState, type ReactElement } from "react";
+import { isArchivedSession } from "../lib/sessionArchive";
+import { useToasts } from "../lib/toasts";
+import { useTranslation } from "../lib/useTranslation";
+import { selectSessionsById, useAppStore } from "../store";
+import { ChatPane } from "./ChatPane";
+import { Button, IconButton, Modal } from "./ui";
+
+const GraphSessionView = lazy(async () => {
+  const module = await import("./GraphSessionView");
+  return { default: module.GraphSessionView };
+});
+
+/**
+ * Full-window preview for an archived session. Same expanded-shell shape as
+ * the kanban terminal popover's maximize control, so panes / kanban / canvas
+ * all see one overlay instead of hijacking a live pane.
+ */
+export function ArchivedSessionPreviewModal(): ReactElement | null {
+  const t = useTranslation();
+  const showToast = useToasts((s) => s.show);
+  const previewId = useAppStore((s) => s.archivedPreviewSessionId);
+  const session = useAppStore((s) =>
+    previewId ? (selectSessionsById(s).get(previewId) ?? null) : null,
+  );
+  const dismissArchivedPreview = useAppStore((s) => s.dismissArchivedPreview);
+  const resumeSession = useAppStore((s) => s.resumeSession);
+  const requestRemoveSession = useAppStore((s) => s.requestRemoveSession);
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    if (previewId && !session) dismissArchivedPreview();
+  }, [dismissArchivedPreview, previewId, session]);
+
+  if (!previewId || !session || !isArchivedSession(session)) return null;
+
+  const target = session;
+  const isChat = session.mode === "chat";
+
+  async function restore() {
+    if (restoring) return;
+    setRestoring(true);
+    try {
+      const resumed = await resumeSession(target.id);
+      const error = useAppStore.getState().consumeError();
+      if (!resumed || error) {
+        showToast(`${t("toasts.session.resumeFailed")} ${error ?? ""}`.trim());
+      }
+    } finally {
+      setRestoring(false);
+    }
+  }
+
+  function remove() {
+    dismissArchivedPreview();
+    requestRemoveSession(target.id);
+  }
+
+  return (
+    <Modal
+      open
+      onClose={dismissArchivedPreview}
+      variant="panel"
+      ariaLabel={t("pane.archivedRestore.ariaLabel")}
+      className="max-w-[calc(100vw-1.5rem)]"
+    >
+      <header className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-sm font-semibold text-fg">
+            {session.name}
+          </h2>
+          <p className="truncate text-[11px] text-fg-muted">
+            {session.branch}
+            {session.worktree_path ? ` · ${session.worktree_path}` : ""}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="dangerGhost"
+          size="xs"
+          onClick={remove}
+        >
+          {t("pane.archivedRestore.remove")}
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          size="xs"
+          disabled={restoring}
+          onClick={() => void restore()}
+        >
+          {restoring
+            ? t("pane.archivedRestore.restoring")
+            : t("pane.archivedRestore.restore")}
+        </Button>
+        <IconButton
+          aria-label={t("dialogs.common.close")}
+          onClick={dismissArchivedPreview}
+          size="sm"
+          surface="panel"
+        >
+          <X size={14} />
+        </IconButton>
+      </header>
+      <div className="relative flex min-h-0 flex-1 flex-col bg-bg">
+        {session.graph ? (
+          <Suspense fallback={null}>
+            <GraphSessionView session={session} isActive />
+          </Suspense>
+        ) : isChat ? (
+          <ChatPane
+            sessionId={session.id}
+            isActive
+            repoPath={session.worktree_path}
+            session={session}
+          />
+        ) : (
+          <div
+            className="absolute inset-0"
+            data-archived-preview-body={session.id}
+            data-testid="archived-session-preview-terminal"
+          />
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/ChatPane.tsx
+++ b/src/components/ChatPane.tsx
@@ -43,6 +43,7 @@ import { pathRelativeToCwd } from "../lib/fileMention";
 import { writeClipboardText } from "../lib/clipboardText";
 import { EDIT_AUTONOMOUS_GOAL_SESSION_EVENT } from "../lib/autonomousGoal";
 import { useDialogShortcuts } from "../lib/dialog";
+import { isArchivedSession } from "../lib/sessionArchive";
 import { useAppStore } from "../store";
 import { useTranslation } from "../lib/useTranslation";
 import {
@@ -719,7 +720,9 @@ export function ChatPane({
   const hasRunningMessages = messages.some(
     (message) => message.status === "pending" || message.status === "streaming",
   );
-  const composerIsCentered = !loading && !error && !hasMessages;
+  const archived = Boolean(session && isArchivedSession(session));
+  const composerIsCentered =
+    !archived && !loading && !error && !hasMessages;
   const showEmptyComposerTitle =
     composerIsCentered && !sending && !hasRunningMessages;
   const sourceRepoPath = session?.repo_path ?? repoPath;
@@ -916,7 +919,7 @@ export function ChatPane({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (sending) return;
+    if (sending || archived) return;
     const submittedDraft = draft;
     const submittedAttachments = attachments;
     const content = composeChatMessageContent(
@@ -1610,6 +1613,7 @@ export function ChatPane({
           </button>
         </Tooltip>
       ) : null}
+      {archived ? null : (
       <form
         data-chat-composer={composerIsCentered ? "centered" : "bottom"}
         className={`relative bg-bg px-2 py-2 transition-opacity duration-200 ease-out will-change-opacity ${
@@ -1777,7 +1781,8 @@ export function ChatPane({
           </div>
         </div>
       </form>
-      {session?.graph && !graphReplyAllowed ? (
+      )}
+      {session?.graph && !graphReplyAllowed && !archived ? (
         <div className="shrink-0 border-t border-border bg-bg px-4 py-3 text-center text-[11px] text-fg-muted">
           {t("graphSession.runFromDesign")}
         </div>

--- a/src/components/ProjectSettingsModal.test.tsx
+++ b/src/components/ProjectSettingsModal.test.tsx
@@ -698,6 +698,89 @@ describe("ProjectSettingsModal", () => {
     expect(document.body.textContent).not.toContain("feature-alpha");
   });
 
+  it("blocks worktree deletion while an archived session uses it", async () => {
+    mockApi.getProjectSettings.mockResolvedValue({
+      key: "github:im-ian/acorn",
+      settings: {
+        remember_after_close: true,
+        pull_requests: {
+          generation_prompt: "Use concise release-note style.",
+        },
+        worktrees: { base_branch: null },
+        start_work: { agent_prompt: null },
+      },
+    });
+    mockApi.listProjectWorktrees.mockResolvedValue([
+      {
+        name: "feature-alpha",
+        path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+        modified_ms: null,
+      },
+    ]);
+    useAppStore.setState({
+      sessions: [
+        session({
+          id: "s-alpha-1",
+          name: "alpha terminal",
+          worktree_path: "/repo/acorn/.acorn/worktrees/feature-alpha",
+          in_worktree: true,
+          archived_at: "2026-04-01T00:00:00Z",
+        }),
+      ],
+      activeSessionId: "s-live",
+      projects: [
+        {
+          repo_path: "/repo/acorn",
+          name: "acorn",
+          created_at: "2026-01-01T00:00:00Z",
+          position: 0,
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(
+        <ProjectSettingsModal
+          project={{ name: "acorn", repoPath: "/repo/acorn" }}
+          onClose={() => {}}
+        />,
+      );
+    });
+    await flushPromises();
+
+    const worktreesTab = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Worktrees");
+    await act(async () => {
+      worktreesTab!.click();
+    });
+    await flushPromises();
+
+    expect(document.body.textContent).toContain("Used by 1 session");
+    expect(document.body.textContent).toContain(
+      "An archived session is using this worktree",
+    );
+
+    const remove = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>("button"),
+    ).find(
+      (button) =>
+        button.getAttribute("aria-label") ===
+        "Remove feature-alpha worktree",
+    );
+    expect(remove).toBeDefined();
+    expect(remove?.disabled).toBe(true);
+
+    await act(async () => {
+      remove!.click();
+    });
+
+    expect(document.body.textContent).not.toContain(
+      "Remove sessions and delete worktree",
+    );
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+  });
+
   it("blocks worktree deletion while another session uses it", async () => {
     mockApi.getProjectSettings.mockResolvedValue({
       key: "github:im-ian/acorn",

--- a/src/components/ProjectSettingsModal.tsx
+++ b/src/components/ProjectSettingsModal.tsx
@@ -23,6 +23,7 @@ import {
   resolveStartWorkAgentPrompt,
 } from "../lib/project-settings";
 import { basenamePath, projectRootPaths } from "../lib/projectFolders";
+import { isArchivedSession } from "../lib/sessionArchive";
 import {
   sessionsUsingProjectWorktree,
   sessionsUsingWorktreePath,
@@ -190,7 +191,10 @@ function blockingSessionsForProjectWorktree(
   );
   const targetIds = new Set(targetSessions.map((session) => session.id));
   return sessionsUsingWorktreePath(sessions, worktreePath).filter(
-    (session) => !targetIds.has(session.id) || session.id !== activeSessionId,
+    (session) =>
+      isArchivedSession(session) ||
+      !targetIds.has(session.id) ||
+      session.id !== activeSessionId,
   );
 }
 
@@ -1371,13 +1375,21 @@ function ProjectWorktreeList({
               worktree.path,
             );
             const sessionCount = usedBySessions.length;
+            const removeBlockedByArchivedSessions = usedBySessions.some(
+              isArchivedSession,
+            );
             const removeBlockedByOtherSessions =
+              removeBlockedByArchivedSessions ||
               blockingSessionsForProjectWorktree(
                 sessions,
                 worktree.rootPath,
                 worktree.path,
                 activeSessionId,
               ).length > 0;
+            const removeBlockedReason: DialogTranslationKey =
+              removeBlockedByArchivedSessions
+                ? "dialogs.projectSettings.removeWorktreeBlockedByArchivedSession"
+                : "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions";
             return (
               <li key={`${worktree.rootPath}:${worktree.path}`} className="px-3 py-2">
                 <div className="flex items-start justify-between gap-3">
@@ -1417,10 +1429,7 @@ function ProjectWorktreeList({
                     ) : null}
                     {removeBlockedByOtherSessions ? (
                       <p className="text-[11px] text-fg-muted">
-                        {dt(
-                          t,
-                          "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
-                        )}
+                        {dt(t, removeBlockedReason)}
                       </p>
                     ) : null}
                   </div>
@@ -1432,10 +1441,7 @@ function ProjectWorktreeList({
                     )}
                     title={
                       removeBlockedByOtherSessions
-                        ? dt(
-                            t,
-                            "dialogs.projectSettings.removeWorktreeBlockedByOtherSessions",
-                          )
+                        ? dt(t, removeBlockedReason)
                         : undefined
                     }
                     onClick={() => onRequestRemove(worktree)}

--- a/src/components/RemoveSessionDialog.tsx
+++ b/src/components/RemoveSessionDialog.tsx
@@ -4,6 +4,7 @@ import type { Session } from "../lib/types";
 import { useDialogShortcuts } from "../lib/dialog";
 import type { TranslationKey, Translator } from "../lib/i18n";
 import { useSettings } from "../lib/settings";
+import { isArchivedSession } from "../lib/sessionArchive";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
 import { useTranslation } from "../lib/useTranslation";
 import { Button, Modal, ModalFooter, ModalHeader } from "./ui";
@@ -123,7 +124,9 @@ export function RemoveSessionDialog({
                 <p className="text-xs text-fg-muted">
                   {canDeleteWorktree
                     ? dt(t, "dialogs.removeSession.deleteWorktreeQuestion")
-                    : dt(t, "dialogs.removeSession.keepSharedWorktree")}
+                    : isArchivedSession(session)
+                      ? dt(t, "dialogs.removeSession.keepArchivedWorktree")
+                      : dt(t, "dialogs.removeSession.keepSharedWorktree")}
                 </p>
               </div>
             ) : (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -117,7 +117,9 @@ import {
 import { suggestDefaultSessionName } from "../lib/sessionName";
 import {
   hasRecordedWorktree,
+  sessionsUsingProjectWorktree,
   shouldAutoDeleteSessionWorktree,
+  worktreeWorkspaceIsOccupied,
 } from "../lib/sessionWorktree";
 import { useToasts } from "../lib/toasts";
 import { useTranslation } from "../lib/useTranslation";
@@ -763,6 +765,16 @@ export function Sidebar() {
     if (!folderGroup) return;
     if (folderGroup.sessions.length === 0) {
       if (isWorktreeWorkspace(folderGroup.folder)) {
+        if (
+          worktreeWorkspaceIsOccupied(
+            sessions,
+            folderGroup.folder.repoPath,
+            folderGroup.folder.cwdPath,
+          )
+        ) {
+          setPendingRemoveProjectFolderId(folderGroup.folder.id);
+          return;
+        }
         if (deleteEmptyWorktreeWorkspacesWithoutPrompt) {
           void removeProjectFolderAndWorktree(folderGroup.folder);
         } else {
@@ -1743,7 +1755,17 @@ export function Sidebar() {
       />
       <RemoveProjectFolderDialog
         folder={pendingRemoveProjectFolderGroup?.folder ?? null}
-        sessions={pendingRemoveProjectFolderGroup?.sessions ?? []}
+        sessions={
+          pendingRemoveProjectFolderGroup
+            ? isWorktreeWorkspace(pendingRemoveProjectFolderGroup.folder)
+              ? sessionsUsingProjectWorktree(
+                  sessions,
+                  pendingRemoveProjectFolderGroup.folder.repoPath,
+                  pendingRemoveProjectFolderGroup.folder.cwdPath,
+                )
+              : pendingRemoveProjectFolderGroup.sessions
+            : []
+        }
         worktreeWorkspace={Boolean(
           pendingRemoveProjectFolderGroup &&
             isWorktreeWorkspace(pendingRemoveProjectFolderGroup.folder),
@@ -3987,8 +4009,13 @@ function ArchivedSessionsSection({
   const t = useTranslation();
   const showToast = useToasts((s) => s.show);
   const resumeSession = useAppStore((s) => s.resumeSession);
+  const openSessionSurface = useAppStore((s) => s.openSessionSurface);
   const [expanded, setExpanded] = useState(false);
   if (sessions.length === 0) return null;
+
+  function openPreview(session: Session) {
+    openSessionSurface(session.id);
+  }
 
   async function resume(session: Session) {
     const resumed = await resumeSession(session.id);
@@ -4028,6 +4055,7 @@ function ArchivedSessionsSection({
             <ArchivedSessionRow
               key={session.id}
               session={session}
+              onOpen={() => openPreview(session)}
               onResume={() => void resume(session)}
               onRemove={() => onRemove(session)}
             />
@@ -4040,10 +4068,12 @@ function ArchivedSessionsSection({
 
 function ArchivedSessionRow({
   session,
+  onOpen,
   onResume,
   onRemove,
 }: {
   session: Session;
+  onOpen: () => void;
   onResume: () => void;
   onRemove: () => void;
 }) {
@@ -4072,11 +4102,11 @@ function ArchivedSessionRow({
       <div
         role="button"
         tabIndex={0}
-        onClick={onResume}
+        onClick={onOpen}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            onResume();
+            onOpen();
           }
         }}
         onContextMenu={(e) => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -129,6 +129,7 @@ import {
   type WorktreeAdoptionIntent,
 } from "../lib/worktreeAdoption";
 import { hasRecordedWorktree } from "../lib/sessionWorktree";
+import { isArchivedSession } from "../lib/sessionArchive";
 import { useAppStore, type PendingTerminalInput } from "../store";
 import { StickyUserPrompt } from "./StickyUserPrompt";
 import { FloatingTooltip, Tooltip, type TooltipAnchorRect } from "./Tooltip";
@@ -1423,6 +1424,10 @@ export function Terminal({
         : [sessionId];
       const targetIds = targets.length > 0 ? targets : [sessionId];
       for (const targetId of targetIds) {
+        const target = state.sessions.find(
+          (candidate) => candidate.id === targetId,
+        );
+        if (target && isArchivedSession(target)) continue;
         writeToPty(targetId, data);
       }
     };
@@ -2756,6 +2761,10 @@ export function Terminal({
 
     async function spawnPty() {
       if (disposed || spawnInFlight) return;
+      const session = useAppStore
+        .getState()
+        .sessions.find((candidate) => candidate.id === sessionId);
+      if (session && isArchivedSession(session)) return;
       spawnInFlight = true;
       try {
         ptyReady = false;
@@ -2989,6 +2998,12 @@ export function Terminal({
             }
             if (disposed) return;
             worktreeAdoptionIntent = { kind: "none" };
+            const session =
+              useAppStore
+                .getState()
+                .sessions.find((candidate) => candidate.id === sessionId) ??
+              null;
+            if (session && isArchivedSession(session)) return;
             if (adoptedPath) {
               const name = adoptedPath.split("/").pop() || adoptedPath;
               await useAppStore
@@ -3022,6 +3037,7 @@ export function Terminal({
               const session =
                 store.sessions.find((candidate) => candidate.id === sessionId) ??
                 null;
+              if (session && isArchivedSession(session)) return;
               if (session && hasRecordedWorktree(session)) {
                 store.requestRemoveSession(sessionId);
               } else {
@@ -3177,6 +3193,21 @@ export function Terminal({
 
       if (disposed) return;
       await spawnPty();
+      if (disposed) return;
+
+      const unsubArchiveResume = useAppStore.subscribe((state, prev) => {
+        const current = state.sessions.find(
+          (candidate) => candidate.id === sessionId,
+        );
+        const previous = prev.sessions.find(
+          (candidate) => candidate.id === sessionId,
+        );
+        if (!current || !previous) return;
+        if (isArchivedSession(previous) && !isArchivedSession(current)) {
+          void spawnPty();
+        }
+      });
+      unlistenFns.push(unsubArchiveResume);
     })();
 
     // Scrollback persistence is event-driven, not periodic:

--- a/src/components/TerminalHost.tsx
+++ b/src/components/TerminalHost.tsx
@@ -191,6 +191,7 @@ function visibleTerminalSessionIdKey(state: AppStateSnapshot): string {
     }
   }
   if (state.terminalPopupSessionId) ids.push(state.terminalPopupSessionId);
+  if (state.archivedPreviewSessionId) ids.push(state.archivedPreviewSessionId);
   return [...new Set(ids)].sort().join(SESSION_ID_KEY_SEPARATOR);
 }
 
@@ -200,6 +201,9 @@ function visibleTerminalTargetKey(
 ): string | null {
   if (state.terminalPopupSessionId === sessionId) {
     return `popover:${sessionId}`;
+  }
+  if (state.archivedPreviewSessionId === sessionId) {
+    return `archived-preview:${sessionId}`;
   }
   const workspaceId = activeWorkspaceId(state);
   if (!workspaceId) return null;
@@ -227,6 +231,12 @@ function terminalDestinationForTargetKey(
       `[data-terminal-popover-body="${cssEscape(sessionId)}"]`,
     ) as HTMLElement | null;
   }
+  if (targetKey.startsWith("archived-preview:")) {
+    const sessionId = targetKey.slice("archived-preview:".length);
+    return document.querySelector(
+      `[data-archived-preview-body="${cssEscape(sessionId)}"]`,
+    ) as HTMLElement | null;
+  }
   if (targetKey.startsWith("canvas:")) {
     const sessionId = targetKey.slice("canvas:".length);
     return document.querySelector(
@@ -243,7 +253,10 @@ function terminalDestinationForTargetKey(
 }
 
 function terminalTargetIsPopover(targetKey: string | null): boolean {
-  return Boolean(targetKey?.startsWith("popover:"));
+  return Boolean(
+    targetKey?.startsWith("popover:") ||
+      targetKey?.startsWith("archived-preview:"),
+  );
 }
 
 function terminalTargetIsCanvas(targetKey: string | null): boolean {
@@ -289,7 +302,8 @@ function PortaledTerminal({ session }: { session: Session }) {
       ? true
       : terminalTargetIsCanvas(visibleTargetKey)
         ? state.activeSessionId === session.id
-      : isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
+      : state.archivedPreviewSessionId === session.id ||
+        isSessionInFocusedPane(session.id, state.panes, state.focusedPaneId),
   );
   const workspaceKey = useAppStore((state) =>
     workspaceContextKeyForSession(state, session.id),

--- a/src/components/WorkspaceMain.tsx
+++ b/src/components/WorkspaceMain.tsx
@@ -130,6 +130,7 @@ import {
   type WorkspaceViewMode,
 } from "../store";
 import { IconButton, StatusDot, type StatusTone } from "./ui";
+import { ArchivedSessionPreviewModal } from "./ArchivedSessionPreviewModal";
 import { ChatPane } from "./ChatPane";
 import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import { FileViewer } from "./FileViewer";
@@ -304,6 +305,7 @@ export function WorkspaceMain({ layout, viewMode }: WorkspaceMainProps) {
       >
         <LayoutRenderer node={layout} />
       </div>
+      <ArchivedSessionPreviewModal />
     </div>
   );
 }

--- a/src/lib/sessionWorktree.test.ts
+++ b/src/lib/sessionWorktree.test.ts
@@ -11,6 +11,7 @@ import {
   sessionsUsingProjectWorktree,
   sessionsUsingWorktreePath,
   shouldAutoDeleteSessionWorktree,
+  worktreeWorkspaceIsOccupied,
 } from "./sessionWorktree";
 
 function session(overrides: Partial<Session> = {}): Session {
@@ -138,6 +139,33 @@ describe("worktree deletion policy", () => {
     });
 
     expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(true);
+    expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
+  });
+
+  it("treats archived sessions as occupying a worktree workspace", () => {
+    const parked = session({
+      archived_at: "2026-04-01T00:00:00Z",
+      worktree_path: "/repo/.acorn/worktrees/shared",
+    });
+
+    expect(
+      worktreeWorkspaceIsOccupied(
+        [parked],
+        "/repo",
+        "/repo/.acorn/worktrees/shared",
+      ),
+    ).toBe(true);
+    expect(worktreeWorkspaceIsOccupied([parked], "/repo", "/repo")).toBe(false);
+  });
+
+  it("does not delete a worktree while the session is archived", () => {
+    const target = session({
+      isolated: true,
+      worktree_path: "/repo/.acorn/worktrees/solo",
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+
+    expect(canDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
     expect(shouldAutoDeleteSessionWorktree(target, foldersByRepo)).toBe(false);
   });
 });

--- a/src/lib/sessionWorktree.ts
+++ b/src/lib/sessionWorktree.ts
@@ -1,5 +1,6 @@
-import type { Session } from "./types";
 import type { ProjectFoldersByRepo } from "./projectFolders";
+import { isArchivedSession } from "./sessionArchive";
+import type { Session } from "./types";
 
 export function hasRecordedWorktree(session: Session): boolean {
   return session.isolated || session.in_worktree;
@@ -23,6 +24,14 @@ export function sessionsUsingProjectWorktree(
       sameWorkspacePath(session.repo_path, repoPath) &&
       sameWorkspacePath(session.worktree_path, worktreePath),
   );
+}
+
+export function worktreeWorkspaceIsOccupied(
+  sessions: readonly Session[],
+  repoPath: string,
+  worktreePath: string,
+): boolean {
+  return sessionsUsingProjectWorktree(sessions, repoPath, worktreePath).length > 0;
 }
 
 export function sessionsUsingWorktreePath(
@@ -107,6 +116,7 @@ export function canDeleteSessionWorktree(
   foldersByRepo: ProjectFoldersByRepo,
   sessions: readonly Session[] = [session],
 ): boolean {
+  if (isArchivedSession(session)) return false;
   const removalIds = sessionRemovalCascadeIds(sessions, session);
   return (
     hasRecordedWorktree(session) &&

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1639,6 +1639,14 @@
     }
   },
   "pane": {
+    "archivedRestore": {
+      "title": "Restore this session?",
+      "body": "This session is archived. Restore it to continue in a live terminal.",
+      "restore": "Restore",
+      "restoring": "Restoring...",
+      "remove": "Remove",
+      "ariaLabel": "Archived session preview"
+    },
     "empty": {
       "dropTabOrDoubleClick": "Drop a tab here or double-click to start a session",
       "createProject": "Create a project to get started. Double-click here."
@@ -2184,6 +2192,7 @@
       "filesIn": "Files in",
       "willNotBeTouched": "will not be touched.",
       "keepSharedWorktree": "This worktree is shared by a workspace and will be kept on disk.",
+      "keepArchivedWorktree": "Archived sessions keep their worktree so they can be resumed. Remove the session first, or resume it before deleting the worktree.",
       "dontAskAgain": "Don't ask again (toggle in Settings → Sessions)",
       "autoDeleteIsolatedWorktreesNextTime": "Delete standalone isolated worktrees without asking next time",
       "keepWorktree": "Remove only",
@@ -2318,6 +2327,7 @@
       "removeWorktree": "Remove",
       "removeWorktreeAria": "Remove {name} worktree",
       "removeWorktreeBlockedByOtherSessions": "Close other sessions using this worktree before removing it.",
+      "removeWorktreeBlockedByArchivedSession": "An archived session is using this worktree. Resume or permanently remove that session before deleting it.",
       "confirmRemoveDialog": "Delete worktree",
       "confirmRemoveTitle": "Delete {name}?",
       "confirmRemoveBody": "This removes the linked git worktree directory from disk. Sessions using it may need to be reopened from the main project.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1639,6 +1639,14 @@
     }
   },
   "pane": {
+    "archivedRestore": {
+      "title": "このセッションを復元しますか？",
+      "body": "アーカイブされたセッションです。復元するとライブ端末で作業を続けられます。",
+      "restore": "復元",
+      "restoring": "復元中...",
+      "remove": "削除",
+      "ariaLabel": "アーカイブセッションのプレビュー"
+    },
     "empty": {
       "dropTabOrDoubleClick": "ここにタブをドロップするか、ダブルクリックしてセッションを開始します",
       "createProject": "プロジェクトを作成して開始します。ここをダブルクリックします。"
@@ -2184,6 +2192,7 @@
       "filesIn": "のファイル",
       "willNotBeTouched": "触れられないだろう。",
       "keepSharedWorktree": "このワークツリーはワークスペースによって共有され、ディスク上に保持されます。",
+      "keepArchivedWorktree": "アーカイブされたセッションは再開できるようワークツリーを保持します。削除する前にセッションを再開するか、先にセッションを削除してください。",
       "dontAskAgain": "二度と質問しないでください ([設定] → [セッション] に切り替えます)",
       "autoDeleteIsolatedWorktreesNextTime": "次回確認せずにスタンドアロンの分離ワークツリーを削除します",
       "keepWorktree": "削除のみ",
@@ -2318,6 +2327,7 @@
       "removeWorktree": "削除",
       "removeWorktreeAria": "{name} ワークツリーを削除します",
       "removeWorktreeBlockedByOtherSessions": "ワークツリーを削除する前に、このワークツリーを使用している他のセッションを閉じてください。",
+      "removeWorktreeBlockedByArchivedSession": "アーカイブされたセッションがこのワークツリーを使用しています。削除する前にそのセッションを再開するか、先に削除してください。",
       "confirmRemoveDialog": "ワークツリーの削除",
       "confirmRemoveTitle": "{name} を削除しますか?",
       "confirmRemoveBody": "これにより、リンクされた git worktree ディレクトリがディスクから削除されます。これを使用するセッションは、メイン プロジェクトから再度開く必要がある場合があります。",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1639,6 +1639,14 @@
     }
   },
   "pane": {
+    "archivedRestore": {
+      "title": "이 세션을 복구할까요?",
+      "body": "아카이브된 세션입니다. 복구하면 라이브 터미널에서 이어서 작업할 수 있습니다.",
+      "restore": "복구",
+      "restoring": "복구 중...",
+      "remove": "제거",
+      "ariaLabel": "아카이브 세션 미리보기"
+    },
     "empty": {
       "dropTabOrDoubleClick": "여기에 탭을 놓거나 더블 클릭해 세션을 시작하세요",
       "createProject": "시작하려면 프로젝트를 만드세요. 여기를 더블 클릭하세요."
@@ -2184,6 +2192,7 @@
       "filesIn": "다음 위치의 파일은",
       "willNotBeTouched": "변경되지 않습니다.",
       "keepSharedWorktree": "이 워크트리는 작업공간에서 공유 중이므로 디스크에 유지됩니다.",
+      "keepArchivedWorktree": "아카이브된 세션은 재개를 위해 워크트리를 유지합니다. 워크트리를 지우려면 먼저 세션을 제거하거나 재개하세요.",
       "dontAskAgain": "다시 묻지 않기(설정 → 세션에서 변경)",
       "autoDeleteIsolatedWorktreesNextTime": "다음부터 단독 격리 워크트리는 묻지 않고 삭제",
       "keepWorktree": "세션만 제거",
@@ -2318,6 +2327,7 @@
       "removeWorktree": "제거",
       "removeWorktreeAria": "{name} 워크트리 제거",
       "removeWorktreeBlockedByOtherSessions": "이 워크트리를 사용하는 다른 세션을 모두 닫은 뒤 제거할 수 있습니다.",
+      "removeWorktreeBlockedByArchivedSession": "아카이브된 세션이 이 워크트리를 사용 중입니다. 삭제하려면 해당 세션을 재개하거나 먼저 제거하세요.",
       "confirmRemoveDialog": "워크트리 삭제",
       "confirmRemoveTitle": "{name} 삭제",
       "confirmRemoveBody": "연결된 Git 워크트리 디렉터리를 디스크에서 제거합니다. 이 워크트리를 사용하는 세션은 메인 프로젝트에서 다시 열어야 할 수 있습니다.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1639,6 +1639,14 @@
     }
   },
   "pane": {
+    "archivedRestore": {
+      "title": "要恢复此会话吗？",
+      "body": "此会话已归档。恢复后可在实时终端中继续工作。",
+      "restore": "恢复",
+      "restoring": "正在恢复...",
+      "remove": "删除",
+      "ariaLabel": "已归档会话预览"
+    },
     "empty": {
       "dropTabOrDoubleClick": "将标签页拖放到此处或双击启动会话",
       "createProject": "创建项目开始。双击此处。"
@@ -2184,6 +2192,7 @@
       "filesIn": "以下位置中的文件",
       "willNotBeTouched": "不会受到影响。",
       "keepSharedWorktree": "此工作树由工作区共享，并将保留在磁盘上。",
+      "keepArchivedWorktree": "已归档会话会保留工作树以便恢复。请先恢复或删除该会话，然后再删除工作树。",
       "dontAskAgain": "不要再询问（在设置 → 会话中切换）",
       "autoDeleteIsolatedWorktreesNextTime": "删除独立的隔离工作树，下次无需询问",
       "keepWorktree": "仅删除",
@@ -2318,6 +2327,7 @@
       "removeWorktree": "删除",
       "removeWorktreeAria": "删除 {name} 工作树",
       "removeWorktreeBlockedByOtherSessions": "在删除之前关闭使用此工作树的其他会话。",
+      "removeWorktreeBlockedByArchivedSession": "已归档会话正在使用此工作树。请先恢复或永久删除该会话，然后再删除工作树。",
       "confirmRemoveDialog": "删除工作树",
       "confirmRemoveTitle": "删除 {name}？",
       "confirmRemoveBody": "这会从磁盘删除链接的 Git 工作树目录。使用它的会话可能需要从主项目重新打开。",

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -27,6 +27,7 @@ vi.mock("./lib/api", () => {
       createSession: vi.fn(async () => ({}) as Session),
       archiveSession: vi.fn(async () => ({}) as Session),
       resumeSession: vi.fn(async () => ({}) as Session),
+      updateSessionWorktree: vi.fn(async () => ({}) as Session),
       removeSession: vi.fn(async () => ({
         result: null,
         removedSessionIds: [],
@@ -1745,17 +1746,67 @@ describe("archiveSession", () => {
     ]);
     expect(useAppStore.getState().sessions[0]?.archived_at).toBeTruthy();
     expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
-    expect(useAppStore.getState().activeSessionId).toBe("a2");
+    expect(useAppStore.getState().archivedPreviewSessionId).toBe("a1");
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
 
     pending.resolve(archived);
     await archive;
     expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+    expect(useAppStore.getState().archivedPreviewSessionId).toBe("a1");
     expect(useAppStore.getState().sessions).toHaveLength(2);
+  });
+
+  it("parks control-owned descendants with the controller", async () => {
+    const ctl = session("ctl", REPO_A, { kind: "control" });
+    const worker = session("worker", REPO_A, {
+      owner: { kind: "control", session_id: "ctl" },
+    });
+    const other = session("other", REPO_A);
+    await seed([project(REPO_A, 0)], [ctl, worker, other]);
+
+    const archivedCtl = { ...ctl, archived_at: "2026-04-01T00:00:00Z" };
+    const archivedWorker = { ...worker, archived_at: "2026-04-01T00:00:00Z" };
+    mockApi.archiveSession.mockResolvedValueOnce(archivedCtl);
+    mockApi.listSessions.mockResolvedValue([
+      archivedCtl,
+      archivedWorker,
+      other,
+    ]);
+    mockApi.listProjects.mockResolvedValue([project(REPO_A, 0)]);
+
+    await useAppStore.getState().archiveSession("ctl");
+
+    const state = useAppStore.getState();
+    expect(state.sessions.find((item) => item.id === "ctl")?.archived_at).toBeTruthy();
+    expect(
+      state.sessions.find((item) => item.id === "worker")?.archived_at,
+    ).toBeTruthy();
+    expect(state.sessions.find((item) => item.id === "other")?.archived_at).toBeFalsy();
+    expect(state.panes.root.tabIds).not.toContain("ctl");
+    expect(state.panes.root.tabIds).not.toContain("worker");
+  });
+});
+
+describe("adoptSessionWorktree", () => {
+  it("refuses to adopt a worktree onto an archived session", async () => {
+    const parked = session("a1", REPO_A, {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    await seed([project(REPO_A, 0)], [parked]);
+
+    await useAppStore
+      .getState()
+      .adoptSessionWorktree("a1", `${REPO_A}/.acorn/worktrees/other`);
+
+    expect(mockApi.updateSessionWorktree).not.toHaveBeenCalled();
+    expect(useAppStore.getState().error).toBe(
+      "Cannot start a terminal or adopt a worktree for an archived session.",
+    );
   });
 });
 
 describe("selectSession", () => {
-  it("does not reinsert an archived session as a workspace tab", async () => {
+  it("opens an archived session as a tabless preview without resuming", async () => {
     const parked = session("a1", REPO_A, {
       archived_at: "2026-04-01T00:00:00Z",
     });
@@ -1765,7 +1816,41 @@ describe("selectSession", () => {
     useAppStore.getState().selectSession("a1");
 
     expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+    expect(useAppStore.getState().archivedPreviewSessionId).toBe("a1");
+    expect(useAppStore.getState().activeSessionId).toBe("a1");
+    expect(mockApi.resumeSession).not.toHaveBeenCalled();
+  });
+
+  it("closes the archived preview when selecting another tab", async () => {
+    const parked = session("a1", REPO_A, {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [parked, a2]);
+    useAppStore.getState().selectSession("a1");
+    expect(useAppStore.getState().archivedPreviewSessionId).toBe("a1");
+
+    useAppStore.getState().selectSession("a2");
+
+    expect(useAppStore.getState().archivedPreviewSessionId).toBeNull();
     expect(useAppStore.getState().activeSessionId).toBe("a2");
+    expect(useAppStore.getState().panes.root.tabIds).toEqual(["a2"]);
+  });
+
+  it("dismisses the archived preview without resuming", async () => {
+    const parked = session("a1", REPO_A, {
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    const a2 = session("a2", REPO_A);
+    await seed([project(REPO_A, 0)], [parked, a2]);
+    useAppStore.getState().selectSession("a1");
+    expect(useAppStore.getState().archivedPreviewSessionId).toBe("a1");
+
+    useAppStore.getState().dismissArchivedPreview();
+
+    expect(useAppStore.getState().archivedPreviewSessionId).toBeNull();
+    expect(useAppStore.getState().activeSessionId).toBe("a2");
+    expect(mockApi.resumeSession).not.toHaveBeenCalled();
   });
 });
 
@@ -1787,6 +1872,7 @@ describe("resumeSession", () => {
 
     expect(mockApi.resumeSession).toHaveBeenCalledWith("a1");
     expect(resumed?.id).toBe("a1");
+    expect(useAppStore.getState().archivedPreviewSessionId).toBeNull();
     expect(useAppStore.getState().panes.root.tabIds).toContain("a1");
     expect(useAppStore.getState().activeSessionId).toBe("a1");
   });
@@ -1862,6 +1948,25 @@ describe("removeSession", () => {
     expect(s.error).toBe("delete failed");
     expect(s.sessions.map((session) => session.id)).toEqual(["a1"]);
     expect(s.activeSessionId).toBe("a1");
+  });
+
+  it("refuses to delete a worktree while the session is archived", async () => {
+    const worktreePath = `${REPO_A}/.worktrees/parked`;
+    const parked = session("a1", REPO_A, {
+      isolated: true,
+      worktree_path: worktreePath,
+      archived_at: "2026-04-01T00:00:00Z",
+    });
+    await seed([project(REPO_A, 0)], [parked]);
+
+    const removed = await useAppStore.getState().removeSession("a1", true);
+
+    expect(removed).toBeNull();
+    expect(mockApi.removeSession).not.toHaveBeenCalled();
+    expect(useAppStore.getState().sessions.map((s) => s.id)).toEqual(["a1"]);
+    expect(useAppStore.getState().error).toBe(
+      "Resume or permanently remove the archived session using this worktree before deleting it.",
+    );
   });
 
   it("refuses to delete a worktree while another session still uses it", async () => {
@@ -3691,6 +3796,32 @@ describe("removeProjectWorktree", () => {
       ),
     ).toBe(false);
     expect(state.workspaces[folder!.id]).toBeUndefined();
+  });
+
+  it("refuses to delete a worktree while an archived session uses it", async () => {
+    const worktreePath = `${REPO_B}/.acorn/worktrees/feature-alpha`;
+    const repo = project(REPO_B, 0);
+    await seed(
+      [repo],
+      [
+        session("b1", REPO_B, {
+          worktree_path: worktreePath,
+          in_worktree: true,
+          archived_at: "2026-04-01T00:00:00Z",
+        }),
+      ],
+    );
+
+    await expect(
+      useAppStore.getState().removeProjectWorktree(REPO_B, worktreePath, true),
+    ).rejects.toThrow("archived session using this worktree");
+
+    const state = useAppStore.getState();
+    expect(mockApi.removeWorktree).not.toHaveBeenCalled();
+    expect(state.sessions.map((candidate) => candidate.id)).toEqual(["b1"]);
+    expect(state.error).toBe(
+      "Resume or permanently remove the archived session using this worktree before deleting it.",
+    );
   });
 
   it("refuses to delete a worktree while another session uses it", async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -110,6 +110,10 @@ const ROOT_PANE_ID: PaneId = "root";
 const SESSION_TITLE_GENERATING_MIN_MS = 900;
 const WORKTREE_IN_USE_BY_OTHER_SESSIONS =
   "Close other sessions using this worktree before removing it.";
+const WORKTREE_HELD_BY_ARCHIVED_SESSION =
+  "Resume or permanently remove the archived session using this worktree before deleting it.";
+const SESSION_IS_ARCHIVED =
+  "Cannot start a terminal or adopt a worktree for an archived session.";
 
 let statusPollRunning = false;
 let statusPollChain: Promise<void> | null = null;
@@ -419,6 +423,11 @@ interface AppStateModel {
   focusedPaneId: PaneId;
   activeTabId: string | null;
   activeSessionId: string | null;
+  /**
+   * Archived session shown in the focused pane without a tab chip.
+   * Selecting any live tab, project, or folder dismisses it.
+   */
+  archivedPreviewSessionId: string | null;
   workspaceViewMode: WorkspaceViewMode;
   terminalPopupSessionId: string | null;
   consumeError: () => string | null;
@@ -527,6 +536,7 @@ interface AppStateModel {
   ) => void;
   openTerminalPopup: (sessionId: string) => void;
   closeTerminalPopup: () => void;
+  dismissArchivedPreview: () => void;
   focusAdjacentPane: (direction: PaneFocusDirection) => void;
   setPaneSplitSizes: (splitId: string, sizes: readonly number[]) => void;
   splitFocusedPane: (direction: Direction) => void;
@@ -962,6 +972,29 @@ function mirrorActive(
   };
 }
 
+function retainedArchivedPreviewSessionId(
+  sessions: readonly Session[],
+  previewId: string | null | undefined,
+): string | null {
+  if (!previewId) return null;
+  const session = sessions.find((item) => item.id === previewId);
+  return session && isArchivedSession(session) ? previewId : null;
+}
+
+function withArchivedPreview(
+  mirrored: ReturnType<typeof mirrorActive>,
+  previewId: string | null,
+): ReturnType<typeof mirrorActive> & { archivedPreviewSessionId: string | null } {
+  if (!previewId) {
+    return { ...mirrored, archivedPreviewSessionId: null };
+  }
+  return {
+    ...mirrored,
+    archivedPreviewSessionId: previewId,
+    activeSessionId: previewId,
+  };
+}
+
 /**
  * Reconcile a single project's pane state with that project's session list.
  * New sessions land in the focused pane. Removed sessions are dropped.
@@ -1026,6 +1059,7 @@ function reconcileWorkspace(
     if (!newPanes[target]) newPanes[target] = emptyPane(target);
   }
   for (const s of sessions) {
+    if (isArchivedSession(s)) continue;
     if (!assigned.has(s.id)) {
       const pane = newPanes[target];
       newPanes[target] = {
@@ -1740,6 +1774,7 @@ export const useAppStore = create<AppStateModel>()(
   focusedPaneId: ROOT_PANE_ID,
   activeTabId: null,
   activeSessionId: null,
+  archivedPreviewSessionId: null,
   workspaceViewMode: defaultWorkspaceViewMode(),
   terminalPopupSessionId: null,
 
@@ -1889,15 +1924,21 @@ export const useAppStore = create<AppStateModel>()(
           sessionFolderIds: reconciled.sessionFolderIds,
           activeProject: reconciled.activeProject,
           activeProjectFolderId: reconciled.activeProjectFolderId,
-          ...mirrorActive(
-            reconciled.workspaces,
-            reconciled.activeProjectFolderId,
-            {
-              sessions: s.sessions,
-              projects,
-              projectFolders: reconciled.projectFolders,
-              activeProject: reconciled.activeProject,
-            },
+          ...withArchivedPreview(
+            mirrorActive(
+              reconciled.workspaces,
+              reconciled.activeProjectFolderId,
+              {
+                sessions: s.sessions,
+                projects,
+                projectFolders: reconciled.projectFolders,
+                activeProject: reconciled.activeProject,
+              },
+            ),
+            retainedArchivedPreviewSessionId(
+              s.sessions,
+              s.archivedPreviewSessionId,
+            ),
           ),
         };
       });
@@ -1979,15 +2020,21 @@ export const useAppStore = create<AppStateModel>()(
         sessionFolderIds: reconciled.sessionFolderIds,
         activeProject: reconciled.activeProject,
         activeProjectFolderId: reconciled.activeProjectFolderId,
-        ...mirrorActive(
-          reconciled.workspaces,
-          reconciled.activeProjectFolderId,
-          {
+        ...withArchivedPreview(
+          mirrorActive(
+            reconciled.workspaces,
+            reconciled.activeProjectFolderId,
+            {
+              sessions,
+              projects,
+              projectFolders: reconciled.projectFolders,
+              activeProject: reconciled.activeProject,
+            },
+          ),
+          retainedArchivedPreviewSessionId(
             sessions,
-            projects,
-            projectFolders: reconciled.projectFolders,
-            activeProject: reconciled.activeProject,
-          },
+            s.archivedPreviewSessionId,
+          ),
         ),
       };
       return applyKnownSessionPlacementIntents(nextState);
@@ -2243,7 +2290,10 @@ export const useAppStore = create<AppStateModel>()(
             },
           };
         });
-        return patch ?? s;
+        if (!patch) {
+          return s.archivedPreviewSessionId ? { archivedPreviewSessionId: null } : s;
+        }
+        return { ...patch, archivedPreviewSessionId: null };
       }
 
       if (isWorkspaceTabId(id)) {
@@ -2268,6 +2318,7 @@ export const useAppStore = create<AppStateModel>()(
           workspaces,
           activeProject,
           activeProjectFolderId: owner.projectFolderId,
+          archivedPreviewSessionId: null,
           ...mirrorActive(workspaces, owner.projectFolderId, {
             ...s,
             activeProject,
@@ -2277,7 +2328,36 @@ export const useAppStore = create<AppStateModel>()(
 
       // Find session, switch active project to its repo, set active in pane.
       const session = s.sessions.find((x) => x.id === id);
-      if (!session || isArchivedSession(session)) return s;
+      if (!session) return s;
+      if (isArchivedSession(session)) {
+        const folders = s.projectFolders[session.repo_path] ?? [];
+        const targetProjectFolderId = resolveProjectFolderIdForSession(
+          folders,
+          session,
+          s.sessionFolderIds,
+        );
+        const workspaceId = s.workspaces[targetProjectFolderId]
+          ? targetProjectFolderId
+          : defaultProjectFolderId(session.repo_path);
+        const ws = s.workspaces[workspaceId];
+        if (!ws) {
+          return {
+            archivedPreviewSessionId: session.id,
+            activeSessionId: session.id,
+            activeProject: session.repo_path,
+          };
+        }
+        return {
+          archivedPreviewSessionId: session.id,
+          activeProject: session.repo_path,
+          activeProjectFolderId: workspaceId,
+          ...mirrorActive(s.workspaces, workspaceId, {
+            ...s,
+            activeProject: session.repo_path,
+          }),
+          activeSessionId: session.id,
+        };
+      }
 
       const folders = s.projectFolders[session.repo_path] ?? [];
       const targetProjectFolderId = resolveProjectFolderIdForSession(
@@ -2316,6 +2396,7 @@ export const useAppStore = create<AppStateModel>()(
         workspaces,
         activeProject: session.repo_path,
         activeProjectFolderId: workspaceId,
+        archivedPreviewSessionId: null,
         ...mirrorActive(workspaces, workspaceId, {
           ...s,
           activeProject: session.repo_path,
@@ -2353,11 +2434,16 @@ export const useAppStore = create<AppStateModel>()(
 
   openSessionSurface(id, options) {
     const session = get().sessions.find((candidate) => candidate.id === id);
-    if (!session || isArchivedSession(session)) return false;
+    if (!session) return false;
 
     get().selectSession(id);
     const state = get();
     if (state.activeSessionId !== id) return false;
+
+    if (isArchivedSession(session)) {
+      state.closeTerminalPopup();
+      return true;
+    }
 
     if (state.workspaceViewMode === "kanban") {
       state.openTerminalPopup(id);
@@ -2397,6 +2483,7 @@ export const useAppStore = create<AppStateModel>()(
       return {
         activeProject: null,
         activeProjectFolderId: null,
+        archivedPreviewSessionId: null,
         ...fallbackEmptyMirror(),
       };
     });
@@ -2451,6 +2538,7 @@ export const useAppStore = create<AppStateModel>()(
         projectFolders,
         activeProject: repoPath,
         activeProjectFolderId: folderId,
+        archivedPreviewSessionId: null,
         ...mirrorActive(workspaces, folderId, {
           ...s,
           projectFolders,
@@ -2483,6 +2571,7 @@ export const useAppStore = create<AppStateModel>()(
         workspaces,
         activeProject: folder.repoPath,
         activeProjectFolderId: folder.id,
+        archivedPreviewSessionId: null,
         ...mirrorActive(workspaces, folder.id, {
           ...s,
           activeProject: folder.repoPath,
@@ -2762,6 +2851,14 @@ export const useAppStore = create<AppStateModel>()(
     set({ terminalPopupSessionId: null });
   },
 
+  dismissArchivedPreview() {
+    if (!get().archivedPreviewSessionId) return;
+    set((s) => ({
+      archivedPreviewSessionId: null,
+      ...mirrorActive(s.workspaces, s.activeProjectFolderId, s),
+    }));
+  },
+
   focusAdjacentPane(direction) {
     set((s) => {
       const patch = updateActiveWorkspace(s, (ws) => {
@@ -2875,6 +2972,10 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   closeFocusedTab() {
+    if (get().archivedPreviewSessionId) {
+      get().dismissArchivedPreview();
+      return;
+    }
     const { activeTabId } = get();
     if (!activeTabId) return;
     if (isWorkspaceTabId(activeTabId)) {
@@ -3295,11 +3396,19 @@ export const useAppStore = create<AppStateModel>()(
     if (removeWorktree) {
       const state = get();
       if (target) {
+        if (isArchivedSession(target)) {
+          set({ error: WORKTREE_HELD_BY_ARCHIVED_SESSION });
+          return null;
+        }
         const otherSessions = otherSessionsUsingWorktreePath(
           state.sessions,
           target.worktree_path,
           target.id,
         ).filter((session) => !removalIds.has(session.id));
+        if (otherSessions.some((session) => isArchivedSession(session))) {
+          set({ error: WORKTREE_HELD_BY_ARCHIVED_SESSION });
+          return null;
+        }
         if (otherSessions.length > 0) {
           set({ error: WORKTREE_IN_USE_BY_OTHER_SESSIONS });
           return null;
@@ -3361,15 +3470,21 @@ export const useAppStore = create<AppStateModel>()(
         sessionFolderIds: reconciled.sessionFolderIds,
         activeProject: reconciled.activeProject,
         activeProjectFolderId: reconciled.activeProjectFolderId,
-        ...mirrorActive(
-          reconciled.workspaces,
-          reconciled.activeProjectFolderId,
-          {
+        ...withArchivedPreview(
+          mirrorActive(
+            reconciled.workspaces,
+            reconciled.activeProjectFolderId,
+            {
+              sessions,
+              projects: s.projects,
+              projectFolders: reconciled.projectFolders,
+              activeProject: reconciled.activeProject,
+            },
+          ),
+          retainedArchivedPreviewSessionId(
             sessions,
-            projects: s.projects,
-            projectFolders: reconciled.projectFolders,
-            activeProject: reconciled.activeProject,
-          },
+            s.archivedPreviewSessionId,
+          ),
         ),
       };
     });
@@ -3408,9 +3523,12 @@ export const useAppStore = create<AppStateModel>()(
     if (isArchivedSession(target)) return target;
 
     const archivedAt = new Date().toISOString();
+    const cascadeIds = sessionRemovalCascadeIds(get().sessions, target);
     set((s) => {
       const sessions = s.sessions.map((session) =>
-        session.id === id ? { ...session, archived_at: archivedAt } : session,
+        cascadeIds.has(session.id)
+          ? { ...session, archived_at: session.archived_at ?? archivedAt }
+          : session,
       );
       const reconciled = reconcileWorkspaces(
         sessions,
@@ -3422,6 +3540,9 @@ export const useAppStore = create<AppStateModel>()(
         s.activeProjectFolderId,
         true,
       );
+      const previewId = cascadeIds.has(s.activeSessionId ?? "")
+        ? id
+        : retainedArchivedPreviewSessionId(sessions, s.archivedPreviewSessionId);
       return {
         sessions,
         error: null,
@@ -3432,15 +3553,18 @@ export const useAppStore = create<AppStateModel>()(
         sessionFolderIds: reconciled.sessionFolderIds,
         activeProject: reconciled.activeProject,
         activeProjectFolderId: reconciled.activeProjectFolderId,
-        ...mirrorActive(
-          reconciled.workspaces,
-          reconciled.activeProjectFolderId,
-          {
-            sessions,
-            projects: s.projects,
-            projectFolders: reconciled.projectFolders,
-            activeProject: reconciled.activeProject,
-          },
+        ...withArchivedPreview(
+          mirrorActive(
+            reconciled.workspaces,
+            reconciled.activeProjectFolderId,
+            {
+              sessions,
+              projects: s.projects,
+              projectFolders: reconciled.projectFolders,
+              activeProject: reconciled.activeProject,
+            },
+          ),
+          previewId,
         ),
       };
     });
@@ -3545,6 +3669,11 @@ export const useAppStore = create<AppStateModel>()(
   },
 
   async adoptSessionWorktree(id, worktreePath) {
+    const target = get().sessions.find((session) => session.id === id);
+    if (target && isArchivedSession(target)) {
+      set({ error: SESSION_IS_ARCHIVED });
+      return;
+    }
     try {
       await api.updateSessionWorktree(id, worktreePath);
       await get().refreshSessions();
@@ -3838,6 +3967,14 @@ export const useAppStore = create<AppStateModel>()(
           targetSessions[0]?.id === state.activeSessionId);
       const removingRequiredSessions =
         targetSessions.length === 0 || removeSessions;
+      const archivedOccupants = sessionsUsingWorktreePath(
+        state.sessions,
+        worktreePath,
+      ).filter(isArchivedSession);
+      if (archivedOccupants.length > 0) {
+        set({ error: WORKTREE_HELD_BY_ARCHIVED_SESSION });
+        throw new Error(WORKTREE_HELD_BY_ARCHIVED_SESSION);
+      }
       if (
         sessionsOutsideProject.length > 0 ||
         !canRemoveSessions ||

--- a/tests/e2e/session-archive.spec.ts
+++ b/tests/e2e/session-archive.spec.ts
@@ -121,12 +121,29 @@ test.describe("session archive", () => {
     );
     expect(removeCalls).toEqual([]);
 
-    await sidebar.getByRole("button", { name: /Archived/ }).click();
-    const archivedRow = sidebar.getByRole("button", {
-      name: /alpha.*Ready/,
+    const preview = page.getByRole("dialog", {
+      name: /archived session preview/i,
     });
-    await expect(archivedRow).toBeVisible();
-    await archivedRow.click();
+    await expect(preview).toBeVisible();
+    await expect(
+      preview.getByRole("button", { name: "Restore", exact: true }),
+    ).toBeVisible();
+    await expect(
+      preview.getByRole("button", { name: "Remove", exact: true }),
+    ).toBeVisible();
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (window as unknown as { __resumeCalls?: unknown[] }).__resumeCalls
+                ?.length ?? 0,
+          ),
+        { timeout: 1_000 },
+      )
+      .toBe(0);
+
+    await preview.getByRole("button", { name: "Restore", exact: true }).click();
 
     await expect
       .poll(
@@ -139,9 +156,200 @@ test.describe("session archive", () => {
         { timeout: 3_000 },
       )
       .toBe(1);
+    await expect(preview).toHaveCount(0);
     await expect(
       sidebar.getByRole("button", { name: /alpha.*Ready/ }),
     ).toBeVisible();
+  });
+
+  test("restore banner spawns a PTY after preview", async ({ page, tauri }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.handle("list_sessions", () => {
+      const w = window as unknown as { __archived?: boolean };
+      return [
+        {
+          id: "s-live",
+          name: "feature-auth",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.acorn/worktrees/feature-auth",
+          branch: "feat/auth",
+          isolated: true,
+          in_worktree: true,
+          status: "working",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-04-01T00:00:08Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          title_source: "default",
+          archived_at: null,
+        },
+        {
+          id: "s-1",
+          name: "alpha",
+          repo_path: "/tmp/demo",
+          worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+          branch: "main",
+          isolated: true,
+          in_worktree: true,
+          status: "ready",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:05Z",
+          last_message: null,
+          kind: "regular",
+          owner: { kind: "user" },
+          position: null,
+          title_source: "default",
+          archived_at: w.__archived === false ? null : "2026-04-01T00:00:00Z",
+        },
+      ];
+    });
+    await tauri.handle("resume_session", (args) => {
+      const w = window as unknown as {
+        __resumeCalls?: unknown[];
+        __archived?: boolean;
+      };
+      w.__resumeCalls = w.__resumeCalls ?? [];
+      w.__resumeCalls.push(args);
+      w.__archived = false;
+      return {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+        branch: "main",
+        isolated: true,
+        in_worktree: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        title_source: "default",
+        archived_at: null,
+      };
+    });
+    await tauri.handle("pty_spawn", (args) => {
+      const w = window as unknown as { __ptySpawnCalls?: unknown[] };
+      w.__ptySpawnCalls = w.__ptySpawnCalls ?? [];
+      w.__ptySpawnCalls.push(args);
+      return null;
+    });
+
+    await page.goto("/");
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await sidebar.getByRole("button", { name: /Archived/ }).click();
+    await sidebar.getByRole("button", { name: /alpha.*Ready/ }).click();
+    const preview = page.getByRole("dialog", {
+      name: /archived session preview/i,
+    });
+    await expect(preview).toBeVisible();
+    await expect(
+      preview.getByRole("button", { name: "Restore", exact: true }),
+    ).toBeVisible();
+
+    const previewSpawns = (await page.evaluate(
+      () =>
+        (window as unknown as { __ptySpawnCalls?: Array<{ sessionId: string }> })
+          .__ptySpawnCalls ?? [],
+    )) as Array<{ sessionId: string }>;
+    expect(previewSpawns.filter((call) => call.sessionId === "s-1")).toEqual(
+      [],
+    );
+
+    await preview.getByRole("button", { name: "Restore", exact: true }).click();
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            () =>
+              (
+                (window as unknown as {
+                  __ptySpawnCalls?: Array<{ sessionId: string }>;
+                }).__ptySpawnCalls ?? []
+              ).filter((call) => call.sessionId === "s-1").length,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThanOrEqual(1);
+
+    const restoredSpawns = (await page.evaluate(
+      () =>
+        (window as unknown as {
+          __ptySpawnCalls?: Array<{ sessionId: string; cwd: string }>;
+        }).__ptySpawnCalls ?? [],
+    )) as Array<{ sessionId: string; cwd: string }>;
+    const spawned = restoredSpawns.find((call) => call.sessionId === "s-1");
+    expect(spawned?.cwd).toBe("/tmp/demo/.acorn/worktrees/alpha");
+    await expect(preview).toHaveCount(0);
+  });
+
+  test("removes an archived session from the sidebar context menu", async ({
+    page,
+    tauri,
+  }) => {
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [
+      {
+        id: "s-live",
+        name: "feature-auth",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/feature-auth",
+        branch: "feat/auth",
+        isolated: true,
+        in_worktree: true,
+        status: "working",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-04-01T00:00:08Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        title_source: "default",
+        archived_at: null,
+      },
+      {
+        id: "s-1",
+        name: "alpha",
+        repo_path: "/tmp/demo",
+        worktree_path: "/tmp/demo/.acorn/worktrees/alpha",
+        branch: "main",
+        isolated: true,
+        in_worktree: true,
+        status: "ready",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:05Z",
+        last_message: null,
+        kind: "regular",
+        owner: { kind: "user" },
+        position: null,
+        title_source: "default",
+        archived_at: "2026-04-01T00:00:00Z",
+      },
+    ]);
+
+    await page.goto("/");
+    const sidebar = page.locator('[data-testid="sidebar"]');
+    await sidebar.getByRole("button", { name: /Archived/ }).click();
+    await sidebar.getByRole("button", { name: /alpha.*Ready/ }).click({
+      button: "right",
+    });
+
+    await expect(
+      page.getByRole("menuitem", { name: "Resume Session", exact: true }),
+    ).toBeVisible();
+    await page
+      .getByRole("menuitem", { name: "Remove Session", exact: true })
+      .click();
+
+    await expect(page.getByRole("heading", { name: "Remove session" })).toBeVisible();
+    await expect(
+      page.getByRole("dialog", { name: /archived session preview/i }),
+    ).toHaveCount(0);
   });
 
   test("resumes an archived session from the command palette", async ({


### PR DESCRIPTION
## Summary
Parked sessions now open as a fullscreen preview overlay (the same expanded-shell shape as the kanban terminal maximize control) instead of a workspace tab. Restore and remove sit in the header. Resume respawns the PTY; archived chat hides the composer.

## Expected impact
- Sidebar **Archived** row click opens a modal over panes, kanban, and canvas. No tab chip.
- Header **Restore** unparks the same session id and spawns a live PTY. **Remove** (and sidebar context **Remove Session**) confirms deletion without deleting the worktree.
- Project Settings cannot delete a worktree still referenced by an archived session.
- Control-session archive also parks owned workers. Resume of the controller restores them.
- Missing worktrees restore at the original path from the recorded branch; occupying non-git directories are not abandoned for a second checkout.

## Design notes
- Preview state is `archivedPreviewSessionId` in the frontend store. It is not persisted and is dismissed by Escape, overlay click, Cmd+W, or switching to a live tab.
- Agent resume probing skips archived sessions and does not pop the conversation modal immediately after unparking.
- `pty_spawn` and worktree adoption refuse archived session ids.

## Follow-up (not in this PR)
- Auto-archive by inactivity or PR merge.
- Recreating a worktree when the git branch itself is gone.

## Test plan
- [x] `pnpm exec tsc --noEmit -p tsconfig.json` — pass
- [x] `pnpm exec vitest run src/store.test.ts src/lib/sessionWorktree.test.ts src/components/ProjectSettingsModal.test.tsx` — 215 pass
- [x] `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` — pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib restore_session_worktree` — 6 pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib archive_session` — 2 pass
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib remove_worktree_rejects` — 2 pass
- [x] `PLAYWRIGHT_PORT=1425 pnpm exec playwright test tests/e2e/session-archive.spec.ts --workers=1` — 4 pass

## Notes
- Changelog label: `feat`
- Follow-up to #892.