### PR TITLE
fix(terminal): stop mouse reports from cancelling the deferred image paste

### DIFF
--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -87,6 +87,7 @@ import {
   AGENT_IMAGE_PASTE_CONTROL,
   getClipboardImageFile,
   hasClipboardImagePayload,
+  isTerminalProtocolReply,
   terminalPasteAction,
   type ClipboardImageFile,
 } from "../lib/terminalPaste";
@@ -1431,7 +1432,9 @@ export function Terminal({
     // reached the PTY as input". PTY *output* must not bump this:
     // a busy agent (spinner, streaming) emits output continuously, and
     // counting it cancelled every deferred image paste while an agent
-    // was running.
+    // was running. Terminal protocol replies (mouse reports, focus
+    // events, query responses) also flow through onData and must not
+    // bump it either — see `isTerminalProtocolReply`.
     let terminalInputVersion = 0;
     let imagePasteFallbackTimer: number | null = null;
     let imagePasteFallbackSerial = 0;
@@ -2532,7 +2535,14 @@ export function Terminal({
     );
 
     const inputDisposable = term.onData((data: string) => {
-      terminalInputVersion += 1;
+      // Mouse reports, focus events, and query replies also arrive through
+      // onData but are terminal protocol chatter, not user input. Counting
+      // them cancelled the deferred image paste whenever the pointer moved
+      // over a mouse-tracking TUI (Claude/Codex/Grok emit motion reports
+      // continuously), and the retry that finally survived attached the
+      // image late — right after an unrelated gesture such as the
+      // right-click selection paste.
+      if (!isTerminalProtocolReply(data)) terminalInputVersion += 1;
       sendUserInputToPty(data);
       if (data.includes("\r") || data.includes("\n")) {
         commandSizeSyncScheduler.schedule();

--- a/src/lib/terminalPaste.test.ts
+++ b/src/lib/terminalPaste.test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_IMAGE_PASTE_CONTROL,
   getClipboardImageFile,
   hasClipboardImagePayload,
+  isTerminalProtocolReply,
   terminalPasteAction,
   type ClipboardImageFile,
 } from "./terminalPaste";
@@ -56,6 +57,38 @@ describe("terminalPasteAction", () => {
         normalizeUnicodeSpaces: false,
       }),
     ).toEqual({ kind: "pasteText", text: "pnpm\u00a0run\u202fdev" });
+  });
+});
+
+describe("isTerminalProtocolReply", () => {
+  it.each([
+    ["SGR mouse motion report", "\x1b[<35;55;34M"],
+    ["SGR wheel report", "\x1b[<65;55;34M"],
+    ["SGR button release report", "\x1b[<0;27;40m"],
+    ["concatenated SGR reports", "\x1b[<35;1;1M\x1b[<35;2;1M"],
+    ["legacy X10 mouse report", "\x1b[M @B"],
+    ["focus in", "\x1b[I"],
+    ["focus out", "\x1b[O"],
+    ["OSC color query response (ST)", "\x1b]11;rgb:ffff/ffff/ffff\x1b\\"],
+    ["OSC color query response (BEL)", "\x1b]11;rgb:0000/0000/0000\x07"],
+    ["primary DA response", "\x1b[?1;2c"],
+    ["secondary DA response", "\x1b[>0;276;0c"],
+    ["DECRPM response", "\x1b[?2026;2$y"],
+    ["cursor position report", "\x1b[24;80R"],
+  ])("treats %s as protocol chatter", (_label, data) => {
+    expect(isTerminalProtocolReply(data)).toBe(true);
+  });
+
+  it.each([
+    ["plain text", "a"],
+    ["enter", "\r"],
+    ["ctrl+c", "\x03"],
+    ["arrow key", "\x1b[A"],
+    ["bracketed paste", "\x1b[200~hello\x1b[201~"],
+    ["mouse report followed by typed text", "\x1b[<35;1;1Mhello"],
+    ["empty string", ""],
+  ])("keeps %s counted as user input", (_label, data) => {
+    expect(isTerminalProtocolReply(data)).toBe(false);
   });
 });
 

