### PR TITLE
feat(tabs): add keyboard shortcuts to minimize and restore tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1658,6 +1658,11 @@ function App() {
       }
       toggleMultiInput();
     };
+    const setActiveTabMinimized = (minimized: boolean) => {
+      const { activeTabId } = useAppStore.getState();
+      if (!activeTabId) return;
+      useAppStore.getState().setTabMinimized(activeTabId, minimized);
+    };
 
     const next: HotkeyBindings = {
       [shortcuts.openPalette]: (e: KeyboardEvent) => {
@@ -1825,6 +1830,14 @@ function App() {
         e.preventDefault();
         if (closeTerminalPopoverFromHotkey()) return;
         useAppStore.getState().closeFocusedTab();
+      },
+      [shortcuts.minimizeTab]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        setActiveTabMinimized(true);
+      },
+      [shortcuts.expandTab]: (e: KeyboardEvent) => {
+        e.preventDefault();
+        setActiveTabMinimized(false);
       },
       [shortcuts.nextTab]: (e: KeyboardEvent) => {
         e.preventDefault();

--- a/src/components/Pane.tsx
+++ b/src/components/Pane.tsx
@@ -1449,6 +1449,10 @@ function TabItem({
         minimized ? "pane.menu.expandTab" : "pane.menu.minimizeTab",
       ),
       icon: minimized ? <Maximize2 size={12} /> : <Minimize2 size={12} />,
+      shortcut: shortcutLabel(
+        shortcuts,
+        minimized ? "expandTab" : "minimizeTab",
+      ),
       onClick: () => setTabMinimized(tab.id, !minimized),
     },
     {

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -1269,6 +1269,8 @@ describe("SettingsModal font controls", () => {
     expect(bodyText).toContain("Focus pane below");
     expect(bodyText).toContain("Find in current view");
     expect(bodyText).toContain("Rename selected item");
+    expect(bodyText).toContain("Minimize focused tab");
+    expect(bodyText).toContain("Restore minimized tab");
     expect(bodyText).toContain("Right panel");
     expect(bodyText).toContain("Record");
     expect(bodyText).toMatch(/⌘P|Ctrl\+P/);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -314,6 +314,14 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
         labelKey: "settings.shortcuts.items.closeTab.label",
       },
       {
+        id: "minimizeTab",
+        labelKey: "settings.shortcuts.items.minimizeTab.label",
+      },
+      {
+        id: "expandTab",
+        labelKey: "settings.shortcuts.items.expandTab.label",
+      },
+      {
         id: "closeEmptyPane",
         labelKey: "settings.shortcuts.items.closeEmptyPane.label",
         descriptionKey: "settings.shortcuts.items.closeEmptyPane.description",

--- a/src/lib/hotkeys.test.ts
+++ b/src/lib/hotkeys.test.ts
@@ -191,6 +191,13 @@ describe("resolveHotkeys", () => {
     expect(DEFAULT_HOTKEYS.renameItem).toBe("F2");
   });
 
+  it("keeps tab minimize and restore off the native window-minimize chord", () => {
+    expect(DEFAULT_HOTKEYS.minimizeTab).toBe("$mod+Shift+m");
+    expect(DEFAULT_HOTKEYS.expandTab).toBe("$mod+Alt+KeyM");
+    expect(DEFAULT_HOTKEYS.minimizeTab).not.toBe("$mod+m");
+    expect(DEFAULT_HOTKEYS.expandTab).not.toBe("$mod+m");
+  });
+
   it("keeps the persisted commits binding unchanged for contextual terminal routing", () => {
     expect(DEFAULT_HOTKEYS.toggleCommits).toBe("$mod+Shift+c");
     expect(

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -45,6 +45,10 @@ export const DEFAULT_HOTKEYS = {
   splitHorizontal: "$mod+Shift+d",
   equalizePanes: "$mod+Alt+KeyE",
   closeTab: "$mod+w",
+  // Cmd+M is the native Window > Minimize accelerator, so tab
+  // minimize/restore sit on Shift/Alt variants of M instead.
+  minimizeTab: "$mod+Shift+m",
+  expandTab: "$mod+Alt+KeyM",
   closeEmptyPane: "Escape",
   openSettings: "$mod+Comma",
   // Mirrors Ghostty's "Reload Config" gesture. Dotfile env values

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -665,6 +665,12 @@
         "closeTab": {
           "label": "Close focused tab"
         },
+        "minimizeTab": {
+          "label": "Minimize focused tab"
+        },
+        "expandTab": {
+          "label": "Restore minimized tab"
+        },
         "closeEmptyPane": {
           "label": "Close empty pane",
           "description": "Only works when the focused pane has no tabs."

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -665,6 +665,12 @@
         "closeTab": {
           "label": "フォーカスされたタブを閉じる"
         },
+        "minimizeTab": {
+          "label": "フォーカスされたタブを最小化"
+        },
+        "expandTab": {
+          "label": "最小化されたタブを復元"
+        },
         "closeEmptyPane": {
           "label": "空のペインを閉じる",
           "description": "フォーカスされたペインにタブがない場合にのみ機能します。"

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -665,6 +665,12 @@
         "closeTab": {
           "label": "포커스된 탭 닫기"
         },
+        "minimizeTab": {
+          "label": "포커스된 탭 최소화"
+        },
+        "expandTab": {
+          "label": "최소화된 탭 복구"
+        },
         "closeEmptyPane": {
           "label": "빈 Pane 닫기",
           "description": "포커스된 Pane에 탭이 없을 때만 작동합니다."

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -665,6 +665,12 @@
         "closeTab": {
           "label": "关闭当前标签页"
         },
+        "minimizeTab": {
+          "label": "最小化当前标签页"
+        },
+        "expandTab": {
+          "label": "还原最小化的标签页"
+        },
         "closeEmptyPane": {
           "label": "关闭空窗格",
           "description": "仅当聚焦的窗格没有标签页时才有效。"

--- a/tests/e2e/panes.spec.ts
+++ b/tests/e2e/panes.spec.ts
@@ -863,4 +863,45 @@ test.describe("pane / sidebar shortcuts", () => {
     await expect(restored).not.toHaveAttribute("data-tab-minimized", "true");
     await expect(restored.getByText("beta", { exact: true })).toBeVisible();
   });
+
+  test("minimize and restore shortcuts collapse and expand the focused tab", async ({
+    page,
+    tauri,
+  }) => {
+    const beta = {
+      ...SESSION,
+      id: "s-2",
+      name: "beta",
+      created_at: "2026-01-01T00:00:01Z",
+      updated_at: "2026-01-01T00:00:06Z",
+    };
+    await tauri.respond("list_projects", [PROJECT]);
+    await tauri.respond("list_sessions", [SESSION, beta]);
+
+    await page.goto("/");
+
+    await page
+      .locator('[data-testid="sidebar"]')
+      .getByRole("button", { name: /^alpha main · Ready/ })
+      .first()
+      .click();
+
+    const betaTab = page.locator('[data-pane-tab-strip] [data-pane-tab="s-2"]');
+    await expect(betaTab).toBeVisible();
+    await betaTab.click();
+
+    await pressHotkey(page, { mod: true, shift: true, key: "m" });
+    await expect(betaTab).toHaveAttribute("data-tab-minimized", "true");
+    await expect(betaTab.getByText("beta", { exact: true })).toHaveCount(0);
+
+    await betaTab.click({ button: "right" });
+    await expect(
+      page.getByRole("menuitem", { name: "Expand Tab" }).locator("kbd"),
+    ).toHaveText(/^(⌥⌘M|Ctrl\+Alt\+M)$/);
+    await page.keyboard.press("Escape");
+
+    await pressHotkey(page, { mod: true, alt: true, key: "m" });
+    await expect(betaTab).not.toHaveAttribute("data-tab-minimized", "true");
+    await expect(betaTab.getByText("beta", { exact: true })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- Add configurable shortcuts for pane-tab and sidebar minimize/restore (`⌘⇧M` / `⌥⌘M` by default).
- Shortcuts operate on the focused tab, matching Close Tab, and show in the tab/sidebar context menus plus Settings → Shortcuts.
- Defaults avoid `⌘M` / `Ctrl+M` so native Window → Minimize keeps that chord.

## Expected impact
Minimizing and restoring a tab no longer requires the context menu. Existing mouse flow is unchanged. Sidebar chips stay in sync because they share `setTabMinimized`.

## Design notes
- `setTabMinimized` is unchanged: minimize is still layout-only, not hide/archive, and does not kill the PTY.
- Restore uses `$mod+Alt+KeyM` so macOS Option does not rewrite `event.key`.
- If the focused tab is already in the requested state, the shortcut is a no-op.

## Test plan
- [x] `pnpm exec vitest run src/lib/hotkeys.test.ts src/lib/i18n.test.ts src/components/SettingsModal.test.tsx`
- [x] `pnpm run typecheck`
- [x] `PLAYWRIGHT_PORT=1430 pnpm exec playwright test tests/e2e/panes.spec.ts --grep "minimize"`
- [ ] Focus a pane tab, press the minimize shortcut, confirm the icon chip and sidebar strip; press restore, confirm title and close button return.
- [ ] Settings → Shortcuts lists both commands and lets them be rebound.

## Notes
- Manual: confirm `⌘M` still minimizes the app window on macOS.