### PR TITLE
fix(terminal): stop Korean input reading one syllable behind

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,15 @@
   opacity: 0 !important;
 }
 
+/* Inline-block so the cell-grid `min-width` set in Terminal.tsx applies; the
+   caret anchor then starts on the same cell boundary the real cursor uses. */
+.acorn-terminal
+  .composition-view
+  .acorn-ime-composition-text {
+  display: inline-block;
+  vertical-align: top;
+}
+
 .acorn-terminal
   .composition-view
   .acorn-ime-composition-cursor {

--- a/src/App.css
+++ b/src/App.css
@@ -187,8 +187,9 @@
   opacity: 0 !important;
 }
 
-/* Inline-block so the cell-grid `min-width` set in Terminal.tsx applies; the
-   caret anchor then starts on the same cell boundary the real cursor uses. */
+/* Inline-block so the per-character cell boxes Terminal.tsx builds lay out on
+   one line; the caret anchor then starts on the cell boundary the real cursor
+   uses, less the inset applied there. */
 .acorn-terminal
   .composition-view
   .acorn-ime-composition-text {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -304,10 +304,47 @@ function terminalLineTailEndColumn(term: XTerm): number {
   return buffer.cursorX;
 }
 
+/**
+ * Row-geometry cache for `renderTerminalLineTail`.
+ *
+ * Measuring the source row forces a synchronous layout, and the tail is
+ * re-rendered several times per IME keystroke (WKWebView fires
+ * `insertCompositionText` + `insertText` for one jamo). The span rects only
+ * change when xterm repaints or the viewport scrolls, so hold them until
+ * `invalidateTerminalLineTailCache` is called from those events.
+ */
+interface TerminalLineTailCache {
+  row: HTMLElement | null;
+  cols: number;
+  rowLeft: number;
+  rowWidth: number;
+  spans: Array<{ span: HTMLElement; left: number; right: number }>;
+}
+
+function createTerminalLineTailCache(): TerminalLineTailCache {
+  return { row: null, cols: 0, rowLeft: 0, rowWidth: 0, spans: [] };
+}
+
+function invalidateTerminalLineTailCache(cache: TerminalLineTailCache): void {
+  cache.row = null;
+  cache.spans = [];
+}
+
+/** Attribute-only identity of a cloned span; `outerHTML` on the hot path
+ *  serialised the whole node once per cell for the same comparison. */
+function tailRunStyleKey(element: HTMLElement): string {
+  let key = "";
+  for (const attribute of Array.from(element.attributes)) {
+    key += `${attribute.name}=${attribute.value} `;
+  }
+  return key;
+}
+
 function renderTerminalLineTail(
   term: XTerm,
   container: HTMLElement,
   tailView: HTMLElement,
+  cache: TerminalLineTailCache,
 ): void {
   const buffer = term.buffer.active;
   const line = buffer.getLine(buffer.baseY + buffer.cursorY);
@@ -327,11 +364,21 @@ function renderTerminalLineTail(
   // Reuse the DOM renderer's resolved spans instead of reimplementing xterm's
   // ANSI, true-color, inverse, dim, and decoration rules. The cloned text is
   // rebuilt from buffer cells so only the tail at/after the cursor is shown.
-  const sourceSpans = Array.from(
-    sourceRow.querySelectorAll<HTMLElement>("span"),
-  ).map((span) => ({ span, rect: span.getBoundingClientRect() }));
-  const rowRect = sourceRow.getBoundingClientRect();
-  const renderedCellWidth = rowRect.width / term.cols;
+  if (cache.row !== sourceRow || cache.cols !== term.cols) {
+    const rowRect = sourceRow.getBoundingClientRect();
+    cache.row = sourceRow;
+    cache.cols = term.cols;
+    cache.rowLeft = rowRect.left;
+    cache.rowWidth = rowRect.width;
+    cache.spans = Array.from(
+      sourceRow.querySelectorAll<HTMLElement>("span"),
+    ).map((span) => {
+      const rect = span.getBoundingClientRect();
+      return { span, left: rect.left, right: rect.right };
+    });
+  }
+  const sourceSpans = cache.spans;
+  const renderedCellWidth = cache.rowWidth / term.cols;
   if (renderedCellWidth <= 0 || sourceSpans.length === 0) {
     tailView.textContent = line.translateToString(true, buffer.cursorX);
     return;
@@ -340,6 +387,10 @@ function renderTerminalLineTail(
   const fragment = document.createDocumentFragment();
   let previousStyleKey = "";
   let previousClone: HTMLElement | null = null;
+  // `cellCenter` grows monotonically with `column`, so the matching span can
+  // only move forward — a rescan from the start per cell made this O(cells ×
+  // spans) on a full-width line.
+  let spanIndex = 0;
   for (let column = buffer.cursorX; column < endColumn; ) {
     const cell = line.getCell(column);
     if (!cell) break;
@@ -357,12 +408,16 @@ function renderTerminalLineTail(
         : " ";
 
     const cellCenter =
-      rowRect.left + (column + width / 2) * renderedCellWidth;
+      cache.rowLeft + (column + width / 2) * renderedCellWidth;
+    while (
+      spanIndex < sourceSpans.length &&
+      cellCenter >= sourceSpans[spanIndex].right + 0.5
+    ) {
+      spanIndex += 1;
+    }
+    const candidate = sourceSpans[spanIndex];
     const source =
-      sourceSpans.find(
-        ({ rect }) =>
-          rect.left - 0.5 <= cellCenter && cellCenter < rect.right + 0.5,
-      )?.span ?? null;
+      candidate && candidate.left - 0.5 <= cellCenter ? candidate.span : null;
     const clone = source
       ? (source.cloneNode(false) as HTMLElement)
       : document.createElement("span");
@@ -376,7 +431,7 @@ function renderTerminalLineTail(
     }
     clone.removeAttribute("id");
     clone.classList.add("acorn-ime-tail-run");
-    const styleKey = clone.outerHTML;
+    const styleKey = tailRunStyleKey(clone);
     if (previousClone && previousStyleKey === styleKey) {
       previousClone.textContent = `${previousClone.textContent ?? ""}${text}`;
     } else {
@@ -1624,8 +1679,39 @@ export function Terminal({
     compositionCursorView.setAttribute("aria-hidden", "true");
     const compositionTailView = document.createElement("span");
     compositionTailView.className = "acorn-ime-line-tail xterm-rows";
+    const lineTailCache = createTerminalLineTailCache();
     let composingText = "";
 
+    // A committed syllable is sent to the PTY but does not appear on screen
+    // until the agent echoes it back — one IPC round trip plus a TUI redraw
+    // later. Clearing the overlay at commit time leaves that syllable in
+    // neither the overlay nor the xterm buffer for the whole window, which is
+    // the "typing is one syllable behind" feel. Keep it painted at the cell it
+    // was committed from; the echo advances the cursor, which is exactly when
+    // the buffer takes ownership and the hold can drop.
+    const PENDING_COMMIT_MAX_MS = 400;
+    let pendingCommit: { text: string; x: number; y: number } | null = null;
+    let pendingCommitTimer: number | null = null;
+
+    const clearPendingCommit = () => {
+      pendingCommit = null;
+      if (pendingCommitTimer !== null) {
+        window.clearTimeout(pendingCommitTimer);
+        pendingCommitTimer = null;
+      }
+    };
+    /** Drop the hold once the cursor leaves the cell it was committed from —
+     *  the echo landed, or the TUI redrew somewhere else. */
+    const dropEchoedPendingCommit = () => {
+      if (!pendingCommit) return;
+      const buf = term.buffer.active;
+      if (
+        buf.cursorX !== pendingCommit.x ||
+        buf.baseY + buf.cursorY !== pendingCommit.y
+      ) {
+        clearPendingCommit();
+      }
+    };
     const positionComposing = () => {
       if (!compositionView) return;
       const cell = getCellDims();
@@ -1657,13 +1743,18 @@ export function Terminal({
         );
       }
     };
-    const renderComposing = () => {
-      if (!compositionView || composingText.length === 0) return;
-      compositionTextView.textContent = composingText;
+    const renderComposing = (text: string) => {
+      if (!compositionView || text.length === 0) return;
+      compositionTextView.textContent = text;
       // Until the PTY receives a committed composition, its buffer still has
       // the text under and after the cursor in the old position. Mirror that
       // tail after the preview so mid-line composition reads as insertion.
-      renderTerminalLineTail(term, container, compositionTailView);
+      renderTerminalLineTail(
+        term,
+        container,
+        compositionTailView,
+        lineTailCache,
+      );
       compositionCursorView.dataset.acornImeCursorStyle =
         cursorApplicationStyle ??
         useSettings.getState().settings.terminal.cursorStyle;
@@ -1701,24 +1792,60 @@ export function Terminal({
         compositionView.style.backgroundColor = background;
       }
     };
-    const hideComposing = () => {
-      composingText = "";
-      container.classList.remove(COMPOSING_CLASS);
+    /**
+     * Single owner of the overlay's visible state: the syllable still being
+     * composed, prefixed by any committed syllable whose echo has not landed
+     * yet. Empty on both counts tears the overlay down.
+     */
+    const syncComposing = (): void => {
       if (!compositionView) return;
-      compositionView.classList.remove("active");
-      compositionView.replaceChildren();
-    };
-    const showComposing = (text: string) => {
-      if (!compositionView) return;
+      dropEchoedPendingCommit();
+      const text = `${pendingCommit?.text ?? ""}${composingText}`;
       if (text.length === 0) {
-        hideComposing();
+        container.classList.remove(COMPOSING_CLASS);
+        compositionView.classList.remove("active");
+        compositionView.replaceChildren();
         return;
       }
-      composingText = text;
       container.classList.add(COMPOSING_CLASS);
-      renderComposing();
+      renderComposing(text);
       positionComposing();
       compositionView.classList.add("active");
+    };
+    /** Ends the live preview. The overlay survives while a committed syllable
+     *  is still in flight to the PTY. */
+    const hideComposing = () => {
+      composingText = "";
+      syncComposing();
+    };
+    const showComposing = (text: string) => {
+      composingText = text;
+      syncComposing();
+    };
+
+    const holdCommittedText = (text: string) => {
+      if (text.length === 0) return;
+      // Typing faster than the echo commits several syllables against the
+      // same cell. Whatever survives this call is still anchored there, so
+      // append rather than replace — dropping the earlier syllable would
+      // reopen the very gap this hold exists to cover.
+      dropEchoedPendingCommit();
+      const buf = term.buffer.active;
+      pendingCommit = {
+        text: `${pendingCommit?.text ?? ""}${text}`,
+        x: buf.cursorX,
+        y: buf.baseY + buf.cursorY,
+      };
+      // A PTY that never echoes (dead shell, password prompt) would otherwise
+      // leave the held text painted forever.
+      if (pendingCommitTimer !== null) {
+        window.clearTimeout(pendingCommitTimer);
+      }
+      pendingCommitTimer = window.setTimeout(() => {
+        pendingCommitTimer = null;
+        pendingCommit = null;
+        syncComposing();
+      }, PENDING_COMMIT_MAX_MS);
     };
 
     // WKWebView delivers a single Korean syllable across a mix of
@@ -1759,7 +1886,10 @@ export function Terminal({
         ? ta.value.slice(sentPrefix.length)
         : "";
       const data = tail || explicit || "";
-      if (data) sendUserInputToPty(data);
+      if (data) {
+        sendUserInputToPty(data);
+        holdCommittedText(data);
+      }
       if (ta) ta.value = "";
       sentPrefix = "";
       composing = false;
@@ -1881,7 +2011,9 @@ export function Terminal({
           }
           const committedEnd = value.length - newCharLen;
           if (committedEnd > sentPrefix.length) {
-            sendUserInputToPty(value.slice(sentPrefix.length, committedEnd));
+            const committed = value.slice(sentPrefix.length, committedEnd);
+            sendUserInputToPty(committed);
+            holdCommittedText(committed);
             sentPrefix = value.slice(0, committedEnd);
           }
           showComposing(value.slice(sentPrefix.length));
@@ -2544,12 +2676,27 @@ export function Terminal({
     // term.write); without this, the preview stays painted at the previous
     // cursor cell and visually appears one column to the left of the new
     // cursor until the user types again.
-    const repositionComposing = () => {
+    // xterm fires render/scroll/cursor-move separately for the same repaint,
+    // and each rebuild of the overlay measures the source row (a forced
+    // layout). Coalesce them into one recompute per frame.
+    let repositionFrame: number | null = null;
+    const repositionComposingNow = () => {
+      repositionFrame = null;
       if (!compositionView || !compositionView.classList.contains("active")) {
         return;
       }
-      renderComposing();
-      positionComposing();
+      syncComposing();
+    };
+    const repositionComposing = () => {
+      // Row geometry only moves when xterm repaints or scrolls, which is
+      // exactly what got us here — keystroke-driven rebuilds in between reuse
+      // the measurements.
+      invalidateTerminalLineTailCache(lineTailCache);
+      if (repositionFrame !== null) return;
+      if (!compositionView || !compositionView.classList.contains("active")) {
+        return;
+      }
+      repositionFrame = requestAnimationFrame(repositionComposingNow);
     };
     const renderDisposable = term.onRender(repositionComposing);
     // PTY output that arrives while the user is mid-composition can scroll
@@ -3244,6 +3391,11 @@ export function Terminal({
       try { cursorFullResetParserDisposable.dispose(); } catch { /* ignore */ }
       container.removeAttribute("data-acorn-cursor-application-override");
       container.classList.remove(COMPOSING_CLASS);
+      clearPendingCommit();
+      if (repositionFrame !== null) {
+        cancelAnimationFrame(repositionFrame);
+        repositionFrame = null;
+      }
       try { fitAddon.dispose(); } catch { /* ignore */ }
       try { serializeAddon.dispose(); } catch { /* ignore */ }
       term.dispose();

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1672,6 +1672,24 @@ export function Terminal({
       const cell = core?._renderService?.dimensions?.css?.cell;
       return cell ? { width: cell.width, height: cell.height } : null;
     };
+    /** Columns the terminal would spend on `text` — 2 per Hangul syllable. */
+    const stringCellWidth = (text: string): number => {
+      type UnicodeService = { getStringCellWidth?: (value: string) => number };
+      const core = (
+        term as unknown as {
+          _core?: {
+            unicodeService?: UnicodeService;
+            _unicodeService?: UnicodeService;
+          };
+        }
+      )._core;
+      const unicode = core?.unicodeService ?? core?._unicodeService;
+      try {
+        return unicode?.getStringCellWidth?.(text) ?? 0;
+      } catch {
+        return 0;
+      }
+    };
     const compositionTextView = document.createElement("span");
     compositionTextView.className = "acorn-ime-composition-text";
     const compositionCursorView = document.createElement("span");
@@ -1746,6 +1764,16 @@ export function Terminal({
     const renderComposing = (text: string) => {
       if (!compositionView || text.length === 0) return;
       compositionTextView.textContent = text;
+      // Snap the preview to the terminal's cell grid. A Hangul syllable spends
+      // two columns, but the raw glyph advance is usually narrower than two
+      // cells, which parked the caret marker tight against the glyph instead
+      // of on the cell boundary the real cursor would sit at. `min-width` so a
+      // font whose glyphs run wider than their cells still pushes the caret
+      // out rather than colliding with it.
+      const cellDims = getCellDims();
+      const columns = stringCellWidth(text);
+      compositionTextView.style.minWidth =
+        cellDims && columns > 0 ? `${columns * cellDims.width}px` : "";
       // Until the PTY receives a committed composition, its buffer still has
       // the text under and after the cursor in the old position. Mirror that
       // tail after the preview so mid-line composition reads as insertion.

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1764,25 +1764,48 @@ export function Terminal({
         );
       }
     };
+    /** Paint `text` one cell-sized box per character. Zero-width characters
+     *  (combining marks) ride along with the character they modify. */
+    const renderComposingCells = (text: string) => {
+      const cellDims = getCellDims();
+      if (!cellDims) {
+        compositionTextView.textContent = text;
+        compositionTextView.style.marginRight = "";
+        return;
+      }
+      const cells: HTMLElement[] = [];
+      for (const char of text) {
+        const columns = stringCellWidth(char);
+        const previous = cells[cells.length - 1];
+        if (columns <= 0 && previous) {
+          previous.textContent = `${previous.textContent ?? ""}${char}`;
+          continue;
+        }
+        const cell = document.createElement("span");
+        cell.textContent = char;
+        cell.style.display = "inline-block";
+        cell.style.width = `${Math.max(1, columns) * cellDims.width}px`;
+        cells.push(cell);
+      }
+      compositionTextView.replaceChildren(...cells);
+      // Negative margin pulls the caret — the next inline box — back inside
+      // the grid without disturbing the glyph spacing before it.
+      compositionTextView.style.marginRight = `${-CARET_CELL_GRID_INSET_PX}px`;
+    };
     const renderComposing = (text: string) => {
       if (!compositionView || text.length === 0) return;
-      compositionTextView.textContent = text;
-      // Snap the preview to the terminal's cell grid. A Hangul syllable spends
-      // two columns, but the raw glyph advance is usually narrower than two
-      // cells, which parked the caret marker tight against the glyph instead
-      // of near the cell boundary the real cursor sits at. `min-width` so a
-      // font whose glyphs run wider than their cells still pushes the caret
-      // out rather than colliding with it.
+      // Lay the preview out on the terminal's cell grid. A Hangul syllable
+      // spends two columns but its glyph advance is usually narrower, so raw
+      // text bunches to the left and the caret lands short of where the real
+      // cursor will be. xterm solves this on its own rows with a per-span
+      // `letter-spacing`; giving each character a cell-sized box is the same
+      // idea and stays correct when the preview mixes widths, or holds several
+      // syllables at once because typing outran the echo.
       //
-      // The inset holds the caret just inside that boundary: dead-on reads as
-      // detached from the syllable being composed. Tuned by eye against the
-      // app's default terminal font — `CARET_CELL_GRID_INSET_PX` is the knob.
-      const cellDims = getCellDims();
-      const columns = stringCellWidth(text);
-      compositionTextView.style.minWidth =
-        cellDims && columns > 0
-          ? `${Math.max(0, columns * cellDims.width - CARET_CELL_GRID_INSET_PX)}px`
-          : "";
+      // The inset then holds the caret just inside the boundary: dead-on reads
+      // as detached from the syllable. Tuned by eye against the app's default
+      // terminal font — `CARET_CELL_GRID_INSET_PX` is the knob.
+      renderComposingCells(text);
       // Until the PTY receives a committed composition, its buffer still has
       // the text under and after the cursor in the old position. Mirror that
       // tail after the preview so mid-line composition reads as insertion.

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1675,8 +1675,9 @@ export function Terminal({
       const cell = core?._renderService?.dimensions?.css?.cell;
       return cell ? { width: cell.width, height: cell.height } : null;
     };
-    /** Columns the terminal would spend on `text` — 2 per Hangul syllable. */
-    const stringCellWidth = (text: string): number => {
+    /** Columns the terminal would spend on `text` — 2 per Hangul syllable.
+     *  `null` when the measurement is unavailable. */
+    const stringCellWidth = (text: string): number | null => {
       type UnicodeService = { getStringCellWidth?: (value: string) => number };
       const core = (
         term as unknown as {
@@ -1688,9 +1689,12 @@ export function Terminal({
       )._core;
       const unicode = core?.unicodeService ?? core?._unicodeService;
       try {
-        return unicode?.getStringCellWidth?.(text) ?? 0;
+        return unicode?.getStringCellWidth?.(text) ?? null;
       } catch {
-        return 0;
+        // Undocumented internals — an xterm bump can move or remove them.
+        // `null` means "unknown", which callers must not confuse with the
+        // legitimate 0 of a combining mark.
+        return null;
       }
     };
     const compositionTextView = document.createElement("span");
@@ -1721,17 +1725,42 @@ export function Terminal({
         pendingCommitTimer = null;
       }
     };
-    /** Drop the hold once the cursor leaves the cell it was committed from —
-     *  the echo landed, or the TUI redrew somewhere else. */
+    /**
+     * Release the part of the hold the buffer has taken over. Echoes arrive
+     * per syllable, so a cursor advance of N columns retires exactly the
+     * leading N columns of held text — dropping the whole hold there would
+     * reopen the gap for syllables still in flight. Anything that does not
+     * line up (cursor moved backwards, changed row, or landed mid-syllable)
+     * is a redraw rather than an echo: drop everything, which is the safe
+     * direction since the held text is only ever a visual bridge.
+     */
     const dropEchoedPendingCommit = () => {
       if (!pendingCommit) return;
       const buf = term.buffer.active;
-      if (
-        buf.cursorX !== pendingCommit.x ||
-        buf.baseY + buf.cursorY !== pendingCommit.y
-      ) {
+      const advanced = buf.cursorX - pendingCommit.x;
+      if (buf.baseY + buf.cursorY !== pendingCommit.y || advanced < 0) {
         clearPendingCommit();
+        return;
       }
+      if (advanced === 0) return;
+      let columns = 0;
+      let retired = 0;
+      for (const char of pendingCommit.text) {
+        if (columns >= advanced) break;
+        const width = stringCellWidth(char);
+        if (width === null) {
+          clearPendingCommit();
+          return;
+        }
+        columns += width;
+        retired += char.length;
+      }
+      const rest = pendingCommit.text.slice(retired);
+      if (columns !== advanced || rest.length === 0) {
+        clearPendingCommit();
+        return;
+      }
+      pendingCommit = { text: rest, x: buf.cursorX, y: pendingCommit.y };
     };
     const positionComposing = () => {
       if (!compositionView) return;
@@ -1771,13 +1800,22 @@ export function Terminal({
       if (!cellDims) {
         compositionTextView.textContent = text;
         compositionTextView.style.marginRight = "";
+        compositionTextView.style.letterSpacing = "";
         return;
       }
       const cells: HTMLElement[] = [];
       for (const char of text) {
         const columns = stringCellWidth(char);
+        if (columns === null) {
+          // Widths unavailable — plain text beats cramming the whole preview
+          // into one cell-sized box.
+          compositionTextView.textContent = text;
+          compositionTextView.style.marginRight = "";
+          compositionTextView.style.letterSpacing = "";
+          return;
+        }
         const previous = cells[cells.length - 1];
-        if (columns <= 0 && previous) {
+        if (columns === 0 && previous) {
           previous.textContent = `${previous.textContent ?? ""}${char}`;
           continue;
         }
@@ -1787,6 +1825,10 @@ export function Terminal({
         cell.style.width = `${Math.max(1, columns) * cellDims.width}px`;
         cells.push(cell);
       }
+      // The cell width already carries the configured letter spacing; the
+      // composition view applies it again for the cloned tail runs, which
+      // need it. Neutralise it over the explicit boxes.
+      compositionTextView.style.letterSpacing = "0";
       compositionTextView.replaceChildren(...cells);
       // Negative margin pulls the caret — the next inline box — back inside
       // the grid without disturbing the glyph spacing before it.
@@ -1897,10 +1939,11 @@ export function Terminal({
         y: buf.baseY + buf.cursorY,
       };
       // A PTY that never echoes (dead shell, password prompt) would otherwise
-      // leave the held text painted forever.
-      if (pendingCommitTimer !== null) {
-        window.clearTimeout(pendingCommitTimer);
-      }
+      // leave the held text painted forever. The ceiling runs from the first
+      // held syllable: restarting it per commit would let continuous typing
+      // into a silent app extend the hold — and the hidden native cursor that
+      // comes with it — indefinitely.
+      if (pendingCommitTimer !== null) return;
       pendingCommitTimer = window.setTimeout(() => {
         pendingCommitTimer = null;
         pendingCommit = null;
@@ -2739,10 +2782,14 @@ export function Terminal({
     // xterm fires render/scroll/cursor-move separately for the same repaint,
     // and each rebuild of the overlay measures the source row (a forced
     // layout). Coalesce them into one recompute per frame.
-    let repositionFrame: number | null = null;
+    let repositionPending = false;
     const repositionComposingNow = () => {
-      repositionFrame = null;
-      if (!compositionView || !compositionView.classList.contains("active")) {
+      repositionPending = false;
+      if (
+        disposed ||
+        !compositionView ||
+        !compositionView.classList.contains("active")
+      ) {
         return;
       }
       syncComposing();
@@ -2752,11 +2799,16 @@ export function Terminal({
       // exactly what got us here — keystroke-driven rebuilds in between reuse
       // the measurements.
       invalidateTerminalLineTailCache(lineTailCache);
-      if (repositionFrame !== null) return;
+      if (repositionPending) return;
       if (!compositionView || !compositionView.classList.contains("active")) {
         return;
       }
-      repositionFrame = requestAnimationFrame(repositionComposingNow);
+      // A microtask, not a frame: xterm already fires these from inside its
+      // own render callback, so deferring to the next frame would leave the
+      // overlay a frame behind a scroll. This still collapses the
+      // render/scroll/cursor-move burst for one repaint into a single pass.
+      repositionPending = true;
+      queueMicrotask(repositionComposingNow);
     };
     const renderDisposable = term.onRender(repositionComposing);
     // PTY output that arrives while the user is mid-composition can scroll
@@ -3452,10 +3504,7 @@ export function Terminal({
       container.removeAttribute("data-acorn-cursor-application-override");
       container.classList.remove(COMPOSING_CLASS);
       clearPendingCommit();
-      if (repositionFrame !== null) {
-        cancelAnimationFrame(repositionFrame);
-        repositionFrame = null;
-      }
+      repositionPending = false;
       try { fitAddon.dispose(); } catch { /* ignore */ }
       try { serializeAddon.dispose(); } catch { /* ignore */ }
       term.dispose();

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -217,6 +217,9 @@ const ANSI_RESET = "\x1b[0m";
 const ANSI_DIM = "\x1b[2m";
 const SCROLL_TO_BOTTOM_VISIBLE_ROWS = 10;
 const COMPOSING_CLASS = "acorn-terminal-composing";
+/** How far inside the cell boundary the IME caret marker sits. See
+ *  `renderComposing` — purely visual, the PTY still gets full-width cells. */
+const CARET_CELL_GRID_INSET_PX = 2;
 // xterm briefly leaves and re-enters hovered links when refreshed rows repaint.
 const LINK_TOOLTIP_HIDE_GRACE_MS = 80;
 
@@ -1767,13 +1770,19 @@ export function Terminal({
       // Snap the preview to the terminal's cell grid. A Hangul syllable spends
       // two columns, but the raw glyph advance is usually narrower than two
       // cells, which parked the caret marker tight against the glyph instead
-      // of on the cell boundary the real cursor would sit at. `min-width` so a
+      // of near the cell boundary the real cursor sits at. `min-width` so a
       // font whose glyphs run wider than their cells still pushes the caret
       // out rather than colliding with it.
+      //
+      // The inset holds the caret just inside that boundary: dead-on reads as
+      // detached from the syllable being composed. Tuned by eye against the
+      // app's default terminal font — `CARET_CELL_GRID_INSET_PX` is the knob.
       const cellDims = getCellDims();
       const columns = stringCellWidth(text);
       compositionTextView.style.minWidth =
-        cellDims && columns > 0 ? `${columns * cellDims.width}px` : "";
+        cellDims && columns > 0
+          ? `${Math.max(0, columns * cellDims.width - CARET_CELL_GRID_INSET_PX)}px`
+          : "";
       // Until the PTY receives a committed composition, its buffer still has
       // the text under and after the cursor in the old position. Mirror that
       // tail after the preview so mid-line composition reads as insertion.

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -309,10 +309,10 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(cursorLayout.markerHeight).toBeGreaterThan(0);
     expect(cursorLayout.nativeCursorOpacity).toBe("0");
     expect(cursorLayout.cursorAnchorWidth).toBe(0);
-    // "한" spends two terminal columns; the preview must claim both so the
-    // caret lands on the cell boundary instead of hugging the glyph.
+    // "한" spends two terminal columns; the preview claims both (less the
+    // 2px caret inset) instead of collapsing to the glyph's own advance.
     expect(cursorLayout.textWidth).toBeGreaterThanOrEqual(
-      2 * cursorLayout.cellWidth - 0.5,
+      2 * cursorLayout.cellWidth - 2.5,
     );
     expect(cursorLayout.cursorAfterText).toBeLessThan(0.5);
     expect(cursorLayout.tailAfterCursor).toBeLessThan(0.5);
@@ -390,11 +390,13 @@ test.describe("terminal: IME (PR #104 regression)", () => {
       return cursor.getBoundingClientRect().left;
     });
 
-    // The whole point: committing must not shift the caret. A preview laid out
-    // at the glyph's natural advance lands short of the cell boundary, so the
-    // caret would jump outward once the echo arrives — once per syllable.
-    expect(Math.abs(composing.snapped - realCursorLeft)).toBeLessThan(1);
-    expect(realCursorLeft - composing.naturalAdvance).toBeGreaterThan(1);
+    // Committing must barely shift the caret. The preview tracks the cell
+    // boundary the real cursor lands on, held 2px inside it so the marker
+    // still reads as attached to the syllable. Laying the preview out at the
+    // glyph's natural advance instead lands materially further short, so the
+    // caret would visibly jump outward on every echo.
+    expect(realCursorLeft - composing.snapped).toBeCloseTo(2, 0);
+    expect(realCursorLeft - composing.naturalAdvance).toBeGreaterThan(3);
   });
 
   test("committed syllables stay painted until the PTY echo lands", async ({

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -283,6 +283,10 @@ test.describe("terminal: IME (PR #104 regression)", () => {
       );
       return {
         childClasses: children.map((child) => child.className),
+        cellWidth: Number.parseFloat(
+          getComputedStyle(element).getPropertyValue("--acorn-ime-cell-width"),
+        ),
+        textWidth: textRect.width,
         markerBackground: marker.backgroundColor,
         markerHeight: Number.parseFloat(marker.height),
         markerWidth: Number.parseFloat(marker.width),
@@ -305,6 +309,11 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(cursorLayout.markerHeight).toBeGreaterThan(0);
     expect(cursorLayout.nativeCursorOpacity).toBe("0");
     expect(cursorLayout.cursorAnchorWidth).toBe(0);
+    // "한" spends two terminal columns; the preview must claim both so the
+    // caret lands on the cell boundary instead of hugging the glyph.
+    expect(cursorLayout.textWidth).toBeGreaterThanOrEqual(
+      2 * cursorLayout.cellWidth - 0.5,
+    );
     expect(cursorLayout.cursorAfterText).toBeLessThan(0.5);
     expect(cursorLayout.tailAfterCursor).toBeLessThan(0.5);
 

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -309,12 +309,11 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     expect(cursorLayout.markerHeight).toBeGreaterThan(0);
     expect(cursorLayout.nativeCursorOpacity).toBe("0");
     expect(cursorLayout.cursorAnchorWidth).toBe(0);
-    // "한" spends two terminal columns; the preview claims both (less the
-    // 2px caret inset) instead of collapsing to the glyph's own advance.
-    expect(cursorLayout.textWidth).toBeGreaterThanOrEqual(
-      2 * cursorLayout.cellWidth - 2.5,
-    );
-    expect(cursorLayout.cursorAfterText).toBeLessThan(0.5);
+    // "한" spends two terminal columns; the preview lays it out on that grid
+    // instead of collapsing to the glyph's own advance.
+    expect(cursorLayout.textWidth).toBeCloseTo(2 * cursorLayout.cellWidth, 0);
+    // The caret sits one inset inside the text box's trailing cell edge.
+    expect(cursorLayout.cursorAfterText).toBeCloseTo(2, 0);
     expect(cursorLayout.tailAfterCursor).toBeLessThan(0.5);
 
     await runIme(page, [
@@ -364,10 +363,13 @@ test.describe("terminal: IME (PR #104 regression)", () => {
       );
       if (!text || !caret) throw new Error("IME overlay nodes missing");
       const snapped = caret.getBoundingClientRect().left;
-      const cellGridWidth = text.style.minWidth;
-      text.style.minWidth = "";
+      const cellMarkup = text.innerHTML;
+      const inset = text.style.marginRight;
+      text.style.marginRight = "";
+      text.textContent = text.textContent ?? "";
       const naturalAdvance = caret.getBoundingClientRect().left;
-      text.style.minWidth = cellGridWidth;
+      text.innerHTML = cellMarkup;
+      text.style.marginRight = inset;
       return { snapped, naturalAdvance };
     });
 
@@ -433,6 +435,21 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     // replace the syllable already in flight.
     await runIme(page, commit("녕"));
     expect(await imeOverlayText(page)).toBe("안녕");
+    // Two held syllables span four columns. Laid out as raw text they would
+    // bunch to the left of the box and drift away from the committed text.
+    const heldLayout = await page.evaluate(() => {
+      const view = document.querySelector<HTMLElement>(".composition-view")!;
+      const text = view.querySelector<HTMLElement>(
+        ".acorn-ime-composition-text",
+      )!;
+      return {
+        width: text.getBoundingClientRect().width,
+        cellWidth: Number.parseFloat(
+          getComputedStyle(view).getPropertyValue("--acorn-ime-cell-width"),
+        ),
+      };
+    });
+    expect(heldLayout.width).toBeCloseTo(4 * heldLayout.cellWidth, 0);
 
     // The echo advances the cursor off the committed cell: the buffer now owns
     // the glyphs, so the overlay must let go instead of double-painting them.

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -166,6 +166,19 @@ function countToken(writes: string[], token: string): number {
   return n;
 }
 
+/** Text currently painted by the IME overlay ("" when it is torn down). */
+async function imeOverlayText(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const view = document.querySelector<HTMLElement>(
+      ".composition-view.active",
+    );
+    return (
+      view?.querySelector<HTMLElement>(".acorn-ime-composition-text")
+        ?.textContent ?? ""
+    );
+  });
+}
+
 async function emitPtyOutput(page: Page, text: string): Promise<void> {
   await expect
     .poll(() =>
@@ -179,6 +192,7 @@ async function emitPtyOutput(page: Page, text: string): Promise<void> {
   await page.evaluate((output) => {
     const w = window as unknown as {
       __imeOutputChannelId?: number;
+      __imeOutputIndex?: number;
       [key: string]: unknown;
     };
     const id = w.__imeOutputChannelId;
@@ -187,8 +201,12 @@ async function emitPtyOutput(page: Page, text: string): Promise<void> {
       | ((payload: { index: number; message: number[] }) => void)
       | undefined;
     if (!callback) throw new Error("IME output callback missing");
+    // Tauri's Channel reorders by `index` and parks anything it has already
+    // delivered — a second emit reusing 0 would never reach the terminal.
+    const index = w.__imeOutputIndex ?? 0;
+    w.__imeOutputIndex = index + 1;
     callback({
-      index: 0,
+      index,
       message: Array.from(new TextEncoder().encode(output)),
     });
   }, text);
@@ -298,10 +316,59 @@ test.describe("terminal: IME (PR #104 regression)", () => {
         taValue: "한",
       },
     ]);
+    // The commit only sends the syllable; the overlay holds it until the echo
+    // hands ownership to the xterm buffer.
+    await emitPtyOutput(page, "한");
     await expect(page.locator(".acorn-terminal")).not.toHaveClass(
       /acorn-terminal-composing/,
     );
     await expect(imeCursor).toHaveCount(0);
+  });
+
+  test("committed syllables stay painted until the PTY echo lands", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+    await emitPtyOutput(page, "› ");
+    await expect(page.locator(".xterm-rows")).toContainText("›");
+
+    const commit = (syllable: string) => [
+      { type: "keydown" as const, key: "Process", keyCode: 229 },
+      {
+        type: "input" as const,
+        inputType: "insertCompositionText",
+        data: syllable,
+        taValue: syllable,
+      },
+      {
+        type: "input" as const,
+        inputType: "insertFromComposition",
+        data: syllable,
+        taValue: syllable,
+      },
+    ];
+
+    // Without the hold, a committed syllable exists in neither the overlay nor
+    // the buffer for a full IPC round trip — the "one syllable behind" gap.
+    await runIme(page, commit("안"));
+    expect(await imeOverlayText(page)).toBe("안");
+
+    // Typing faster than the echo must accumulate against the same cell, not
+    // replace the syllable already in flight.
+    await runIme(page, commit("녕"));
+    expect(await imeOverlayText(page)).toBe("안녕");
+
+    // The echo advances the cursor off the committed cell: the buffer now owns
+    // the glyphs, so the overlay must let go instead of double-painting them.
+    await emitPtyOutput(page, "안녕");
+    await expect(page.locator(".composition-view.active")).toHaveCount(0);
+    await expect(page.locator(".xterm-rows")).toContainText("› 안녕");
+
+    const writes = await getWrites(page);
+    expect(countToken(writes, "안")).toBe(1);
+    expect(countToken(writes, "녕")).toBe(1);
   });
 
   test("composition cursor follows an application-owned DECSCUSR shape", async ({

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -334,6 +334,69 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     await expect(imeCursor).toHaveCount(0);
   });
 
+  test("the composing caret sits where the real cursor will land", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+    await emitPtyOutput(page, "> ");
+    await expect(page.locator(".xterm-rows")).toContainText(">");
+
+    await runIme(page, [
+      { type: "keydown", key: "Process", keyCode: 229 },
+      {
+        type: "input",
+        inputType: "insertCompositionText",
+        data: "한",
+        taValue: "한",
+      },
+    ]);
+    // Measure the caret as rendered, and again with the cell-grid width
+    // removed — the difference is what the preview would be off by if it laid
+    // the syllable out at the font's natural advance.
+    const composing = await page.evaluate(() => {
+      const text = document.querySelector<HTMLElement>(
+        ".acorn-ime-composition-text",
+      );
+      const caret = document.querySelector<HTMLElement>(
+        ".acorn-ime-composition-cursor",
+      );
+      if (!text || !caret) throw new Error("IME overlay nodes missing");
+      const snapped = caret.getBoundingClientRect().left;
+      const cellGridWidth = text.style.minWidth;
+      text.style.minWidth = "";
+      const naturalAdvance = caret.getBoundingClientRect().left;
+      text.style.minWidth = cellGridWidth;
+      return { snapped, naturalAdvance };
+    });
+
+    await runIme(page, [
+      {
+        type: "input",
+        inputType: "insertFromComposition",
+        data: "한",
+        taValue: "한",
+      },
+    ]);
+    await emitPtyOutput(page, "한");
+    await expect(page.locator(".composition-view.active")).toHaveCount(0);
+
+    const realCursorLeft = await page.evaluate(() => {
+      const cursor = document.querySelector<HTMLElement>(
+        ".acorn-terminal .xterm-cursor",
+      );
+      if (!cursor) throw new Error("terminal cursor missing");
+      return cursor.getBoundingClientRect().left;
+    });
+
+    // The whole point: committing must not shift the caret. A preview laid out
+    // at the glyph's natural advance lands short of the cell boundary, so the
+    // caret would jump outward once the echo arrives — once per syllable.
+    expect(Math.abs(composing.snapped - realCursorLeft)).toBeLessThan(1);
+    expect(realCursorLeft - composing.naturalAdvance).toBeGreaterThan(1);
+  });
+
   test("committed syllables stay painted until the PTY echo lands", async ({
     page,
     tauri,

--- a/tests/e2e/terminal-ime.spec.ts
+++ b/tests/e2e/terminal-ime.spec.ts
@@ -192,7 +192,7 @@ async function emitPtyOutput(page: Page, text: string): Promise<void> {
   await page.evaluate((output) => {
     const w = window as unknown as {
       __imeOutputChannelId?: number;
-      __imeOutputIndex?: number;
+      __imeOutputIndexByChannel?: Record<number, number>;
       [key: string]: unknown;
     };
     const id = w.__imeOutputChannelId;
@@ -201,10 +201,13 @@ async function emitPtyOutput(page: Page, text: string): Promise<void> {
       | ((payload: { index: number; message: number[] }) => void)
       | undefined;
     if (!callback) throw new Error("IME output callback missing");
-    // Tauri's Channel reorders by `index` and parks anything it has already
-    // delivered — a second emit reusing 0 would never reach the terminal.
-    const index = w.__imeOutputIndex ?? 0;
-    w.__imeOutputIndex = index + 1;
+    // Tauri's Channel reorders by `index` and parks anything out of sequence.
+    // The sequence is per channel: a terminal remount re-subscribes with a
+    // fresh one that expects to start at 0 again, so carrying a single global
+    // counter across it parks every later emit forever.
+    const sequences = (w.__imeOutputIndexByChannel ??= {});
+    const index = sequences[id] ?? 0;
+    sequences[id] = index + 1;
     callback({
       index,
       message: Array.from(new TextEncoder().encode(output)),
@@ -382,6 +385,12 @@ test.describe("terminal: IME (PR #104 regression)", () => {
       },
     ]);
     await emitPtyOutput(page, "한");
+    // Wait on the echo reaching the buffer, not on the overlay clearing — the
+    // hold also expires on its own ceiling, which would let the cursor be
+    // measured before it ever advanced.
+    await expect(page.locator(".xterm-screen > .xterm-rows")).toContainText(
+      "> 한",
+    );
     await expect(page.locator(".composition-view.active")).toHaveCount(0);
 
     const realCursorLeft = await page.evaluate(() => {
@@ -398,7 +407,9 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     // glyph's natural advance instead lands materially further short, so the
     // caret would visibly jump outward on every echo.
     expect(realCursorLeft - composing.snapped).toBeCloseTo(2, 0);
-    expect(realCursorLeft - composing.naturalAdvance).toBeGreaterThan(3);
+    // Not asserted as a magnitude: how far short the raw glyph advance falls
+    // depends on the CJK font the test browser happens to resolve.
+    expect(composing.naturalAdvance).toBeLessThanOrEqual(composing.snapped);
   });
 
   test("committed syllables stay painted until the PTY echo lands", async ({
@@ -460,6 +471,53 @@ test.describe("terminal: IME (PR #104 regression)", () => {
     const writes = await getWrites(page);
     expect(countToken(writes, "안")).toBe(1);
     expect(countToken(writes, "녕")).toBe(1);
+  });
+
+  test("a partial echo releases only the syllables the buffer took over", async ({
+    page,
+    tauri,
+  }) => {
+    await seed(tauri);
+    await activateTerminal(page);
+    await emitPtyOutput(page, "> ");
+    await expect(page.locator(".xterm-rows")).toContainText(">");
+
+    const commit = (syllable: string) => [
+      { type: "keydown" as const, key: "Process", keyCode: 229 },
+      {
+        type: "input" as const,
+        inputType: "insertCompositionText",
+        data: syllable,
+        taValue: syllable,
+      },
+      {
+        type: "input" as const,
+        inputType: "insertFromComposition",
+        data: syllable,
+        taValue: syllable,
+      },
+    ];
+
+    await runIme(page, commit("안"));
+    await runIme(page, commit("녕"));
+    expect(await imeOverlayText(page)).toBe("안녕");
+
+    // Only the first syllable comes back. Dropping the whole hold here would
+    // strand 녕 in neither the overlay nor the buffer until its own echo —
+    // exactly the gap the hold exists to close.
+    await emitPtyOutput(page, "안");
+    await expect.poll(() => imeOverlayText(page)).toBe("녕");
+    // `.xterm-rows` alone also matches the overlay's tail view while the
+    // composition is live.
+    await expect(page.locator(".xterm-screen > .xterm-rows")).toContainText(
+      "> 안",
+    );
+
+    await emitPtyOutput(page, "녕");
+    await expect(page.locator(".composition-view.active")).toHaveCount(0);
+    await expect(page.locator(".xterm-screen > .xterm-rows")).toContainText(
+      "> 안녕",
+    );
   });
 
   test("composition cursor follows an application-owned DECSCUSR shape", async ({


### PR DESCRIPTION
## TL;DR

Typing Korean into an agent session felt a step behind. The composition overlay never bridged the round trip a committed syllable takes to come back from the PTY, and rebuilding that overlay was the most expensive thing on the Korean input path. Both are fixed, plus the preview now lays out on the terminal's cell grid so the caret sits where the real cursor will land.

## The lag

A committed syllable is sent to the PTY but does not appear until the agent echoes it back — one IPC round trip plus a TUI redraw. The overlay was cleared at commit time, so for that whole window the syllable existed in neither the overlay nor the xterm buffer. That is the "one syllable behind" feel.

The syllable now stays painted at the cell it was committed from and is released as the echo advances the cursor past it. Echoes arrive per syllable, so the release is per syllable too — holding several and dropping them all on the first echo would just reopen the gap further along. A 400ms ceiling, measured from the first held syllable, covers a PTY that never echoes at all.

## The cost

The overlay rebuild runs two to three times per jamo — WKWebView splits one jamo across `insertCompositionText` and `insertText` — and again on every xterm render while composing.

- `renderTerminalLineTail` measured every span in the source row on each call, a forced layout immediately after the previous call wrote styles. Row geometry is now cached and invalidated from the render/scroll/cursor-move handlers, which are the only things that can move it.
- The per-cell style key was `clone.outerHTML`, serialising a DOM node per cell purely to compare it against the previous one. It compares attributes instead.
- The column-to-span lookup rescanned from the start for every cell; `cellCenter` is monotonic, so it advances a cursor.
- Render, scroll, and cursor-move each triggered a full rebuild for the same repaint. They coalesce into one pass per repaint.

Agent TUIs draw a border around their input box, so the cursor's line is non-empty out to the last column and that loop ran over nearly the full terminal width every time.

## The caret

A Hangul syllable spends two columns, but its glyph advance is usually narrower, so the preview bunched to the left and the caret landed short of where the real cursor goes. Measured in the test browser: cell width 7.20px, so "한" should span 14.39px, and the preview claimed 10.39px — the caret sat 4px inside the true boundary and jumped outward when the syllable committed.

xterm spaces its own wide glyphs with a per-span `letter-spacing`. The preview gives each character a cell-sized box, which is the same layout and stays correct when it mixes character widths or holds several syllables at once. The caret is then held 2px inside that boundary by eye — `CARET_CELL_GRID_INSET_PX` is the knob — because dead-on reads as detached from the syllable being composed.

## Notes

- `terminal-cjk-cell-width-addon.ts` declares `_core._unicodeService`, which does not exist; the service is at `_core.unicodeService`. The declaration is unused there so nothing was broken, but it is misleading and is worth correcting separately.
- Switching xterm to the canvas renderer, which is the obvious remaining performance lever, would break both that addon (it patches the DOM renderer's width cache) and the IME tail preview (it clones `.xterm-rows` spans). Not attempted.
- The e2e emit helper carried a single output sequence across channels, so any emit after a terminal remount was parked forever by Tauri's Channel reordering and silently never reached the terminal. Sequencing is now per channel; without it every multi-output IME test was quietly testing less than it looked.

## Verification

- [x] `pnpm exec playwright test tests/e2e/terminal-ime.spec.ts` — 18 passed, and 72/72 under `--repeat-each=4` across two runs after the flake fixes above
- [x] `pnpm exec playwright test tests/e2e/terminal.spec.ts tests/e2e/terminal-scroll-perf.spec.ts` — 62 passed
- [x] `pnpm exec vitest run` — 1545 passed
- [x] `pnpm typecheck`
- [x] Manual: Korean typing in a local dev build against Claude and Grok sessions, including bursts fast enough to hold multiple syllables

New coverage: the caret coincides with the terminal's own cursor after the echo; a partial echo releases only the syllables the buffer took over; a multi-syllable hold spans its full column count.