--- a/src/lib/terminalPaste.ts
+++ b/src/lib/terminalPaste.ts
@@ -123,6 +123,31 @@ export function hasClipboardImagePayload(
   return false;
 }
 
+// Sequences xterm emits on its data channel that are terminal protocol
+// replies rather than keyboard input: SGR/X10 mouse reports, focus in/out,
+// OSC query responses (e.g. background color), DA/DECRPM reports, and
+// cursor-position reports. A mouse-tracking TUI streams motion reports
+// continuously, so treating these as user input cancelled the deferred
+// image-paste fallback whenever the pointer moved — and let the one paste
+// that survived land late, after an unrelated gesture.
+const TERMINAL_PROTOCOL_REPLY_RE = new RegExp(
+  "^(?:" +
+    [
+      "\\x1b\\[<\\d+;\\d+;\\d+[Mm]", // SGR mouse report
+      "\\x1b\\[M[\\s\\S]{3}", // legacy X10 mouse report
+      "\\x1b\\[[IO]", // focus in / focus out
+      "\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)", // OSC response
+      "\\x1b\\[[?>][\\d;]*c", // primary/secondary DA response
+      "\\x1b\\[\\?[\\d;]*\\$y", // DECRPM response
+      "\\x1b\\[\\d+;\\d+R", // cursor position report
+    ].join("|") +
+    ")+$",
+);
+
+export function isTerminalProtocolReply(data: string): boolean {
+  return data.length > 0 && TERMINAL_PROTOCOL_REPLY_RE.test(data);
+}
+
 export function terminalPasteAction({
   text,
   hasImagePayload,


### PR DESCRIPTION
## TL;DR

Pasting a clipboard image into an agent TUI silently failed whenever the pointer moved, and the attempt that eventually succeeded attached the image at an unrelated moment — most visibly right after a right-click selection paste, which made the selection paste look like it pasted the clipboard image too.

## Root cause

`scheduleClipboardImageFallback` defers the image attach by 500 ms and cancels itself when `terminalInputVersion` advances, which is meant to say "the paste already reached the PTY as real input". Every `term.onData` callback bumped that counter, but `onData` is not only keyboard input: inside a mouse-tracking TUI (Claude, Codex, Grok) it also carries SGR mouse motion reports, focus in/out events, and terminal query responses, and those stream continuously while the pointer moves. Any pointer movement inside the 500 ms window therefore cancelled the pending image attach without a trace, so the user pressed Cmd+V again; the one attempt that happened to land while the mouse was still then fired 500 ms later, landing after whatever gesture came next.

## Fix

`isTerminalProtocolReply` classifies the sequences xterm emits as protocol replies rather than user input — SGR and legacy X10 mouse reports, focus in/out, OSC query responses, primary/secondary DA replies, DECRPM replies, and cursor position reports — and `onData` no longer bumps the input version for them. Bracketed pastes and ordinary keystrokes still count as input, so a real keystroke or text paste cancels a pending image attach exactly as before.

## Verification

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run test` — 135 files, 1580 tests passing, including 20 new cases covering both directions of the classifier
- [x] Reproduced and confirmed fixed in a local dev build (`ACORN_PROFILE=dev`): with a screenshot on the clipboard, Cmd+V while moving the pointer over a mouse-tracking TUI previously cancelled the attach on 7 of 8 attempts; instrumented logs showed `versionMatch: false` on every cancelled run

## Not covered by this PR

Grok attaches a clipboard image on any bracketed paste it receives, independent of Acorn. Verified with five controlled headless runs (image on the clipboard, plain text sent as a bracketed paste): Grok wrote a new attachment into `~/.grok/sessions/<id>/images/` every time, including with `GROK_CLIPBOARD_NO_NATIVE_READ` and the other clipboard opt-outs set, and regardless of whether the clipboard also held text matching the pasted payload. Acorn cannot suppress that without clearing the user's clipboard, so it needs an upstream report rather than a change here. Claude only probes the clipboard when the pasted payload is empty, and Codex gates it behind its explicit `paste_image` key action, so neither is affected.
